### PR TITLE
Keep long-running tasks alive during silent LLM phases

### DIFF
--- a/happyhq/app/api/health/route.test.ts
+++ b/happyhq/app/api/health/route.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { GET } from './route'
+
+describe('GET /api/health', () => {
+  it('returns 200 with { ok: true }', async () => {
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+  })
+})

--- a/happyhq/app/api/health/route.ts
+++ b/happyhq/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ ok: true })
+}

--- a/happyhq/fly.toml
+++ b/happyhq/fly.toml
@@ -6,6 +6,9 @@
   auto_stop_machines = "stop"
   auto_start_machines = true
   min_machines_running = 0
+  # Give the run loop room to tear down cleanly on autostop instead of
+  # getting SIGKILL'd mid-iteration (which logs nothing and breaks diagnosis).
+  kill_timeout = "30s"
 
 [mounts]
   source = "happyhq_data"

--- a/happyhq/lib/chat/types.ts
+++ b/happyhq/lib/chat/types.ts
@@ -14,6 +14,7 @@ export type ChatStreamEvent =
   | ChatStreamContentChangedEvent // Agent wrote a file (Write/Edit) — client should revalidate SWR
   | ChatTaskContentChangedEvent // Run agent wrote a file (Write/Edit) — client should revalidate task SWR
   | ChatModeChangedEvent // Chat mode transition (general ↔ learning)
+  | ChatHeartbeatEvent // Keepalive so fly-proxy doesn't reap the stream during silent phases
 
 export interface ChatPartialEvent {
   type: 'partial'
@@ -149,6 +150,13 @@ export interface ChatModeChangedEvent {
   type: 'mode_changed'
   mode: 'general' | 'learning'
   streamSlug?: string // present when entering learning mode
+}
+
+// Periodic keepalive so intermediaries (proxies, load balancers) don't close
+// the stream during silent phases. Clients can ignore.
+export interface ChatHeartbeatEvent {
+  type: 'heartbeat'
+  t: string // ISO timestamp
 }
 
 // Sent from canUseTool when an unapproved tool is invoked — the SDK query is

--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -49,6 +49,8 @@ interface RunLoopState {
   starting: boolean
   activeRunStream: string | null
   activeRunTask: string | null
+  heartbeatInterval: ReturnType<typeof setInterval> | null
+  selfPingInterval: ReturnType<typeof setInterval> | null
 }
 
 const STATE_KEY = Symbol.for('__happyhq_run_loop_state__')
@@ -64,6 +66,8 @@ function getState(): RunLoopState {
       starting: false,
       activeRunStream: null,
       activeRunTask: null,
+      heartbeatInterval: null,
+      selfPingInterval: null,
     }
   }
   return g[STATE_KEY]
@@ -124,6 +128,7 @@ export async function startRun(
     s.subscribers = new Set()
     s.activeRunStream = streamName
     s.activeRunTask = taskName
+    startKeepalives(s)
 
     // Defer heavy work (commitGitState uses execSync) with setImmediate so
     // the HTTP response is sent before we block the event loop.
@@ -198,6 +203,7 @@ export async function startRun(
             // If setup fails before runLoop(), clean up state so we don't
             // permanently block future runs.
             console.error('[Q:run] Setup error before loop:', err)
+            stopKeepalives(s)
             for (const writer of s.subscribers) {
               writer.close().catch(() => {})
             }
@@ -408,6 +414,7 @@ async function runLoop(
       }
     }
 
+    stopKeepalives(s)
     // Close all subscriber streams (fire-and-forget)
     for (const writer of s.subscribers) {
       writer.close().catch(() => {})
@@ -1004,6 +1011,40 @@ function broadcast(chunk: Uint8Array): void {
       writer.close().catch(() => {})
       s.subscribers.delete(writer)
     })
+  }
+}
+
+const HEARTBEAT_INTERVAL_MS = 20_000
+const SELF_PING_INTERVAL_MS = 30_000
+
+// Keeps bytes flowing to watching clients and traffic arriving at the machine
+// so the edge proxy's idle-timeout and autostop-idle timers don't fire during
+// long silent phases of a run (extended thinking, long tool calls). Without
+// these, a run in progress looks idle to the platform and the machine can be
+// stopped out from under it.
+function startKeepalives(s: RunLoopState): void {
+  s.heartbeatInterval = setInterval(() => {
+    if (s.subscribers.size === 0) return
+    broadcast(encodeEvent({ type: 'heartbeat', t: new Date().toISOString() }))
+  }, HEARTBEAT_INTERVAL_MS)
+
+  const appName = process.env.FLY_APP_NAME
+  if (appName) {
+    const pingUrl = `https://${appName}.fly.dev/api/health`
+    s.selfPingInterval = setInterval(() => {
+      fetch(pingUrl).catch(() => {})
+    }, SELF_PING_INTERVAL_MS)
+  }
+}
+
+function stopKeepalives(s: RunLoopState): void {
+  if (s.heartbeatInterval) {
+    clearInterval(s.heartbeatInterval)
+    s.heartbeatInterval = null
+  }
+  if (s.selfPingInterval) {
+    clearInterval(s.selfPingInterval)
+    s.selfPingInterval = null
   }
 }
 

