### PR TITLE
chore: add CI workflow (lint, check-types, test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter happyhq exec vitest run --pool=forks --poolOptions.forks.singleFork=true --reporter=verbose --reporter=hanging-process
+      - run: pnpm --filter happyhq exec vitest run --pool=forks --poolOptions.forks.singleFork=true --exclude='**/parse-history.server.test.ts' --reporter=verbose --reporter=hanging-process

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter happyhq exec vitest run --exclude='**/middleware.test.ts' --exclude='**/app/api/health/route.test.ts' --reporter=verbose --reporter=hanging-process
+      - run: pnpm --filter happyhq exec vitest run --exclude='**/middleware.test.ts' --exclude='**/lib/log.server.test.ts' --reporter=verbose --reporter=hanging-process

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test -- --reporter=verbose
+      - run: pnpm --filter happyhq exec vitest run --reporter=verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
@@ -47,4 +48,4 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter happyhq exec vitest run --reporter=verbose
+      - run: pnpm --filter happyhq exec vitest run --reporter=verbose --reporter=hanging-process

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter happyhq exec vitest run lib/log.server.test.ts --bail=1 --testTimeout=5000 --hookTimeout=5000 --reporter=verbose --reporter=hanging-process
+      - run: pnpm --filter happyhq exec vitest run --reporter=verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter happyhq exec vitest run --exclude='**/middleware.test.ts' --reporter=verbose --reporter=hanging-process
+      - run: pnpm --filter happyhq exec vitest run --exclude='**/middleware.test.ts' --exclude='**/app/api/health/route.test.ts' --reporter=verbose --reporter=hanging-process

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
@@ -48,4 +48,4 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter happyhq exec vitest run --reporter=verbose --reporter=hanging-process
+      - run: pnpm --filter happyhq exec vitest run --pool=forks --poolOptions.forks.singleFork=true --reporter=verbose --reporter=hanging-process

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter happyhq exec vitest run --pool=forks --poolOptions.forks.singleFork=true --exclude='**/parse-history.server.test.ts' --reporter=verbose --reporter=hanging-process
+      - run: pnpm --filter happyhq exec vitest run --exclude='**/middleware.test.ts' --reporter=verbose --reporter=hanging-process

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  check-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check-types
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -25,9 +28,9 @@ jobs:
   check-types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -37,11 +40,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test
+      - run: pnpm test -- --reporter=verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter happyhq exec vitest run --exclude='**/middleware.test.ts' --exclude='**/lib/log.server.test.ts' --reporter=verbose --reporter=hanging-process
+      - run: pnpm --filter happyhq exec vitest run lib/log.server.test.ts --bail=1 --testTimeout=5000 --hookTimeout=5000 --reporter=verbose --reporter=hanging-process

--- a/happyhq/app/api/fs/reveal/route.test.ts
+++ b/happyhq/app/api/fs/reveal/route.test.ts
@@ -97,16 +97,22 @@ describe('POST /api/fs/reveal', () => {
   it('calls open -R and returns ok for a valid file', async () => {
     mockStat.mockResolvedValue({ isFile: () => true })
     mockExecSync.mockReturnValue(undefined)
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
 
-    const response = await POST(
-      makeRequest({ path: 'my-stream/outputs/report.md' }),
-    )
-    const body = await response.json()
+    try {
+      const response = await POST(
+        makeRequest({ path: 'my-stream/outputs/report.md' }),
+      )
+      const body = await response.json()
 
-    expect(response.status).toBe(200)
-    expect(body).toEqual({ ok: true })
-    expect(mockExecSync).toHaveBeenCalledWith(
-      'open -R "/mock/home/HappyHQ/my-stream/outputs/report.md"',
-    )
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ ok: true })
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'open -R "/mock/home/HappyHQ/my-stream/outputs/report.md"',
+      )
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    }
   })
 })

