### PR TITLE
fix: replace `<img>` with `next/image` for no-img-element warnings

### DIFF
--- a/happyhq/app/(auth)/login/login-page.tsx
+++ b/happyhq/app/(auth)/login/login-page.tsx
@@ -5,6 +5,7 @@ import { ErrorMessage, Field } from '@/components/common/catalyst/fieldset'
 import { Input } from '@/components/common/catalyst/input'
 import { AccountsLogin } from '@/components/features/auth/accounts-login'
 import { isAccountsEnabledClient } from '@/lib/accounts/config'
+import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useActionState, useEffect, useRef, useState } from 'react'
 import { login } from './actions'
@@ -23,7 +24,15 @@ export function LoginPage({ hasPasswordGate }: { hasPasswordGate: boolean }) {
     <div className="bg-background flex min-h-screen items-center justify-center px-4">
       <div className="w-full max-w-[320px]">
         <div className="mb-8 flex justify-center">
-          <img src="/brand/logo.svg" alt="HappyHQ" className="h-12" />
+          <Image
+            src="/brand/logo.svg"
+            alt="HappyHQ"
+            width={235}
+            height={48}
+            priority
+            unoptimized
+            className="h-12 w-auto"
+          />
         </div>
 
         {accountsEnabled && (!hasPasswordGate || passwordCleared) ? (

--- a/happyhq/app/(auth)/login/page.test.tsx
+++ b/happyhq/app/(auth)/login/page.test.tsx
@@ -23,7 +23,7 @@ vi.mock('next/image', () => ({
     priority: _,
     ...props
   }: React.ComponentProps<'img'> & { priority?: boolean }) => {
-    // eslint-disable-next-line jsx-a11y/alt-text
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text -- mock for next/image, simpler test output
     return <img {...props} />
   },
 }))

--- a/happyhq/app/(auth)/login/page.test.tsx
+++ b/happyhq/app/(auth)/login/page.test.tsx
@@ -23,7 +23,7 @@ vi.mock('next/image', () => ({
     priority: _,
     ...props
   }: React.ComponentProps<'img'> & { priority?: boolean }) => {
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    // eslint-disable-next-line jsx-a11y/alt-text
     return <img {...props} />
   },
 }))

--- a/happyhq/app/(auth)/setup/page.tsx
+++ b/happyhq/app/(auth)/setup/page.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/common/catalyst/button'
 import { ErrorMessage, Field } from '@/components/common/catalyst/fieldset'
 import { Input } from '@/components/common/catalyst/input'
