### PR TITLE
feat: add Ralphie bug-fix loop (bugs.sh)

### DIFF
--- a/happyhq/.dev/PROMPT_bugs_fix.md
+++ b/happyhq/.dev/PROMPT_bugs_fix.md
@@ -1,0 +1,38 @@
+0a. Read @bugs-rubric.md — this is the spec. Apply it literally.
+0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
+0c. The issue you are working: #${ISSUE_NUMBER}. Read it: `gh issue view ${ISSUE_NUMBER} --comments`.
+
+1. **Reproduce.** Establish the bug locally — write a failing test, or run the steps in the issue and confirm the failure mode. If repro cannot be established from the issue + linked logs + a focused investigation, apply `ralphie:skip-not-reproducible` (rubric rule 7), post the rubric-shaped comment, exit. Use `~/HappyHQ/.logs/$(date +%Y-%m-%d).jsonl` and `npx tsx scripts/read-logs.ts` for runtime logs (see @CLAUDE.md "Debugging Q").
+
+2. **Branch.** From `main`: `git checkout main && git pull && git checkout -b fix/${ISSUE_NUMBER}-<short-slug>`. The slug is 2–4 hyphenated words derived from the issue title.
+
+3. **Fix + regression test.** Implement the smallest change that fixes the bug. Add a regression test that fails before the fix and passes after. Tests verify behavior, not implementation (see @CLAUDE.md). Use Sonnet subagents for parallel reads/searches; use Opus for debugging or architectural calls.
+
+4. **Verify.** From the `happyhq/` directory, run `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test`. If any fail, fix and re-run. If they fail twice, apply `ralphie:skip-verification-failed` (rubric rule 8), post the rubric-shaped comment with the failing output included, exit.
+
+5. **Size gate.** After the fix is in, check the diff: `git diff --stat main...HEAD`. If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` (rubric rule 6/9), post the rubric-shaped comment summarizing what the fix would have entailed, leave the branch in place (do not push), exit.
+
+6. **Commit.** `git add -A && git commit -m "fix: <one-line summary>\n\nCloses #${ISSUE_NUMBER}"`.
+
+7. **Push + PR.** `git push -u origin fix/${ISSUE_NUMBER}-<slug>` then `gh pr create --base main --assignee @me --title "fix: <summary>" --body "..."`. The `--assignee @me` puts the PR in the maintainer's "Assigned to me" queue — that's how Ralphie's PRs get reviewed (CODEOWNERS auto-request is blocked because `gh` is authenticated as the maintainer, so every PR is self-authored). PR body MUST include:
+   - `Closes #${ISSUE_NUMBER}`
+   - One-paragraph root-cause summary (the **why**)
+   - Link to the regression test (`<file>:<line>`)
+   - AI-assistance disclosure per @CONTRIBUTING.md (e.g., "Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.")
+
+8. **Label.** `gh issue edit ${ISSUE_NUMBER} --add-label "ralphie:fixed-in-pr"`. The PR's `Closes #` is the rest of the breadcrumb.
+
+9. **Return to main.** `git checkout main`. Each session leaves the working tree on `main` so the next session (or the maintainer) starts from a clean baseline. Apply this on the skip paths too — if you abort and revert in step 6 of the guardrails, end on `main`.
+
+10. ${DRY_RUN_NOTE}
+
+11. Exit.
+
+**[1]** ONE issue per session. Do not pick up other issues, do not chain. The orchestrator handles the next one.
+**[2]** Hard constraints from @bugs-rubric.md are non-negotiable: never push to `main`, never modify `happyhq/ee/`, `.github/`, CI workflows, lockfiles (beyond what the focused fix demands), or licensing files. If the fix would require any of these, apply `ralphie:skip-out-of-scope` and exit.
+**[3]** A regression test is required. A fix without a test that exercises the bug is incomplete — re-think the fix.
+**[4]** Tests verify behavior — what the system guarantees to the user. Never `toBeTruthy()`, snapshots, or "renders without crashing."
+**[5]** Capture the **why** in the PR body and (if non-obvious) a code comment. Never narrate **what** in comments — well-named code does that.
+**[6]** If you discover the fix requires a schema migration / new env var / new dep / CI change mid-implementation, stop, revert your changes (`git checkout main && git branch -D fix/${ISSUE_NUMBER}-...`), apply `ralphie:skip-out-of-scope`, exit.
+**[7]** AI disclosure in the PR body is required by @CONTRIBUTING.md. Never omit it.
+**[8]** When applying any `ralphie:skip-*` label, the comment uses the rubric's "Comment shape" format. Always.

