### PR TITLE
fix: pass auth token from draft panel when creating a stream

### DIFF
--- a/happyhq/components/features/streams/panel/draft.tsx
+++ b/happyhq/components/features/streams/panel/draft.tsx
@@ -9,6 +9,7 @@ import {
   Shell,
   Sidebar,
 } from '@/components/features/desktop/panels/atoms'
+import { useCurrentUser } from '@/lib/accounts/hooks'
 import {
   checkStreamExists,
   createStream,
@@ -21,6 +22,7 @@ import { useRouter } from 'next/navigation'
 export function DraftStreamPanel() {
   const router = useRouter()
   const mutateStreams = useStreamsMutate()
+  const { token } = useCurrentUser()
 
   const [name, setName] = useState('')
   const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -42,7 +44,7 @@ export function DraftStreamPanel() {
         setIsCreating(false)
         return
       }
-      await createStream(slug)
+      await createStream(slug, token)
       await writeStreamTitle(slug, trimmed)
       mutateStreams?.()
       router.replace(`/${encodeURIComponent(slug)}`)


### PR DESCRIPTION
## Summary
[lib/actions/streams.ts](happyhq/lib/actions/streams.ts) accepts an optional `token` arg used for billing-tier verification, and its own docstring says the client should pass `db.useAuth().user.refresh_token`. But the only call site, [components/features/streams/panel/draft.tsx](happyhq/components/features/streams/panel/draft.tsx), called `createStream(slug)` with no token — so on a billing-enabled instance, even a signed-in user hit:

```
Error: Sign in required to create a stream.
```

Read the token from the existing `useCurrentUser()` hook ([lib/accounts/hooks.ts](happyhq/lib/accounts/hooks.ts)) — which already exposes `token` specifically for this purpose — and forward it to `createStream()`. When accounts/billing are disabled, the hook returns `undefined` and the action's billing path is skipped, preserving existing CE behavior.

## Heads-up
The same UI gap likely exists for the `samples.ts` and `ingestion.ts` actions, which also take optional `token` args. They aren't blocking the immediate stream-creation flow, but a follow-up PR should audit those call sites the same way.

## Test plan
- [x] `pnpm test lib/actions/streams.test.ts` — 20/20 pass (no behavior change in the action itself)
- [x] `pnpm lint` / `pnpm check-types` — clean
- [ ] After merge + redeploy: create a stream as a signed-in user on a billing-enabled instance — succeeds without the spurious sign-in error

🤖 Generated with [Claude Code](https://claude.com/claude-code)