### PR TITLE
fix: pass auth token from task creation file uploads

### DIFF
--- a/happyhq/components/features/tasks/create/dialog.tsx
+++ b/happyhq/components/features/tasks/create/dialog.tsx
@@ -6,6 +6,7 @@ import { useSidebarOptional } from '@/components/common/ui/sidebar'
 import { FileRow } from '@/components/features/desktop/windows/shared/file-row'
 import { useFileDrop } from '@/components/features/desktop/windows/shared/use-file-drop'
 import { StreamPicker } from '@/components/features/tasks/atoms/stream-picker'
+import { useCurrentUser } from '@/lib/accounts/hooks'
 import { createTask, ingestTaskInput } from '@/lib/actions'
 import { generateTaskSlug } from '@/lib/format'
 import { taskItemsKey } from '@/lib/swr-keys'
@@ -26,6 +27,7 @@ export function TaskCreateDialog({
   const sidebar = useSidebarOptional()
   const streams = useStreams()
   const { mutate } = useSWRConfig()
+  const { token } = useCurrentUser()
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [selectedStream, setSelectedStream] = useState<string | null>(null)
@@ -74,7 +76,7 @@ export function TaskCreateDialog({
         const formData = new FormData()
         formData.append('file', file)
         try {
-          await ingestTaskInput(slug, formData)
+          await ingestTaskInput(slug, formData, token ?? undefined)
         } catch {
           toast.error(`Failed to attach ${file.name}`)
         }

--- a/happyhq/components/features/tasks/create/quick-add.tsx
+++ b/happyhq/components/features/tasks/create/quick-add.tsx
@@ -6,6 +6,7 @@ import { toastError, toastWarning } from '@/components/common/ui/sonner'
 import { FileRow } from '@/components/features/desktop/windows/shared/file-row'
 import { useFileDrop } from '@/components/features/desktop/windows/shared/use-file-drop'
 import { StreamPicker } from '@/components/features/tasks/atoms/stream-picker'
+import { useCurrentUser } from '@/lib/accounts/hooks'
 import { createTask, ingestTaskInput } from '@/lib/actions'
 import { toSlug } from '@/lib/format'
 import { taskItemsKey } from '@/lib/swr-keys'
@@ -22,6 +23,7 @@ export function TaskQuickAdd({
 } = {}) {
   const streams = useStreams()
   const { mutate } = useSWRConfig()
+  const { token } = useCurrentUser()
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [selectedStream, setSelectedStream] = useState<string | null>(
@@ -65,7 +67,11 @@ export function TaskQuickAdd({
         const formData = new FormData()
         formData.append('file', file)
         try {
-          const result = await ingestTaskInput(slug, formData)
+          const result = await ingestTaskInput(
+            slug,
+            formData,
+            token ?? undefined,
+          )
           if (result.quality === 'poor' || result.quality === 'empty') {
             toastWarning(
               `"${file.name.length > 20 ? file.name.slice(0, 20) + '…' : file.name}" not optimized for AI comprehension`,


### PR DESCRIPTION
## Summary
Same shape as #56. `ingestTaskInput()` takes an optional `token` for billing-tier verification; the two task-creation entry points were calling it as `(slug, formData)` with no token, so attaching files during task creation threw "Sign in required..." on a billing-enabled instance even for signed-in users.

Fix:
- [components/features/tasks/create/dialog.tsx](happyhq/components/features/tasks/create/dialog.tsx) — `TaskCreateDialog` now reads `token` from `useCurrentUser()` and forwards it.
- [components/features/tasks/create/quick-add.tsx](happyhq/components/features/tasks/create/quick-add.tsx) — same in `TaskQuickAdd`.

The other `ingestTaskInput` call sites ([card/index.tsx](happyhq/components/features/tasks/card/index.tsx), [hooks/use-optimistic-uploads.ts](happyhq/components/features/tasks/hooks/use-optimistic-uploads.ts)) were already passing `token` correctly — this just brings the create-flow into line.

## Test plan
- [x] `pnpm test lib/actions/ingestion.test.ts` — 21/21 pass
- [x] `pnpm lint` / `pnpm check-types` — clean
- [ ] After merge + redeploy: create a new task with an attached file as a signed-in user — succeeds without spurious sign-in error

🤖 Generated with [Claude Code](https://claude.com/claude-code)