--- a/happyhq/lib/log.server.test.ts
+++ b/happyhq/lib/log.server.test.ts
@@ -92,8 +92,14 @@ describe('log', () => {
   })
 
   it('does not throw when directory creation fails', () => {
-    mockLogsDir.mockReturnValue('/proc/nonexistent/impossible')
+    // Use a mock instead of a real "impossible" path: fs.mkdirSync on
+    // /proc/* paths hangs synchronously on Linux (CI), even though it
+    // returns an error on macOS. A direct mock is platform-independent.
+    const mkdirSpy = vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {
+      throw new Error('mock mkdir failure')
+    })
     expect(() => log('task.created', { task: 'x' })).not.toThrow()
+    mkdirSpy.mockRestore()
   })
 
   it('does not throw when file write fails', () => {

--- a/happyhq/vitest.config.mts
+++ b/happyhq/vitest.config.mts
@@ -11,11 +11,15 @@ export default defineConfig({
     globals: true,
     testTimeout: 10_000,
     exclude: [...configDefaults.exclude, 'tests/**/*.spec.ts'],
-    pool: 'threads',
+    pool: process.env.CI ? 'forks' : 'threads',
     poolOptions: {
       threads: {
         maxThreads: 2,
         minThreads: 1,
+      },
+      forks: {
+        maxForks: 2,
+        minForks: 1,
       },
     },
   },

--- a/happyhq/vitest.setup.ts
+++ b/happyhq/vitest.setup.ts
@@ -1,20 +1,9 @@
-import { beforeAll, beforeEach, vi } from 'vitest'
+import { vi } from 'vitest'
 
 // Prevent tests from writing to the real log file (~/.HappyHQ/.logs/)
 vi.mock('@/lib/log.server', () => ({
   log: vi.fn(),
 }))
-
-// Diagnostic: emit file start so CI logs show which file is running
-// before completion (vitest reporters only emit on file *finish*).
-if (process.env.CI) {
-  beforeAll((suite) => {
-    process.stdout.write(`>>> START FILE: ${suite.file?.name ?? '?'}\n`)
-  })
-  beforeEach((ctx) => {
-    process.stdout.write(`>>> START TEST: ${ctx.task.name}\n`)
-  })
-}
 
 const localStorageMock = {
   store: {} as Record<string, string>,

--- a/happyhq/vitest.setup.ts
+++ b/happyhq/vitest.setup.ts
@@ -1,9 +1,17 @@
-import { vi } from 'vitest'
+import { beforeAll, vi } from 'vitest'
 
 // Prevent tests from writing to the real log file (~/.HappyHQ/.logs/)
 vi.mock('@/lib/log.server', () => ({
   log: vi.fn(),
 }))
+
+// Diagnostic: emit file start so CI logs show which file is running
+// before completion (vitest reporters only emit on file *finish*).
+if (process.env.CI) {
+  beforeAll((suite) => {
+    process.stdout.write(`>>> START FILE: ${suite.file?.name ?? '?'}\n`)
+  })
+}
 
 const localStorageMock = {
   store: {} as Record<string, string>,

--- a/happyhq/vitest.setup.ts
+++ b/happyhq/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { beforeAll, vi } from 'vitest'
+import { beforeAll, beforeEach, vi } from 'vitest'
 
 // Prevent tests from writing to the real log file (~/.HappyHQ/.logs/)
 vi.mock('@/lib/log.server', () => ({
@@ -10,6 +10,9 @@ vi.mock('@/lib/log.server', () => ({
 if (process.env.CI) {
   beforeAll((suite) => {
     process.stdout.write(`>>> START FILE: ${suite.file?.name ?? '?'}\n`)
+  })
+  beforeEach((ctx) => {
+    process.stdout.write(`>>> START TEST: ${ctx.task.name}\n`)
   })
 }
 


### PR DESCRIPTION
## Summary
- Add \`.github/workflows/ci.yml\` with three parallel jobs: \`lint\`, \`check-types\`, \`test\`
- Runs on PRs and pushes to \`main\`
- Concurrency cancels redundant runs on the same PR

## Notes
- \`build\` is intentionally not gated yet — adding in a follow-up once we've confirmed it can run cleanly in CI without secrets.
- Required-checks gate not added yet. Once this workflow has run at least once, the \`protect-main\` ruleset can be updated to require these jobs before merge.

## Test plan
- [ ] All three CI jobs complete green on this PR
- [ ] Cancel-in-progress works (push a follow-up commit, see prior run cancel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)