### PR TITLE
fix: use non-capturing group in middleware matcher

### DIFF
--- a/happyhq/middleware.ts
+++ b/happyhq/middleware.ts
@@ -45,6 +45,6 @@ export const config = {
      * - common image extensions in /public (so the unauthenticated login
      *   page can load its own logo and other static art)
      */
-    '/((?!login|setup|api/health|_next/static|_next/image|favicon\\.ico|.*\\.(png|svg|jpg|jpeg|webp|gif|ico)$).*)',
+    '/((?!login|setup|api/health|_next/static|_next/image|favicon\\.ico|.*\\.(?:png|svg|jpg|jpeg|webp|gif|ico)$).*)',
   ],
 }


### PR DESCRIPTION
## Summary
Follow-up to #53. The widened asset allowlist in [middleware.ts](happyhq/middleware.ts#L46) used a plain capturing group `(png|svg|jpg|...)`, which Next.js rejects at build time:

```
Invalid source '/((?!...|.*\.(png|svg|...)$).*)':
Capturing groups are not allowed at 70
```

Vitest exercises the middleware function directly and never runs the matcher through Next.js's path-to-regexp parser, so the unit tests passed despite the broken pattern. Caught when the q-tokyo redeploy build failed.

Switch to a non-capturing group `(?:png|svg|...)` so the matcher parses cleanly.

## Test plan
- [x] `pnpm --filter=happyhq build` — completes successfully (this is what failed before)
- [x] `pnpm --filter=happyhq test middleware.test` — passes
- [ ] After merge, redeploy a q-* and confirm `/login` loads with logo + no broken-image fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)