### PR TITLE
chore: add SECURITY.md and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# GitHub uses this file to auto-request reviewers on PRs.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @jrphilo

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report security issues privately via GitHub's [**Report a vulnerability**](https://github.com/happyhqdotcom/happyhq/security/advisories/new) button under the **Security** tab.
+
+We aim to acknowledge new reports within 2 business days and provide a fix or mitigation timeline within 7 days. Please do not open a public issue, discussion, or PR for security problems — we will publish a coordinated advisory once a fix is shipped.
+
+## Scope
+
+In scope: code in this repository (the HappyHQ application).
+
+Out of scope: third-party services HappyHQ integrates with (report those to the upstream vendor), social-engineering attempts, denial of service, and findings that require physical access or already-compromised credentials.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` pointing reporters to GitHub's **Report a vulnerability** button (private vulnerability reporting was just enabled on this repo).
- Adds `.github/CODEOWNERS` so PRs auto-request review from @jrphilo.

## How I tested this

- `pnpm format` — clean (markdown unchanged after prettier).
- Verified the linked URL `https://github.com/happyhqdotcom/happyhq/security/advisories/new` resolves once PVR is enabled (it is).
- CODEOWNERS will start auto-requesting reviews on the next PR.

## AI assistance

Drafted with Claude (Opus 4.7) — wording reviewed by hand.

## Checklist

- [x] `pnpm check-types && pnpm lint && pnpm test` — N/A, docs/config-only change
- [x] Ran `pnpm format`
- [x] No behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)