### PR TITLE
fix: use next/image for auth logos, disable no-img-element elsewhere

### DIFF
--- a/happyhq/app/(auth)/login/login-page.tsx
+++ b/happyhq/app/(auth)/login/login-page.tsx
@@ -5,6 +5,7 @@ import { ErrorMessage, Field } from '@/components/common/catalyst/fieldset'
 import { Input } from '@/components/common/catalyst/input'
 import { AccountsLogin } from '@/components/features/auth/accounts-login'
 import { isAccountsEnabledClient } from '@/lib/accounts/config'
+import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useActionState, useEffect, useRef, useState } from 'react'
 import { login } from './actions'
@@ -23,7 +24,15 @@ export function LoginPage({ hasPasswordGate }: { hasPasswordGate: boolean }) {
     <div className="bg-background flex min-h-screen items-center justify-center px-4">
       <div className="w-full max-w-[320px]">
         <div className="mb-8 flex justify-center">
-          <img src="/brand/logo.svg" alt="HappyHQ" className="h-12" />
+          <Image
+            src="/brand/logo.svg"
+            alt="HappyHQ"
+            width={235}
+            height={48}
+            priority
+            unoptimized
+            className="h-12 w-auto"
+          />
         </div>
 
         {accountsEnabled && (!hasPasswordGate || passwordCleared) ? (

--- a/happyhq/app/(auth)/login/page.test.tsx
+++ b/happyhq/app/(auth)/login/page.test.tsx
@@ -23,7 +23,7 @@ vi.mock('next/image', () => ({
     priority: _,
     ...props
   }: React.ComponentProps<'img'> & { priority?: boolean }) => {
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    // eslint-disable-next-line jsx-a11y/alt-text
     return <img {...props} />
   },
 }))

--- a/happyhq/app/(auth)/setup/page.tsx
+++ b/happyhq/app/(auth)/setup/page.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/common/catalyst/button'
 import { ErrorMessage, Field } from '@/components/common/catalyst/fieldset'
 import { Input } from '@/components/common/catalyst/input'
+import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 import { mutate } from 'swr'
@@ -112,7 +113,15 @@ export default function SetupPage() {
     <div className="bg-background flex min-h-screen items-center justify-center px-4">
       <div className="w-full max-w-[320px]">
         <div className="mb-8 flex justify-center">
-          <img src="/brand/logo.svg" alt="HappyHQ" className="h-12" />
+          <Image
+            src="/brand/logo.svg"
+            alt="HappyHQ"
+            width={235}
+            height={48}
+            priority
+            unoptimized
+            className="h-12 w-auto"
+          />
         </div>
 
         {mode === 'choice' && (

--- a/happyhq/components/features/command-menu/pages/url-input-page.tsx
+++ b/happyhq/components/features/command-menu/pages/url-input-page.tsx
@@ -262,7 +262,6 @@ export function UrlInputPage({
             }`}
           >
             {isLoaded && unfurlData?.image && (
-              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={unfurlData.image}
                 alt=""
@@ -301,7 +300,6 @@ export function UrlInputPage({
               <>
                 <div className="flex items-start gap-2">
                   {unfurlData.favicon && (
-                    // eslint-disable-next-line @next/next/no-img-element
                     <img
                       src={unfurlData.favicon}
                       alt=""

--- a/happyhq/components/features/tasks/atoms/attachment-list.tsx
+++ b/happyhq/components/features/tasks/atoms/attachment-list.tsx
@@ -112,7 +112,6 @@ function InputRow({
         iconSlot={
           input.favicon ? (
             <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={input.favicon}
                 alt=""

--- a/happyhq/eslint.config.mjs
+++ b/happyhq/eslint.config.mjs
@@ -20,6 +20,7 @@ const eslintConfig = [
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-empty-interface': 'off',
       'prefer-const': 'off',
+      '@next/next/no-img-element': 'off',
     },
   },
 ]


### PR DESCRIPTION
## Summary

Replaces the more invasive #59 (now closed). The original PR migrated 11 `<img>` call sites to `next/image` to clear `@next/next/no-img-element`, but most ended up using `unoptimized` because:

- SVGs can't be optimized without enabling `dangerouslyAllowSVG`
- External unfurl images / favicons would require `remotePatterns`
- Local user files served via `/api/fs/download` can't be optimized at all

Net: full migration cost (including a real logic rewrite in `image-window.tsx`) for a cosmetic win.

This PR keeps the one place the migration actually pays for itself and silences the rule everywhere else.

- `app/(auth)/login/login-page.tsx`, `app/(auth)/setup/page.tsx`: swap `<img>` → `next/image` with `priority` (LCP) and `unoptimized` (SVG without `dangerouslyAllowSVG`). Explicit `width={235} height={48}` to lock layout.
- `eslint.config.mjs`: disable `@next/next/no-img-element`.
- Remove three now-orphan inline `eslint-disable-next-line @next/next/no-img-element` comments (`url-input-page.tsx` ×2, `attachment-list.tsx`) and one combined disable in `login/page.test.tsx` (kept `jsx-a11y/alt-text`).

## Test plan

- [x] `pnpm lint` — `✔ No ESLint warnings or errors`
- [x] `pnpm check-types` — clean
- [x] `pnpm test` — 1333/1333 pass
- [x] `pnpm format` — clean