### PR TITLE
fix: drop pt-2 from desktop chat scroll container so sticky header covers cleanly

### DIFF
--- a/happyhq/components/features/desktop/windows/chat/chat-window.tsx
+++ b/happyhq/components/features/desktop/windows/chat/chat-window.tsx
@@ -282,7 +282,7 @@ export function ChatWindow({ id, canvasRef }: WindowComponentProps) {
           <div
             ref={scrollRef}
             data-chat-surface="window"
-            className="flex-1 overflow-y-auto px-4 pt-2 pb-4"
+            className="flex-1 overflow-y-auto px-4 pb-4"
           >
             <div className="w-full space-y-3">
               <ChatMessageList messages={messages} />


### PR DESCRIPTION
Fixes #33.

## Summary

- The desktop chat window's scroll container had `pt-2` padding-top inside the scrollable area. The sticky user message pins to `top-0` of the content area (i.e., below the padding), so scrolled-up messages briefly peek through that 8px band before the sticky's `bg-white` covers them.
- Removed `pt-2` at `happyhq/components/features/desktop/windows/chat/chat-window.tsx:285`. The first message's existing `pt-5` (from `chat-message-list.tsx`) preserves the visual top gap.
- Audited the other two chat surfaces — `chat-content.tsx` and `chat-page-content.tsx` already use no padding on their scroll containers, so the bug was localized to the desktop chat window.

## Test plan

- [ ] Open a task with run history (planning or working log) on the desktop.
- [ ] Scroll down past the user message so content flows under the sticky header.
- [ ] Confirm the white background of the sticky header extends to the top edge of the chat window — no flicker, no peek-through band.
- [ ] Verify the visible top gap between the window frame and the first message still looks right (carried by the first message's `pt-5`).
- [x] `pnpm check-types` — clean
- [x] `pnpm test` — 1333/1333 pass
- [x] `pnpm lint` — only pre-existing `<img>` warnings
- [x] `pnpm format` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpTpQjN7hwzuritM6DA6Fu)_