### PR TITLE
fix: refresh activity timeline after history reset

### DIFF
--- a/happyhq/components/features/settings/danger-zone.tsx
+++ b/happyhq/components/features/settings/danger-zone.tsx
@@ -3,9 +3,11 @@
 import { SettingsRow } from '@/app/(settings)/settings/_components/settings-row'
 import { Button } from '@/components/common/catalyst/button'
 import { DeleteAlert } from '@/components/common/shared/delete-alert'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 export function DangerZone() {
+  const router = useRouter()
   const [showConfirm, setShowConfirm] = useState(false)
   const [resetting, setResetting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -25,6 +27,7 @@ export function DangerZone() {
         return
       }
 
+      router.refresh()
       setSuccess(true)
       setTimeout(() => setSuccess(false), 3000)
     } catch {


### PR DESCRIPTION
## Summary

Fixes #22.

The Settings → History page is a server component that fetches `getGitLog()` once at render time. The Danger Zone "Reset history" handler clears the workspace git log on disk but never tells Next.js to re-render the route, so the Activity timeline kept showing pre-reset entries until a manual reload.

- `components/features/settings/danger-zone.tsx`: call `router.refresh()` after a successful `/api/git/reset` so the History page's server component re-runs with the cleared log.

## Test plan

- [ ] Visit Settings → History with a non-empty Activity timeline
- [ ] Click "Reset history" in the Danger Zone and confirm
- [ ] Verify the success flash ("History cleared") appears
- [ ] Verify the Activity timeline updates to the cleared state without a manual reload


---
_Generated by [Claude Code](https://claude.ai/code/session_01QDdrZd7meUihqGFVxcQZiM)_