### PR TITLE
chore: add issue/PR templates and gitignore polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Something isn't working. Let us take a look.
+title: 'bug: '
+labels: ['bug']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, what you expected, and what you saw instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps — or a link to a repo / gist that shows the issue.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Output of `git rev-parse --short HEAD`, or the release tag you're on.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Mode
+      description: Which build are you running?
+      options:
+        - CE (no accounts, local-only)
+        - EE (accounts / billing enabled)
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS + version, Node version, pnpm version (e.g. `macOS 14.5, Node 20.11, pnpm 9.1`).
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Runtime logs live at `~/HappyHQ/.logs/YYYY-MM-DD.jsonl`.
+        Paste any lines that look related, or the output of `npx tsx scripts/read-logs.ts --event=api.error --last=20`.
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, related issues, anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussion
+    url: https://github.com/happyhqdotcom/happyhq/discussions
+    about: Ask questions, share ideas, or chat with the community.
+  - name: Report a security vulnerability
+    url: https://github.com/happyhqdotcom/happyhq/security/advisories/new
+    about: Please disclose security issues privately, not in public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an improvement or a new capability.
+title: 'feat: '
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do? What's getting in the way today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? Rough sketches, API shapes, or UI ideas are all welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you'd rule them out.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to related discussions, prior art, or similar features in other tools.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- Please read CONTRIBUTING.md before opening a PR. For anything non-trivial, open an issue first. -->
+
+## Summary
+
+<!-- What does this PR do, and why? Link the issue it closes: Closes #123 -->
+
+## How I tested this
+
+<!-- Commands run, manual steps, new tests added. Be specific enough that a reviewer can reproduce. -->
+
+## Screenshots
+
+<!-- Required for any UI change. Delete this section otherwise. -->
+
+## AI assistance
+
+<!-- Per CONTRIBUTING.md: if any part of this PR was written with an LLM, note which parts and confirm you've read and tested the code yourself. Write "none" if not applicable. -->
+
+## Checklist
+
+- [ ] `pnpm check-types && pnpm lint && pnpm test` pass locally
+- [ ] Ran `pnpm format`
+- [ ] Updated docs or spec if behavior changed

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+*.log
 happyhq/.debug/
 
 # Local experiments (SDK/model tests, diagnostics)
@@ -46,7 +48,15 @@ next-env.d.ts
 
 # Misc
 .DS_Store
+Thumbs.db
 *.pem
+*.swp
+*.swo
+
+# Editors
+.idea/
+.vscode/
+.history/
 
 # Claude Code user-local overrides
 .claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add issue forms (\`.github/ISSUE_TEMPLATE/bug_report.yml\`, \`feature_request.yml\`) with title prefixes and labels
- Add \`config.yml\` to disable blank issues and route Q&A to Discussions, security to private advisory
- Add \`pull_request_template.md\` (summary, test plan, screenshots, AI assistance, checklist)
- Extend \`.gitignore\` with common editor/OS patterns (Thumbs.db, *.swp, .idea/, .vscode/, .history/, pnpm-debug.log*)

## Test plan
- [ ] After merge, opening a new issue offers the bug-report and feature-request forms (no blank option)
- [ ] Opening a new PR pre-fills the template
- [ ] Discussions and Security Advisory contact links render in the issue picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)