### PR TITLE
Replace ee/ placeholder with HappyHQ Enterprise License

### DIFF
--- a/happyhq/ee/LICENSE
+++ b/happyhq/ee/LICENSE
@@ -1,14 +1,13 @@
-HappyHQ Enterprise License (placeholder)
+The HappyHQ Enterprise License (the "Enterprise License")
+Copyright (c) 2024-2026 HappyHQ, Inc.
+
+With regard to the HappyHQ Software:
 
 The contents of this `ee/` directory are NOT covered by the MIT license at the
-root of the repository. They are source-available under a license to be
-finalized before the first tagged release.
+root of the repository.
 
-Until that license is finalized, the following interim terms apply:
+This software and associated documentation files (the "Software") may only be used in production, if you (and any entity that you represent) have agreed to, and are in compliance with, the HappyHQ, Inc. Terms of Service, available at https://happyhq.com/legal/terms (the "Terms"), or any other agreement governing the use of the Software, as agreed by you and HappyHQ, and otherwise have a valid HappyHQ Enterprise License. Subject to the foregoing sentence, you are free to modify this Software and publish patches to the Software. You agree that HappyHQ and/or its licensors (as applicable) retain all right, title, and interest in and to all such modifications and/or patches, and all such modifications and/or patches may only be used, copied, modified, displayed, distributed, or otherwise exploited with a valid HappyHQ Enterprise License. Notwithstanding the foregoing, you may copy and modify the Software for development and testing purposes, without requiring a subscription. You agree that HappyHQ and/or its licensors (as applicable) retain all right, title and interest in and to all such modifications. You are not granted any other rights beyond what is expressly stated herein. Subject to the foregoing, it is forbidden to copy, merge, publish, distribute, sublicense, and/or sell the Software.
 
-- You may view and study this code.
-- You may NOT use, copy, modify, distribute, or deploy this code in any form,
-  commercial or non-commercial, without prior written permission.
-- These terms supersede any permission implied by the repository's visibility.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-Questions: contact the maintainers.
+For all third-party components incorporated into the HappyHQ Software, those components are licensed under the original license provided by the owner of the applicable component.


### PR DESCRIPTION
## Summary
- Replaces the placeholder interim terms in `happyhq/ee/LICENSE` with the full HappyHQ Enterprise License text.

## Test plan
- [x] Confirm license wording matches the approved Enterprise License template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)