### PR TITLE
fix: let unauthenticated login page load its static logo

### DIFF
--- a/happyhq/middleware.ts
+++ b/happyhq/middleware.ts
@@ -42,7 +42,9 @@ export const config = {
      * - /_next/static (static file serving)
      * - /_next/image (image optimization)
      * - /favicon.ico (browser favicon request)
+     * - common image extensions in /public (so the unauthenticated login
+     *   page can load its own logo and other static art)
      */
-    '/((?!login|setup|api/health|_next/static|_next/image|favicon\\.ico|.*\\.png$).*)',
+    '/((?!login|setup|api/health|_next/static|_next/image|favicon\\.ico|.*\\.(png|svg|jpg|jpeg|webp|gif|ico)$).*)',
   ],
 }


### PR DESCRIPTION
## Summary
- Middleware [matcher](happyhq/middleware.ts#L46) only excluded `.png` from the password-gate redirect, so `/brand/logo.svg` (and any other svg/jpg/webp asset under `/public/`) was getting `307 → /login` on unauthenticated requests.
- The login page embeds `/brand/logo.svg` as its own art, so the request got redirected to the HTML login page and the browser rendered the broken-image question mark on every fresh visit.
- Fix: widen the extension allowlist in the matcher to cover the common image types we actually serve from `/public/`.

## Test plan
- [x] `pnpm --filter=happyhq test middleware.test` — passes (no test changes required; existing matcher tests don't assert specific extensions)
- [x] `pnpm --filter=happyhq lint` — passes
- [ ] After merge, redeploy a q-* instance and load `/login` unauthenticated — logo renders, no broken image

🤖 Generated with [Claude Code](https://claude.com/claude-code)