### PR TITLE
Fix Dockerfile workspace filter after monorepo rename

### DIFF
--- a/happyhq/Dockerfile
+++ b/happyhq/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /build
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY happyhq/package.json ./happyhq/
 
-RUN pnpm install --frozen-lockfile --filter=app
+RUN pnpm install --frozen-lockfile --filter=happyhq
 
 # ---------------------------------------------------------------------------
 # Stage 3 — build: compile Next.js standalone output


### PR DESCRIPTION
## Summary

When the monorepo was split, the pnpm workspace was renamed from `app` to `happyhq`, but the Dockerfile's `--filter` flag still said `app`. The filter matched nothing, so `pnpm install` installed zero dependencies into the happyhq workspace, and `pnpm build` exploded with `Cannot find module '/build/happyhq/node_modules/next/dist/bin/next'`.

One-word fix: `--filter=app` → `--filter=happyhq`.