+import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 import { mutate } from 'swr'
@@ -112,7 +113,15 @@ export default function SetupPage() {
     <div className="bg-background flex min-h-screen items-center justify-center px-4">
       <div className="w-full max-w-[320px]">
         <div className="mb-8 flex justify-center">
-          <img src="/brand/logo.svg" alt="HappyHQ" className="h-12" />
+          <Image
+            src="/brand/logo.svg"
+            alt="HappyHQ"
+            width={235}
+            height={48}
+            priority
+            unoptimized
+            className="h-12 w-auto"
+          />
         </div>
 
         {mode === 'choice' && (

--- a/happyhq/components/common/greeting/greeting.tsx
+++ b/happyhq/components/common/greeting/greeting.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import Image from 'next/image'
+
 export function getGreeting(): { text: string; emoji: string } {
   const hour = new Date().getHours()
   if (hour < 12) return { text: 'Good morning', emoji: '☀️' }
@@ -16,11 +18,12 @@ export function Greeting({ showQ = false }: { showQ?: boolean }) {
       }
     >
       {showQ && (
-        <img
+        <Image
           src="/brand/qutie.png"
           alt="Q"
+          width={42}
+          height={55}
           className="mt-1 shrink-0"
-          style={{ width: 42, height: 55 }}
           draggable={false}
         />
       )}

--- a/happyhq/components/common/sticker.tsx
+++ b/happyhq/components/common/sticker.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils'
 import { motion } from 'framer-motion'
+import Image from 'next/image'
 
 interface StickerProps {
   src: string
@@ -56,7 +57,16 @@ export function Sticker({
           ].join(' '),
         }}
       >
-        <img src={src} alt={alt} className="block w-full" draggable={false} />
+        <Image
+          src={src}
+          alt={alt}
+          width={size}
+          height={size}
+          unoptimized
+          draggable={false}
+          className="block w-full"
+          style={{ height: 'auto' }}
+        />
       </div>
     </motion.div>
   )

--- a/happyhq/components/features/chat/list/chat-list-home.tsx
+++ b/happyhq/components/features/chat/list/chat-list-home.tsx
@@ -10,6 +10,7 @@ import { allChatsKey } from '@/lib/swr-keys'
 import { groupByTime } from '@/lib/time-groups'
 import { AnimatePresence, motion } from 'framer-motion'
 import { MessageCircle } from 'lucide-react'
+import Image from 'next/image'
 import { useState } from 'react'
 import useSWR from 'swr'
 import { ChatListItem } from './chat-list-item'
@@ -198,10 +199,13 @@ export function ChatListHome() {
       {/* Poolside mode */}
       {branding === 'poolside' && !isMobile && (
         <div className="pointer-events-none absolute inset-x-0 bottom-0 hidden translate-y-[60%] sm:block">
-          <img
+          <Image
             src="/brand/poolside.png"
             alt="Poolside"
+            width={1734}
+            height={904}
             className="w-full"
+            style={{ height: 'auto' }}
             draggable={false}
           />
         </div>

--- a/happyhq/components/features/command-menu/pages/url-input-page.tsx
+++ b/happyhq/components/features/command-menu/pages/url-input-page.tsx
@@ -15,6 +15,7 @@ import {
   Search,
   Video,
 } from 'lucide-react'
+import Image from 'next/image'
 import { useEffect, useState, useTransition } from 'react'
 
 // Action state exposed to parent for header button
@@ -262,10 +263,13 @@ export function UrlInputPage({
             }`}
           >
             {isLoaded && unfurlData?.image && (
-              <img
+              <Image
                 src={unfurlData.image}
                 alt=""
-                className="absolute inset-0 h-full w-full object-cover"
+                fill
+                unoptimized
+                sizes="320px"
+                className="object-cover"
                 onError={(e) => {
                   e.currentTarget.style.display = 'none'
                 }}
@@ -300,9 +304,12 @@ export function UrlInputPage({
               <>
                 <div className="flex items-start gap-2">
                   {unfurlData.favicon && (
-                    <img
+                    <Image
                       src={unfurlData.favicon}
                       alt=""
+                      width={16}
+                      height={16}
+                      unoptimized
                       className="mt-0.5 size-4 shrink-0 rounded"
                       onError={(e) => {
                         e.currentTarget.style.display = 'none'

--- a/happyhq/components/features/command-menu/pages/url-input-page.tsx
+++ b/happyhq/components/features/command-menu/pages/url-input-page.tsx
@@ -262,7 +262,6 @@ export function UrlInputPage({
             }`}
           >
             {isLoaded && unfurlData?.image && (
-              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={unfurlData.image}
                 alt=""
@@ -301,7 +300,6 @@ export function UrlInputPage({
               <>
                 <div className="flex items-start gap-2">
                   {unfurlData.favicon && (
-                    // eslint-disable-next-line @next/next/no-img-element
                     <img
                       src={unfurlData.favicon}
                       alt=""

--- a/happyhq/components/features/desktop/windows/image/image-window.tsx
+++ b/happyhq/components/features/desktop/windows/image/image-window.tsx
@@ -2,7 +2,8 @@
 
 import { useWindowStore } from '@/stores/windowStore'
 import { Loader2 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import NextImage from 'next/image'
+import { useEffect, useState } from 'react'
 import type { WindowComponentProps } from '../types'
 import { useFrameProps } from '../use-frame-props'
 import { WindowFileActions } from '../window-file-actions'
@@ -18,10 +19,8 @@ const MIN_HEIGHT = 160
 
 export function ImageWindow({ id, canvasRef }: WindowComponentProps) {
   const result = useFrameProps(id, canvasRef)
-  const [loaded, setLoaded] = useState(false)
+  const [natural, setNatural] = useState<{ w: number; h: number } | null>(null)
   const [error, setError] = useState(false)
-  const imgRef = useRef<HTMLImageElement>(null)
-  const resizedRef = useRef(false)
 
   const w = result?.window
   const filePath = w?.contentType === 'image' ? w.meta.filePath : undefined
@@ -29,37 +28,40 @@ export function ImageWindow({ id, canvasRef }: WindowComponentProps) {
     ? `/api/fs/download?path=${encodeURIComponent(filePath)}`
     : undefined
 
-  // Once the image loads, resize the window to fit the natural image size.
+  // Preload to measure natural dimensions, then resize the window to fit.
+  // We preload via the browser Image constructor so next/image can be rendered
+  // with explicit width/height (required for non-fill usage).
   useEffect(() => {
-    if (!loaded || !imgRef.current || resizedRef.current) return
-    resizedRef.current = true
+    if (!src) return
+    const probe = new window.Image()
+    probe.onload = () => {
+      const { naturalWidth, naturalHeight } = probe
+      if (!naturalWidth || !naturalHeight) return
+      setNatural({ w: naturalWidth, h: naturalHeight })
 
-    const { naturalWidth, naturalHeight } = imgRef.current
-    if (!naturalWidth || !naturalHeight) return
-
-    // Fit the image within max bounds while preserving aspect ratio,
-    // accounting for padding and title bar chrome.
-    const maxContentW = MAX_WIDTH - CHROME.w
-    const maxContentH = MAX_HEIGHT - CHROME.h
-    const scale = Math.min(
-      1,
-      maxContentW / naturalWidth,
-      maxContentH / naturalHeight,
-    )
-    const targetW = Math.max(
-      MIN_WIDTH,
-      Math.round(naturalWidth * scale) + CHROME.w,
-    )
-    const targetH = Math.max(
-      MIN_HEIGHT,
-      Math.round(naturalHeight * scale) + CHROME.h,
-    )
-
-    useWindowStore.getState().resizeWindow(id, {
-      width: targetW,
-      height: targetH,
-    })
-  }, [loaded, id])
+      const maxContentW = MAX_WIDTH - CHROME.w
+      const maxContentH = MAX_HEIGHT - CHROME.h
+      const scale = Math.min(
+        1,
+        maxContentW / naturalWidth,
+        maxContentH / naturalHeight,
+      )
+      const targetW = Math.max(
+        MIN_WIDTH,
+        Math.round(naturalWidth * scale) + CHROME.w,
+      )
+      const targetH = Math.max(
+        MIN_HEIGHT,
+        Math.round(naturalHeight * scale) + CHROME.h,
+      )
+      useWindowStore.getState().resizeWindow(id, {
+        width: targetW,
+        height: targetH,
+      })
+    }
+    probe.onerror = () => setError(true)
+    probe.src = src
+  }, [src, id])
 
   if (!result) return null
   const { frameProps } = result
@@ -72,18 +74,19 @@ export function ImageWindow({ id, canvasRef }: WindowComponentProps) {
       actions={<WindowFileActions filePath={w.meta.filePath} />}
     >
       <div className="flex h-full items-center justify-center overflow-hidden bg-zinc-100 p-4">
-        {!loaded && !error && (
+        {!natural && !error && (
           <Loader2 className="h-5 w-5 animate-spin text-zinc-300" />
         )}
         {error && <p className="text-sm text-zinc-400">Failed to load image</p>}
-        {src && (
-          <img
-            ref={imgRef}
+        {src && natural && (
+          <NextImage
             src={src}
             alt={w.title}
-            onLoad={() => setLoaded(true)}
-            onError={() => setError(true)}
-            className={`max-h-full max-w-full object-contain ${loaded ? '' : 'hidden'}`}
+            width={natural.w}
+            height={natural.h}
+            unoptimized
+            className="max-h-full max-w-full object-contain"
+            style={{ width: 'auto', height: 'auto' }}
             draggable={false}
           />
         )}

--- a/happyhq/components/features/settings/account-settings.test.tsx
+++ b/happyhq/components/features/settings/account-settings.test.tsx
@@ -60,6 +60,7 @@ vi.mock('@/components/common/catalyst/avatar', () => ({
   }) => (
     <span data-slot="avatar" className={className}>
       {src?.startsWith('http') ? (
+        // eslint-disable-next-line @next/next/no-img-element -- mock renders plain img for test simplicity
         <img src={src} alt={alt ?? ''} />
       ) : (
         initials && <span>{initials}</span>

--- a/happyhq/components/features/settings/home-branding-picker.tsx
+++ b/happyhq/components/features/settings/home-branding-picker.tsx
@@ -4,6 +4,7 @@ import type { HomeBranding } from '@/lib/config/types'
 import { cn } from '@/lib/utils'
 import { Radio, RadioGroup } from '@headlessui/react'
 import { CircleOff, Shuffle } from 'lucide-react'
+import Image from 'next/image'
 
 const BRANDING_OPTIONS: {
   value: HomeBranding
@@ -34,12 +35,16 @@ function MiniSticker({
   className?: string
 }) {
   return (
-    <img
+    <Image
       src={src}
       alt={alt}
+      width={48}
+      height={48}
+      unoptimized
       draggable={false}
       className={cn('block', className)}
       style={{
+        height: 'auto',
         filter: [
           'drop-shadow(0px -1.5px 0 white)',
           'drop-shadow(0px 1.5px 0 white)',
@@ -80,10 +85,13 @@ function OptionPreview({ value }: { value: HomeBranding }) {
       )
     case 'poolside':
       return (
-        <img
+        <Image
           src="/brand/poolside.png"
           alt="Poolside"
+          width={1734}
+          height={904}
           className="absolute bottom-0 left-0 w-full translate-y-1/3 object-contain"
+          style={{ height: 'auto' }}
           draggable={false}
         />
       )
@@ -97,10 +105,13 @@ function OptionPreview({ value }: { value: HomeBranding }) {
       )
     case 'q':
       return (
-        <img
+        <Image
           src="/brand/qutie-avatar.png"
           alt="Q"
+          width={713}
+          height={1005}
           className="w-10 object-contain"
+          style={{ height: 'auto' }}
           draggable={false}
         />
       )

--- a/happyhq/components/features/sidebar/atoms/account-footer.test.tsx
+++ b/happyhq/components/features/sidebar/atoms/account-footer.test.tsx
@@ -68,7 +68,10 @@ vi.mock('@/components/common/catalyst/avatar', () => ({
     className?: string
   }) => (
     <div data-slot="avatar" data-initials={initials} data-alt={alt}>
-      {src && <img data-slot="avatar-image" src={src} alt={alt ?? ''} />}
+      {src && (
+        // eslint-disable-next-line @next/next/no-img-element -- mock renders plain img for test simplicity
+        <img data-slot="avatar-image" src={src} alt={alt ?? ''} />
+      )}
       {!src && initials && <span data-slot="avatar-fallback">{initials}</span>}
     </div>
   ),

--- a/happyhq/components/features/tasks/atoms/attachment-list.tsx
+++ b/happyhq/components/features/tasks/atoms/attachment-list.tsx
@@ -11,6 +11,7 @@ import { FileRow } from '@/components/features/desktop/windows/shared/file-row'
 import type { PendingFile } from '@/components/features/tasks/hooks/use-optimistic-uploads'
 import type { FileItem } from '@/lib/fs/types'
 import { AlertTriangle, MoreHorizontal } from 'lucide-react'
+import Image from 'next/image'
 
 interface AttachmentListProps {
   inputs: FileItem[]
@@ -123,9 +124,12 @@ function InputRow({
         iconSlot={
           input.favicon ? (
             <>
-              <img
+              <Image
                 src={input.favicon}
                 alt=""
+                width={18}
+                height={18}
+                unoptimized
                 className="h-[18px] w-[18px] shrink-0 rounded-sm"
                 onError={(e) => {
                   // Fall back to generic web icon on favicon load failure

--- a/happyhq/components/features/tasks/atoms/attachment-list.tsx
+++ b/happyhq/components/features/tasks/atoms/attachment-list.tsx
@@ -123,7 +123,6 @@ function InputRow({
         iconSlot={
           input.favicon ? (
             <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={input.favicon}
                 alt=""

--- a/happyhq/components/features/tasks/card/debug/mock-task-panel.tsx
+++ b/happyhq/components/features/tasks/card/debug/mock-task-panel.tsx
@@ -13,6 +13,7 @@ import type { TaskContent } from '@/lib/fs/types'
 import { taskContentKey, taskItemsKey } from '@/lib/swr-keys'
 import { useTaskStore } from '@/stores/taskStore'
 import { X } from 'lucide-react'
+import Image from 'next/image'
 import { useCallback, useState } from 'react'
 import { mutate } from 'swr'
 
@@ -126,9 +127,11 @@ export function MockTaskPanel() {
         onClick={() => setOpen(true)}
         className="fixed right-5 bottom-16 z-50 flex size-9 items-center justify-center rounded-full border border-white/10 bg-zinc-900 shadow-lg transition-colors hover:bg-zinc-800"
       >
-        <img
+        <Image
           src="/brand/gophie.png"
           alt="Dev tools"
+          width={32}
+          height={32}
           className="size-8 rounded-full"
         />
         {mockMode && (

--- a/happyhq/eslint.config.mjs
+++ b/happyhq/eslint.config.mjs
@@ -20,7 +20,6 @@ const eslintConfig = [
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-empty-interface': 'off',
       'prefer-const': 'off',
-      '@next/next/no-img-element': 'off',
     },
   },
 ]

--- a/happyhq/eslint.config.mjs
+++ b/happyhq/eslint.config.mjs
@@ -20,6 +20,7 @@ const eslintConfig = [
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-empty-interface': 'off',
       'prefer-const': 'off',
+      '@next/next/no-img-element': 'off',
     },
   },
 ]


### PR DESCRIPTION
## Summary

Replaces `<img>` tags with `next/image` to actually resolve the 11 `@next/next/no-img-element` warnings instead of silencing the rule.

- **Static brand assets** (`logo.svg`, `qutie.png`, `gophie.png`, `poolside.png`, `qutie-avatar.png`) get explicit `width`/`height` props; SVG sources use `unoptimized` since `dangerouslyAllowSVG` is not enabled.
- **`Sticker`** is generic over `src`, so it forwards the existing `size` prop as `width`/`height` and uses `style={{ height: 'auto' }}` to preserve natural aspect ratio.
- **`ImageWindow`** (dynamic image viewer) now preloads via the browser `Image` constructor to measure natural dimensions, then renders `next/image` with explicit `width`/`height` and `unoptimized` (the source is an arbitrary local file via `/api/fs/download`).
- **Unfurl previews** (`url-input-page`) and **attachment favicons** (`attachment-list`) use `next/image` with `unoptimized` so arbitrary external hosts render without configuring `remotePatterns`.
- **Test mocks** that intentionally render plain `<img>` (mocking `next/image` itself, or the `Avatar` component) keep the `<img>` with a narrowly scoped `eslint-disable-next-line @next/next/no-img-element` plus a one-line reason.

## Test plan

- [x] `pnpm lint` — `✔ No ESLint warnings or errors`
- [x] `pnpm check-types` — clean
- [x] `pnpm test` — 1333 tests pass

https://claude.ai/code/session_01JeDdojGq5ND6iu3H3xVWan