### PR TITLE
fix: stop clobbering TaskCard description while user is typing

### DIFF
--- a/happyhq/components/features/tasks/card/description-section.test.tsx
+++ b/happyhq/components/features/tasks/card/description-section.test.tsx
@@ -1,0 +1,76 @@
+import type { TaskContent } from '@/lib/fs/types'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockState = vi.hoisted(() => ({
+  content: null as TaskContent | null,
+}))
+
+vi.mock('../hooks/use-task-swr', () => ({
+  useTaskContentData: () => mockState.content,
+  useTaskMutate: () => vi.fn(),
+}))
+
+vi.mock('@/stores/taskStore', () => ({
+  useTaskStore: (selector: (s: { taskSlug: string }) => unknown) =>
+    selector({ taskSlug: 'task-1' }),
+}))
+
+vi.mock('@/lib/actions', () => ({
+  writeTaskDescription: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { DescriptionSection } from './description-section'
+
+const baseContent: TaskContent = {
+  description: '',
+  inputs: [],
+  outputs: [],
+  working: [],
+  plan: null,
+  run: null,
+} as unknown as TaskContent
+
+beforeEach(() => {
+  mockState.content = { ...baseContent, description: '' }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('DescriptionSection — cursor stability while typing', () => {
+  it('preserves user input when server data refreshes mid-edit', () => {
+    const { rerender } = render(<DescriptionSection />)
+    const textarea = screen.getByPlaceholderText(
+      'Add context...',
+    ) as HTMLTextAreaElement
+
+    // Simulates a fast typist: user types past what the debounced save has flushed.
+    fireEvent.change(textarea, { target: { value: 'hello world' } })
+    expect(textarea.value).toBe('hello world')
+
+    // Server-side save lands and SWR refetches with the older snapshot
+    // (the value that was sent before the user kept typing).
+    mockState.content = { ...baseContent, description: 'hello' }
+    rerender(<DescriptionSection />)
+
+    // The user's in-flight edit must not be clobbered by the stale server value.
+    expect(textarea.value).toBe('hello world')
+  })
+
+  it('initializes from server description when content arrives after first render', () => {
+    mockState.content = null
+    const { rerender } = render(<DescriptionSection />)
+    const textarea = screen.getByPlaceholderText(
+      'Add context...',
+    ) as HTMLTextAreaElement
+    expect(textarea.value).toBe('')
+
+    mockState.content = { ...baseContent, description: 'loaded from server' }
+    rerender(<DescriptionSection />)
+
+    expect(textarea.value).toBe('loaded from server')
+  })
+})

--- a/happyhq/components/features/tasks/card/description-section.tsx
+++ b/happyhq/components/features/tasks/card/description-section.tsx
@@ -18,15 +18,17 @@ function EditableDescription() {
   const refresh = useTaskMutate()
   const [isEditing, setIsEditing] = useState(false)
 
-  // Inline setState pattern — sync with server data when SWR updates
-  // (e.g., SWRConfig fallback arrives after initial render).
-  const serverDesc = content?.description ?? ''
-  const [lastServerDesc, setLastServerDesc] = useState(serverDesc)
-  const [description, setDescription] = useState(serverDesc)
+  // Initialize from server data exactly once. The parent remounts this
+  // component on taskSlug change (key={taskSlug}), so syncing again after
+  // init only ever races user input — a debounced save triggers an SWR
+  // refetch, the older snapshot wins, and the controlled value snaps back
+  // mid-keystroke (cursor jumps, dropped chars).
+  const [description, setDescription] = useState(content?.description ?? '')
+  const [initialized, setInitialized] = useState(content != null)
 
-  if (serverDesc !== lastServerDesc) {
-    setLastServerDesc(serverDesc)
-    setDescription(serverDesc)
+  if (!initialized && content != null) {
+    setDescription(content.description ?? '')
+    setInitialized(true)
   }
 
   const descTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(


### PR DESCRIPTION
Closes #17

## Root cause

`EditableDescription` in `happyhq/components/features/tasks/card/description-section.tsx` used an inline-setState pattern that re-synced the controlled `description` state to `serverDesc` on every render where the two diverged. The component already remounts on `taskSlug` change (parent passes `key={taskSlug}`), so that sync only ever fired *during* an edit session: a debounced save would land, `refresh()` would trigger an SWR refetch, the older snapshot would race the user's continued typing, and `setDescription(serverDesc)` would overwrite the controlled value mid-keystroke — replacing the textarea contents and resetting the caret. (The `.trim()` calls in `card/index.tsx:71,74` named in the issue feed derived booleans, not controlled values, so they weren't the cause.)

The fix initializes from server data exactly once via an `initialized` flag (matching the pattern already in use in `panel/index.tsx`). After the first sync, server refreshes no longer touch the local state — saves still flow back through the existing debounced `writeTaskDescription`.

## Test plan

- Regression test at `happyhq/components/features/tasks/card/description-section.test.tsx:43` (preserves user input when server data refreshes mid-edit) — fails on `main`, passes with the fix.
- Second test at `happyhq/components/features/tasks/card/description-section.test.tsx:62` covers the legitimate case the old sync was trying to handle (server data arriving after first render).
- `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` (1335 tests) all green.

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop (Claude Opus 4.7). Reviewed by maintainer before merge.