### PR TITLE
Treat plan_ready as a successful billing outcome

### DIFF
--- a/happyhq/lib/run/loop.server.test.ts
+++ b/happyhq/lib/run/loop.server.test.ts
@@ -596,6 +596,23 @@ describe('billing integration', () => {
     )
   })
 
+  it('finalizes with completed status when planning succeeds (plan_ready)', async () => {
+    // Planning's successful terminal state is 'plan_ready', not 'completed'.
+    // Without treating plan_ready as a success for billing purposes, every
+    // successful planning run would be misclassified as 'aborted'.
+    mockQuery.mockReturnValue(fakeQuery([]))
+
+    await startRun('s1', 't1', 'planning', TEST_USER_ID)
+    await _waitForLoop()
+
+    expect(mockFinalizeTaskRun).toHaveBeenCalledWith(
+      TEST_TASK_RUN_ID,
+      'completed',
+      expect.any(Number),
+      expect.any(Number),
+    )
+  })
+
   it('records usage after each working iteration', async () => {
     let callCount = 0
     mockQuery.mockImplementation(() => {

--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -395,10 +395,16 @@ async function runLoop(
       try {
         const { finalizeTaskRun } =
           await import('@/ee/lib/billing/usage.server')
-        const billingStatus =
-          finalStatus === 'completed'
-            ? ('completed' as const)
-            : ('aborted' as const)
+        // Successful terminal states differ by mode: working ends at
+        // 'completed' (agent emitted [done]), planning ends at 'plan_ready'.
+        // Everything else (user stop, error, budget, iteration limit) is an
+        // abort. Without this, every successful planning run was classified
+        // as 'aborted' in billing, skewing dashboards.
+        const successful =
+          finalStatus === 'completed' || finalStatus === 'plan_ready'
+        const billingStatus = successful
+          ? ('completed' as const)
+          : ('aborted' as const)
         // Read final cost from .run.json to get accurate total including planning
         const finalRun = await readRunInfo(taskName)
         const finalCostUsd = finalRun?.costUsd ?? 0


### PR DESCRIPTION
## Summary

`runLoop`'s billing finalizer only flagged a run as `completed` when `finalStatus === 'completed'`. That's the terminal state for a working run that emitted a `[done]` marker — but planning's successful terminal state is `plan_ready`, not `completed`. Result: every successful planning run was being finalized as `aborted` in billing, polluting usage dashboards with false "aborted" records for perfectly healthy planning runs.

Fix: consider both `'completed'` and `'plan_ready'` successful. Other terminal states (user stop, error, budget, iteration limit) still classify as `aborted` — that part was already right.

Adds a unit test covering the planning success path so this can't silently regress.

## Test plan

- [x] `pnpm check-types` clean
- [x] `pnpm test` — 1333 pass (was 1332 + 1 new test)
- [x] `pnpm lint` — no new warnings
- [x] `pnpm format` — no diffs