--- a/happyhq/.dev/PROMPT_bugs_triage.md
+++ b/happyhq/.dev/PROMPT_bugs_triage.md
@@ -1,0 +1,21 @@
+0a. Read @bugs-rubric.md — this is the spec. Apply it literally.
+0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
+
+1. Get the queue: `gh issue list --label bug --state open --limit 100 --json number,title,author,labels,body,createdAt --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)]'`. Empty → exit cleanly.
+
+2. For each issue in the queue (oldest first), in parallel where it makes sense (use Sonnet subagents for reads/searches), evaluate against rubric rules 1–6 (the Phase 1 entries). Read the issue body, ALL comments (`gh issue view <#> --comments`), and any linked logs. For rule 2 (third-party), fetch the author association: `gh api repos/:owner/:repo/issues/<#> --jq '.author_association'` — values OWNER and MEMBER are insiders, anything else (CONTRIBUTOR, FIRST_TIMER, NONE, etc.) is third-party. For rule 6 (size estimate), do a focused code search for the symbols/files the issue mentions before deciding.
+
+3. For each issue, choose ONE outcome:
+   - **Skip** (matches a rubric rule): apply the matching `ralphie:skip-*` label and post the comment in the rubric's "Comment shape" format. Use `gh issue edit <#> --add-label "<label>"` and `gh issue comment <#> --body "..."`.
+   - **Eligible** (passes rules 1–6): leave the issue untouched. Unlabeled = queued for Phase 2.
+
+4. ${DRY_RUN_NOTE}
+
+5. When the queue is exhausted, print a one-line summary: `Triaged N issues: X skipped, Y eligible.` Exit.
+
+**[1]** Apply the rubric in order. Bail at the earliest stop — don't evaluate rule 6 if rule 1 already trips.
+**[2]** Never write code in this phase. Never branch, commit, push, or open a PR. Triage is read-only on the repo and write-only on GitHub metadata (labels + comments).
+**[3]** A skip comment is for the human, the label is for the next Ralphie. Both are required for a skip.
+**[4]** If the rubric is ambiguous about an issue, lean toward eligible — Phase 2 has its own gates (rules 7–9). False eligibility is cheaper than false skip.
+**[5]** Never apply two `ralphie:*` labels to the same issue. First match wins.
+**[6]** If `gh` returns an empty queue, exit 0 silently. No error, no comment.

--- a/happyhq/.dev/WOW.md
+++ b/happyhq/.dev/WOW.md
@@ -60,6 +60,26 @@ git checkout -b ralph/next-thing
 
 Each new branch starts from a richer main. Ralph reads the merged code and builds on top of it.
 
+## Ralphie does bugs
+
+Different shape from the build loop. Reads GitHub issues, opens PRs.
+
+```bash
+./bugs.sh                  # triage everything, then fix up to 3 eligible bugs
+./bugs.sh --triage-only    # just label/comment, don't touch code
+./bugs.sh --issue 42       # skip triage, attempt one fix on #42
+./bugs.sh --dry-run        # Phase 1 preview only (no writes); add --issue <#> to preview a fix
+```
+
+Two phases, one command:
+
+- **Phase 1 — Triage.** One session reads every open `bug` issue with no `ralphie:*` label and applies `bugs-rubric.md`. For each rule trip, it writes a `ralphie:skip-*` label + a comment explaining what it saw and what would unblock it. Eligible issues stay unlabeled.
+- **Phase 2 — Fix.** Loops one fix-session per bug: pick the oldest unlabeled `bug`, reproduce, branch `fix/<#>-...`, fix, regression test, verify, PR. Late-stage rubric checks (not-reproducible, verification-failed, too-big) can still skip a bug here. Stops when the queue is empty or `--max-bugs` is hit.
+
+The breadcrumbs (labels + comments) are how Ralphie talks to itself across runs and how you manage the loop. A `ralphie:*` label is terminal — Ralphie never re-evaluates a labeled issue. **You unblock by removing the label.**
+
+Edit `bugs-rubric.md` when Ralphie misjudges. Same model as `specs/` for the build loop: the spec is the source of truth, the prompts stay thin.
+
 ## Quick Reference
 
 | Command                             | What it does                              |
