### PR TITLE
chore: pin postcss >=8.5.10 via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "overrides": {
       "@types/react": "19.2.2",
       "@types/react-dom": "19.2.2",
+      "postcss": "^8.5.10",
       "vite": "^7.1.11"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@types/react': 19.2.2
   '@types/react-dom': 19.2.2
+  postcss: ^8.5.10
   vite: ^7.1.11
 
 importers:
@@ -283,7 +284,7 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0
       postcss:
-        specifier: ^8.5.1
+        specifier: ^8.5.10
         version: 8.5.10
       tailwindcss:
         specifier: ^4.1.15
@@ -3843,10 +3844,6 @@ packages:
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -8482,7 +8479,7 @@ snapshots:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001788
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       styled-jsx: 5.1.6(react@19.2.0)
@@ -8648,12 +8645,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.10:
     dependencies:


### PR DESCRIPTION
## Summary

Closes Dependabot alert [#12](https://github.com/happyhqdotcom/happyhq/security/dependabot/12) (GHSA-qx2v-qp2m-jg93 / CVE-2026-41305 — XSS via unescaped \`</style>\` in PostCSS CSS stringify output).

\`postcss@8.4.31\` was pulled in transitively by \`next@15.5.15\` while \`@tailwindcss/postcss\` already used \`8.5.10\`. Adding \`pnpm.overrides.postcss: ^8.5.10\` deduplicates the lockfile to the patched line. 8.5.x is API-compatible with 8.4.x for the surface Next uses.

Realistic exposure was already low (no attacker-controlled CSS flows through PostCSS at build time here), but closing the alert keeps the security tab clean.

## How I tested this

- \`pnpm install\` with the override → lockfile dedupes, only \`postcss@8.5.10\` remains.
- CI (lint, check-types, test, CodeQL) will validate.

## AI assistance

Drafted with Claude (Opus 4.7) — diff reviewed by hand.

## Checklist

- [x] \`pnpm format\` ran clean
- [x] No source code changed; only lockfile + override

🤖 Generated with [Claude Code](https://claude.com/claude-code)