### PR TITLE
fix: rename NEXT_PUBLIC_APP_URL to APP_URL for billing redirects

### DIFF
--- a/happyhq/.env.example
+++ b/happyhq/.env.example
@@ -17,7 +17,7 @@ ANTHROPIC_API_KEY=
 # STRIPE_PRICE_ID_STARTER=
 # STRIPE_PRICE_ID_PRO=
 # STRIPE_PRICE_ID_MAX=
-# NEXT_PUBLIC_APP_URL=https://your-app-url.com
+# APP_URL=https://your-app-url.com
 
 # Cloudflare AI Gateway (optional — routes API calls through gateway when accounts enabled)
 # CLOUDFLARE_AI_GATEWAY_URL=

--- a/happyhq/ee/lib/billing/checkout.server.test.ts
+++ b/happyhq/ee/lib/billing/checkout.server.test.ts
@@ -116,7 +116,7 @@ describe('checkout.server', () => {
       mockCheckoutSessionsCreate.mockResolvedValue({
         url: 'https://checkout.stripe.com/test',
       })
-      process.env.NEXT_PUBLIC_APP_URL = 'https://app.example.com'
+      process.env.APP_URL = 'https://app.example.com'
 
       const { createCheckoutSession } = await import('./checkout.server')
       await createCheckoutSession('user-1', 'a@b.com', 'starter')
@@ -131,12 +131,12 @@ describe('checkout.server', () => {
       )
     })
 
-    it('defaults to localhost when NEXT_PUBLIC_APP_URL is not set', async () => {
+    it('defaults to localhost when APP_URL is not set', async () => {
       mockGetOrCreateStripeCustomer.mockResolvedValue('cus_test')
       mockCheckoutSessionsCreate.mockResolvedValue({
         url: 'https://checkout.stripe.com/test',
       })
-      delete process.env.NEXT_PUBLIC_APP_URL
+      delete process.env.APP_URL
 
       const { createCheckoutSession } = await import('./checkout.server')
       await createCheckoutSession('user-1', 'a@b.com', 'starter')

--- a/happyhq/ee/lib/billing/checkout.server.ts
+++ b/happyhq/ee/lib/billing/checkout.server.ts
@@ -44,8 +44,8 @@ export async function createCheckoutSession(
     customer: customerId,
     mode: 'subscription',
     line_items: [{ price: priceId, quantity: 1 }],
-    success_url: `${process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}/settings/billing?checkout=success`,
-    cancel_url: `${process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}/settings/billing?checkout=canceled`,
+    success_url: `${process.env.APP_URL ?? 'http://localhost:3000'}/settings/billing?checkout=success`,
+    cancel_url: `${process.env.APP_URL ?? 'http://localhost:3000'}/settings/billing?checkout=canceled`,
     customer_update: { address: 'auto' },
     // Tier name stored in metadata so the webhook handler can read it
     // without reverse-mapping price IDs.

--- a/happyhq/ee/lib/billing/portal.server.test.ts
+++ b/happyhq/ee/lib/billing/portal.server.test.ts
@@ -89,7 +89,7 @@ describe('portal.server', () => {
       mockPortalSessionsCreate.mockResolvedValue({
         url: 'https://billing.stripe.com/portal',
       })
-      process.env.NEXT_PUBLIC_APP_URL = 'https://app.example.com'
+      process.env.APP_URL = 'https://app.example.com'
 
       const { createPortalSession } = await import('./portal.server')
       await createPortalSession('user-1')
@@ -101,14 +101,14 @@ describe('portal.server', () => {
       )
     })
 
-    it('defaults return URL to localhost when NEXT_PUBLIC_APP_URL is not set', async () => {
+    it('defaults return URL to localhost when APP_URL is not set', async () => {
       mockQuery.mockResolvedValue({
         $users: [{ id: 'user-1', stripeCustomerId: 'cus_test' }],
       })
       mockPortalSessionsCreate.mockResolvedValue({
         url: 'https://billing.stripe.com/portal',
       })
-      delete process.env.NEXT_PUBLIC_APP_URL
+      delete process.env.APP_URL
 
       const { createPortalSession } = await import('./portal.server')
       await createPortalSession('user-1')

--- a/happyhq/ee/lib/billing/portal.server.ts
+++ b/happyhq/ee/lib/billing/portal.server.ts
@@ -24,7 +24,7 @@ export async function createPortalSession(userId: string): Promise<string> {
   const stripe = getStripeClient()
   const session = await stripe.billingPortal.sessions.create({
     customer: user.stripeCustomerId,
-    return_url: `${process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}/settings/billing`,
+    return_url: `${process.env.APP_URL ?? 'http://localhost:3000'}/settings/billing`,
   })
 
   return session.url

--- a/happyhq/specs/billing.md
+++ b/happyhq/specs/billing.md
@@ -354,7 +354,7 @@ HappyHQ is the product. It's open source (MIT or similar) — streams, tasks, le
 | `STRIPE_PRICE_ID_PRO`         | When EE                  | Stripe price ID for Pro tier                                                        |
 | `STRIPE_PRICE_ID_MAX`         | When EE                  | Stripe price ID for Max tier                                                        |
 | `CLOUDFLARE_AI_GATEWAY_URL`   | When EE + local/Electron | AI Gateway endpoint for API key delivery                                            |
-| `NEXT_PUBLIC_APP_URL`         | Optional                 | App URL for Stripe Checkout redirect URLs (defaults to `http://localhost:3000`)     |
+| `APP_URL`                     | Optional                 | App URL for Stripe Checkout redirect URLs (defaults to `http://localhost:3000`)     |
 
 For local dev with billing, use Stripe test mode keys. Webhooks are handled by the separate private `billing` service repo (Cloudflare Worker) — clone that repo and run it locally with `pnpm dev`, then use `stripe listen --forward-to localhost:8787/webhook/stripe`.
 


### PR DESCRIPTION
## Summary
- The Stripe checkout/portal redirect URLs read `process.env.NEXT_PUBLIC_APP_URL`. The `NEXT_PUBLIC_` prefix causes Next.js to inline the build-time value into the bundle (server and client both, via DefinePlugin) — so the runtime value was silently ignored.
- Verified empirically on a deployed instance: `process.env.NEXT_PUBLIC_APP_URL` was `https://q-tokyo.fly.dev` in the running container, but the compiled `route.js` for the billing checkout endpoint contained the literal string `"localhost:3000"` and no reference to `process.env` at the call site at all. Stripe redirects landed on localhost.
- Both [checkout.server.ts](happyhq/ee/lib/billing/checkout.server.ts) and [portal.server.ts](happyhq/ee/lib/billing/portal.server.ts) are server-only files — no client code references the variable — so the `NEXT_PUBLIC_` prefix wasn't earning its keep.
- Drop the prefix → `APP_URL`. Now read at runtime, per-instance values (Fly secrets, container env, etc.) work correctly. `.env.example` and `specs/billing.md` updated to match.

## Test plan
- [x] `pnpm test ee/lib/billing/checkout.server.test.ts ee/lib/billing/portal.server.test.ts` — 12/12 pass
- [x] `pnpm lint` / `pnpm check-types` — clean
- [ ] After merge: redeploy a q-* instance with `APP_URL` Fly secret, confirm Stripe checkout/cancel redirect lands on the right `*.fly.dev` host

## Heads-up for self-hosters
If you have `NEXT_PUBLIC_APP_URL` set in your local `.env*` files, rename it to `APP_URL`. The fallback (`http://localhost:3000`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)