@@ -68,6 +88,10 @@ Each new branch starts from a richer main. Ralph reads the merged code and build
 | `./loop.sh plan-work "description"` | Scoped plan for a branch                  |
 | `./loop.sh`                         | Build mode, unlimited iterations          |
 | `./loop.sh 20`                      | Build mode, max 20 iterations             |
+| `./bugs.sh`                         | Triage + fix up to 3 bugs                 |
+| `./bugs.sh --triage-only`           | Just triage, no code                      |
+| `./bugs.sh --issue <#>`             | Fix one specific issue                    |
+| `./bugs.sh --dry-run`               | Phase 1 preview only, no writes           |
 
 ## When Things Go Wrong
 
@@ -85,4 +109,7 @@ Each new branch starts from a richer main. Ralph reads the merged code and build
 - `PROMPT_plan.md` — Planning prompt. Includes ULTIMATE GOAL.
 - `PROMPT_build.md` — Build prompt. One task per iteration.
 - `PROMPT_plan_work.md` — Scoped planning prompt. Uses `${WORK_SCOPE}`.
+- `bugs-rubric.md` — Source of truth for bug triage/fix judgment. Loaded by both bug prompts.
+- `PROMPT_bugs_triage.md` — Phase 1 prompt. Reads `bugs-rubric.md`, walks the queue, labels.
+- `PROMPT_bugs_fix.md` — Phase 2 prompt. One bug per session. Uses `${ISSUE_NUMBER}`.
 - `lib/` — Standard library. Steer Ralph through code, not just prompts.

--- a/happyhq/.dev/bugs-rubric.md
+++ b/happyhq/.dev/bugs-rubric.md
@@ -1,0 +1,50 @@
+# Bug Rubric
+
+Source of truth for how Ralphie judges open `bug`-labeled issues. Both `PROMPT_bugs_triage.md` and `PROMPT_bugs_fix.md` load this file. Edit here, not in the prompts.
+
+## Queue contract
+
+- The queue is: GitHub issues that are `state:open`, labeled `bug`, and have no label starting with `ralphie:`.
+- A `ralphie:*` label is terminal — Ralphie never re-evaluates a labeled issue. The human removes the label to re-queue.
+- One outcome per session (a label, a comment, or a PR). No chaining.
+
+## Rubric
+
+Apply in order — bail at the earliest stop. The first six are evaluable from the issue text alone (Phase 1 — triage). The last three only show up after attempting a fix (Phase 2).
+
+| #   | Condition                                                                                              | Label applied                      | What unblocks it                                                      |
+| --- | ------------------------------------------------------------------------------------------------------ | ---------------------------------- | --------------------------------------------------------------------- |
+| 1   | Fix would touch `happyhq/ee/`                                                                          | `ralphie:skip-ee`                  | Maintainer decides whether to take it on; remove label after deciding |
+| 2   | Author is not OWNER/MEMBER and the report lacks repro details a third party would need to provide      | `ralphie:skip-third-party-unclear` | Add repro details or escalate; remove label                           |
+| 3   | Issue body or comments contain unresolved questions for the maintainer                                 | `ralphie:skip-needs-decision`      | Answer the question in a comment, remove label                        |
+| 4   | Requires a schema migration, new env var, new dependency, or `.github/`/CI/workflow change             | `ralphie:skip-out-of-scope`        | Maintainer scopes and does it; remove label if the work was decoupled |
+| 5   | No reasonable repro can be inferred from issue + linked logs                                           | `ralphie:skip-not-reproducible`    | Reporter or maintainer adds repro/logs, remove label                  |
+| 6   | Estimated >10 files or >300 LoC after a quick code search                                              | `ralphie:skip-too-big`             | Scope it down (split issue) or do it manually                         |
+| 7   | (Phase 2) Repro could not be established locally                                                       | `ralphie:skip-not-reproducible`    | Same as #5                                                            |
+| 8   | (Phase 2) `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` failed twice | `ralphie:skip-verification-failed` | Read the comment Ralphie left; fix locally                            |
+| 9   | (Phase 2) Fix shipped                                                                                  | `ralphie:fixed-in-pr`              | Terminal — the linked PR closes the loop                              |
+
+## Comment shape (for skips)
+
+Every skip writes one comment, in this shape:
+
+```
+Ralphie skipped this for: <rubric reason name>
+
+What I saw: <1–3 sentences — the specific evidence in the issue/code that triggered the rule>
+
+What would unblock it: <1 sentence — the concrete action that lets the next Ralphie run pick this up>
+```
+
+Comments are for the human reading the queue. The label is for the next Ralphie.
+
+## Hard constraints (never violate, regardless of rubric)
+
+- Never push to `main`. Never force-push. Never `--no-verify`.
+- Never modify files under `happyhq/ee/`, `.github/`, CI workflows, lockfiles (beyond what a focused fix demands), or licensing files.
+- PRs always target `main`, branch from `main`, use the `fix/` prefix, and include `Closes #<issue>` plus an AI-assistance disclosure (per `CONTRIBUTING.md`).
+- One outcome per session. After labeling or opening a PR, exit.
+
+## Tuning signal
+
+When Ralphie gets it wrong — labels something `skip-too-big` that wasn't, opens a PR that shouldn't have been opened, misses an `ee/` touch — that's a rubric-tuning signal, not a one-off correction. Edit this file. The next run will pick up the change.