--- a/happyhq/middleware.ts
+++ b/happyhq/middleware.ts
@@ -37,10 +37,12 @@ export const config = {
      * Match all request paths except:
      * - /login (the login page itself, to avoid redirect loops)
      * - /setup (API auth setup — reached after password auth, not a security bypass)
+     * - /api/health (unauthenticated liveness probe — used by platform health
+     *   checks and the run-loop self-ping, must not redirect)
      * - /_next/static (static file serving)
      * - /_next/image (image optimization)
      * - /favicon.ico (browser favicon request)
      */
-    '/((?!login|setup|_next/static|_next/image|favicon\\.ico|.*\\.png$).*)',
+    '/((?!login|setup|api/health|_next/static|_next/image|favicon\\.ico|.*\\.png$).*)',
   ],
 }


### PR DESCRIPTION
## Summary

A user reported a task that appeared stuck on a run that had actually been killed roughly 45 minutes earlier — the UI was just showing stale state from before the VM went down. When they clicked stop, the orphan state finally got cleared and `"Run lost (server restarted)"` was written to `.run.json`.

**Root cause:** during long LLM thinking phases (or tool calls that take tens of seconds), no bytes flow through the run's NDJSON stream. After ~60s of silence the edge proxy closes the connection. After a few more minutes of no inbound traffic the platform autostops the machine, killing the run loop mid-iteration with no way to resume. From the user's perspective the run just appears to hang forever.

## What this changes

Two keepalives, both gated on run lifecycle so they can't outlive the run they belong to:

- **Stream heartbeat** every 20s while subscribers exist. Keeps the NDJSON connection from going idle during silent phases (`{ type: "heartbeat", t: <iso> }` events that clients can ignore).
- **Self-ping** every 30s from the server to its own `/api/health` endpoint while a run is active. Keeps platform idle counters ticking so the machine doesn't get stopped out from under us.

Both intervals are started in `startRun()` alongside the `AbortController` and cleared in `runLoop()`'s finally block (and the setup-error path). Self-ping no-ops when `FLY_APP_NAME` isn't set, so local dev and tests are unaffected.

**Also included:**

- New `/api/health` route (auth-exempt in middleware) returning `{ ok: true }`. Serves the self-ping now, usable as a real HTTP health check later.
- `kill_timeout = "30s"` in `fly.toml` so if a machine does get stopped, the graceful shutdown actually gets logged instead of vanishing silently. Makes future incidents diagnosable.

## Out of scope (follow-ups worth tracking)

- A `SIGINT` handler on the run loop, so if a machine *does* get stopped while a run is active (deploys, platform events), orphans get a clean `"stopped by shutdown"` status instead of `"Run lost (server restarted)"`.
- Full resumable-run state so a run can survive an actual machine restart rather than dying terminally.

## Test plan

- [x] `pnpm check-types` clean
- [x] `pnpm lint` — no new warnings
- [x] `pnpm test` — 1332 tests pass (1331 existing + 1 new for `/api/health`)
- [x] `pnpm format` — no diffs