--- a/happyhq/.dev/bugs.sh
+++ b/happyhq/.dev/bugs.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+set -o pipefail
+# Usage: ./bugs.sh [options]
+#   ./bugs.sh                          # triage + fix loop, default --max-bugs 3
+#   ./bugs.sh --max-bugs 5             # cap Phase 2 attempts at 5
+#   ./bugs.sh --triage-only            # Phase 1 only
+#   ./bugs.sh --issue 42               # skip triage; one fix session against #42
+#   ./bugs.sh --dry-run                # Phase 1 preview only, no writes
+#   ./bugs.sh --issue 42 --dry-run     # preview a single fix session, no writes
+
+DIM='\033[2m'
+BOLD='\033[1m'
+GREEN='\033[32m'
+CYAN='\033[36m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+MAX_BUGS=3
+TRIAGE_ONLY=0
+SINGLE_ISSUE=""
+DRY_RUN=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --max-bugs)
+            MAX_BUGS="$2"
+            shift 2
+            ;;
+        --triage-only)
+            TRIAGE_ONLY=1
+            shift
+            ;;
+        --issue)
+            SINGLE_ISSUE="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            sed -n '3,9p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+cleanup() {
+    echo -e "\n${DIM}Cleaning up child processes...${RESET}"
+    pkill -P $$ 2>/dev/null
+    exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+if [ -n "$DRY_RUN" ]; then
+    export DRY_RUN_NOTE="**DRY RUN MODE**: For every action that would write to GitHub or the repo (labels, comments, branches, commits, pushes, PRs), print one line prefixed with 'DRY-RUN:' describing what you WOULD do, then SKIP the actual call. Do not invoke any 'gh issue edit', 'gh issue comment', 'gh pr create', 'git commit', 'git push', or filesystem write. Reads (gh issue view/list, code search, file reads) are fine."
+else
+    export DRY_RUN_NOTE=""
+fi
+
+run_session() {
+    local prompt_file="$1"
+    local label="$2"
+
+    echo -e "\n  ${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "  ${BOLD}${label}${RESET}"
+    echo -e "  ${DIM}Prompt:${RESET}  $prompt_file"
+    [ -n "$DRY_RUN" ] && echo -e "  ${YELLOW}DRY RUN${RESET}"
+    echo -e "  ${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+
+    if [ ! -f "$prompt_file" ]; then
+        echo -e "  ${RED}Error: $prompt_file not found${RESET}"
+        return 1
+    fi
+
+    envsubst < "$prompt_file" | claude -p \
+        --dangerously-skip-permissions \
+        --output-format=stream-json \
+        --model opus \
+        --verbose 2>&1 | node "$SCRIPT_DIR/format-stream.mjs"
+
+    return ${PIPESTATUS[1]}
+}
+
+# ── Single-issue mode: skip triage, run one fix session ──
+if [ -n "$SINGLE_ISSUE" ]; then
+    export ISSUE_NUMBER="$SINGLE_ISSUE"
+    run_session "PROMPT_bugs_fix.md" "Fix #$SINGLE_ISSUE"
+    exit $?
+fi
+
+# ── Phase 1: Triage (one session, walks the whole queue) ──
+run_session "PROMPT_bugs_triage.md" "Phase 1 · Triage"
+TRIAGE_EXIT=$?
+if [ $TRIAGE_EXIT -ne 0 ]; then
+    echo -e "  ${RED}Triage exited with status $TRIAGE_EXIT — stopping${RESET}"
+    exit $TRIAGE_EXIT
+fi
+
+if [ $TRIAGE_ONLY -eq 1 ]; then
+    echo -e "\n  ${GREEN}✓${RESET} Triage complete (--triage-only). Exiting."
+    exit 0
+fi
+
+if [ -n "$DRY_RUN" ]; then
+    echo -e "\n  ${GREEN}✓${RESET} Phase 1 preview complete. Skipping Phase 2 in --dry-run (labels weren't applied, so the fix queue would re-pick the same bugs). Use --issue <#> --dry-run to preview a fix session."
+    exit 0
+fi
+
+# ── Phase 2: Fix loop (one session per bug) ──
+BUGS_DONE=0
+while [ $BUGS_DONE -lt $MAX_BUGS ]; do
+    NEXT=$(gh issue list \
+        --label bug \
+        --state open \
+        --limit 100 \
+        --json number,labels,createdAt \
+        --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)] | sort_by(.createdAt) | .[0].number // empty' 2>/dev/null)
+
+    if [ -z "$NEXT" ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Queue empty. $BUGS_DONE bug(s) attempted. Exiting."
+        exit 0
+    fi
+
+    BUGS_DONE=$((BUGS_DONE + 1))
+    export ISSUE_NUMBER="$NEXT"
+    run_session "PROMPT_bugs_fix.md" "Phase 2 · Bug $BUGS_DONE of max $MAX_BUGS · #$NEXT"
+    SESSION_EXIT=$?
+    if [ $SESSION_EXIT -ne 0 ]; then
+        echo -e "  ${RED}Fix session exited with status $SESSION_EXIT — stopping loop${RESET}"
+        exit $SESSION_EXIT
+    fi
+
+    LABELED=$(gh issue view "$NEXT" --json labels --jq '.labels | map(.name) | any(startswith("ralphie:"))' 2>/dev/null)
+    if [ "$LABELED" != "true" ]; then
+        echo -e "  ${RED}Issue #$NEXT has no ralphie:* label after the session — aborting loop to avoid re-picking it.${RESET}"
+        exit 1
+    fi
+done
+
+echo -e "\n  ${YELLOW}Reached --max-bugs=$MAX_BUGS. Stopping.${RESET}"


### PR DESCRIPTION
## Summary

- Adds `happyhq/.dev/bugs.sh` — a sibling of `loop.sh` pointed at the GitHub bug queue.
- Two phases, one command: Phase 1 triage (label + comment via rubric), Phase 2 fix loop (one PR per eligible bug).
- `bugs-rubric.md` is the spec; both prompts (`PROMPT_bugs_triage.md`, `PROMPT_bugs_fix.md`) stay thin and load it. Edit the rubric, not the prompts.
- A `ralphie:*` label is terminal — Ralphie never re-evaluates a labeled issue; remove the label to re-queue.
- PRs use `--assignee @me` so they show up in the maintainer's "Assigned to me" filter (CODEOWNERS auto-request can't fire when `gh` is authenticated as the same user authoring the PR).

## Test plan

- [x] `./bugs.sh --help` prints all six usage lines
- [x] `./bugs.sh --dry-run` walked the live queue and produced sensible verdicts (4 skipped, 8 eligible on first pass)
- [x] `gh issue list ... | jq` returns the eligible-bug queue cleanly
- [x] `envsubst` expands `${ISSUE_NUMBER}` and `${DRY_RUN_NOTE}` without touching `$(date ...)` or other shell forms
- [x] `./bugs.sh --triage-only` on the live queue (writes labels + comments for real)
- [x] `./bugs.sh --issue <#>` end-to-end: real PR opens with `Closes #`, AI disclosure, `--assignee @me`, regression test linked
- [x] After a real run, working tree is back on `main`
- [x] Idempotency — running `./bugs.sh` twice picks the next unlabeled bug, never re-evaluates a labeled one

🤖 Generated with [Claude Code](https://claude.com/claude-code)