### PR TITLE
fix: surface subagent activity in desktop run activity panel

### DIFF
--- a/happyhq/components/features/desktop/hooks/use-run-activity.test.ts
+++ b/happyhq/components/features/desktop/hooks/use-run-activity.test.ts
@@ -1,0 +1,144 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useRunActivity } from './use-run-activity'
+
+type WireEvent = Record<string, unknown>
+
+function ndjsonResponse(events: WireEvent[]): Response {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const e of events) {
+        controller.enqueue(encoder.encode(JSON.stringify(e) + '\n'))
+      }
+      controller.close()
+    },
+  })
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'application/x-ndjson' },
+  })
+}
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch)
+  mockFetch.mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useRunActivity subagent events', () => {
+  it('renders a step from subagent_event:started so subagent activity is visible', async () => {
+    mockFetch.mockResolvedValueOnce(
+      ndjsonResponse([
+        {
+          type: 'subagent_event',
+          subtype: 'started',
+          taskId: 'sa-1',
+          description: 'Drafting',
+        },
+      ]),
+    )
+
+    const { result } = renderHook(() => useRunActivity(true))
+
+    await waitFor(() => {
+      expect(result.current.activitySteps.length).toBe(1)
+    })
+
+    const step = result.current.activitySteps[0]
+    expect(step.label).toBe('Drafting')
+    expect(step.isActive).toBe(true)
+  })
+
+  it('updates the step detail on subagent_event:progress', async () => {
+    mockFetch.mockResolvedValueOnce(
+      ndjsonResponse([
+        {
+          type: 'subagent_event',
+          subtype: 'started',
+          taskId: 'sa-2',
+          description: 'Explore',
+        },
+        {
+          type: 'subagent_event',
+          subtype: 'progress',
+          taskId: 'sa-2',
+          lastToolName: 'Read',
+        },
+      ]),
+    )
+
+    const { result } = renderHook(() => useRunActivity(true))
+
+    await waitFor(() => {
+      const step = result.current.activitySteps.find(
+        (s) => s.label === 'Explore',
+      )
+      expect(step?.detail).toBe('Read')
+      expect(step?.isActive).toBe(true)
+    })
+  })
+
+  it('marks the step inactive and surfaces the summary on subagent_event:completed', async () => {
+    mockFetch.mockResolvedValueOnce(
+      ndjsonResponse([
+        {
+          type: 'subagent_event',
+          subtype: 'started',
+          taskId: 'sa-3',
+          description: 'Drafting',
+        },
+        {
+          type: 'subagent_event',
+          subtype: 'completed',
+          taskId: 'sa-3',
+          status: 'completed',
+          summary: 'Wrote 2 files',
+          toolUses: 4,
+          durationMs: 1500,
+        },
+      ]),
+    )
+
+    const { result } = renderHook(() => useRunActivity(true))
+
+    await waitFor(() => {
+      const step = result.current.activitySteps.find(
+        (s) => s.label === 'Drafting',
+      )
+      expect(step?.isActive).toBe(false)
+      expect(step?.detail).toBe('Wrote 2 files')
+    })
+  })
+
+  it('clears subagent steps on result (iteration boundary)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      ndjsonResponse([
+        {
+          type: 'subagent_event',
+          subtype: 'started',
+          taskId: 'sa-4',
+          description: 'Drafting',
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          result: 'ok',
+          costUsd: 0,
+        },
+      ]),
+    )
+
+    const { result } = renderHook(() => useRunActivity(true))
+
+    await waitFor(() => {
+      expect(result.current.activitySteps).toEqual([])
+    })
+  })
+})

--- a/happyhq/components/features/desktop/hooks/use-run-activity.test.ts
+++ b/happyhq/components/features/desktop/hooks/use-run-activity.test.ts
@@ -52,7 +52,7 @@ describe('useRunActivity subagent events', () => {
     })
 
     const step = result.current.activitySteps[0]
-    expect(step.label).toBe('Drafting')
+    expect(step.label).toBe('Delegating: Drafting')
     expect(step.isActive).toBe(true)
   })
 
@@ -78,7 +78,7 @@ describe('useRunActivity subagent events', () => {
 
     await waitFor(() => {
       const step = result.current.activitySteps.find(
-        (s) => s.label === 'Explore',
+        (s) => s.label === 'Delegating: Explore',
       )
       expect(step?.detail).toBe('Read')
       expect(step?.isActive).toBe(true)
@@ -110,7 +110,7 @@ describe('useRunActivity subagent events', () => {
 
     await waitFor(() => {
       const step = result.current.activitySteps.find(
-        (s) => s.label === 'Drafting',
+        (s) => s.label === 'Delegating: Drafting',
       )
       expect(step?.isActive).toBe(false)
       expect(step?.detail).toBe('Wrote 2 files')

--- a/happyhq/components/features/desktop/hooks/use-run-activity.ts
+++ b/happyhq/components/features/desktop/hooks/use-run-activity.ts
@@ -451,7 +451,9 @@ export function useRunActivity(isActive: boolean): RunActivityState {
                   {
                     toolUseId: subagentStepId,
                     toolName: '__subagent__',
-                    label: event.description ?? 'Subagent',
+                    label: event.description
+                      ? `Delegating: ${event.description}`
+                      : 'Delegating',
                     detail: null,
                     linesAdded: null,
                     elapsedSeconds: 0,

--- a/happyhq/components/features/desktop/hooks/use-run-activity.ts
+++ b/happyhq/components/features/desktop/hooks/use-run-activity.ts
@@ -123,6 +123,9 @@ export function useRunActivity(isActive: boolean): RunActivityState {
     toolName: string
     toolUseId: string
   } | null>(null)
+  // Per-subagent start timestamps — used to compute elapsedSeconds on progress
+  // events, since subagent_event payloads don't carry elapsed time.
+  const subagentStartedAtRef = useRef<Map<string, number>>(new Map())
 
   useEffect(() => {
     if (!isActive) {
@@ -139,6 +142,7 @@ export function useRunActivity(isActive: boolean): RunActivityState {
       confirmedRunningRef.current.clear()
       blockLineCountRef.current.clear()
       lastToolStepRef.current = null
+      subagentStartedAtRef.current.clear()
       return
     }
 
@@ -428,6 +432,73 @@ export function useRunActivity(isActive: boolean): RunActivityState {
                 return next
               })
             }
+          } else if (event.type === 'subagent_event') {
+            // Subagents (Task tool) emit lifecycle events while running.
+            // Without surfacing them here the activity panel goes silent
+            // for the duration of each subagent's work — see issue #26.
+            const subagentStepId = `subagent:${event.taskId}`
+
+            if (event.subtype === 'started') {
+              subagentStartedAtRef.current.set(event.taskId, Date.now())
+              setActivitySteps((prev) => {
+                if (prev.some((s) => s.toolUseId === subagentStepId)) {
+                  return prev
+                }
+                return [
+                  ...prev.map((s) =>
+                    s.toolUseId === THINKING_ID ? { ...s, isActive: false } : s,
+                  ),
+                  {
+                    toolUseId: subagentStepId,
+                    toolName: '__subagent__',
+                    label: event.description ?? 'Subagent',
+                    detail: null,
+                    linesAdded: null,
+                    elapsedSeconds: 0,
+                    isActive: true,
+                  },
+                ]
+              })
+            } else if (event.subtype === 'progress') {
+              const startedAt = subagentStartedAtRef.current.get(event.taskId)
+              const elapsed = startedAt
+                ? Math.floor((Date.now() - startedAt) / 1000)
+                : 0
+              const detail = event.description ?? event.lastToolName ?? null
+              setStatusLine(
+                `${event.description ?? event.lastToolName ?? 'Subagent'}... (${elapsed}s)`,
+              )
+              setActivitySteps((prev) =>
+                prev.map((s) =>
+                  s.toolUseId === subagentStepId
+                    ? {
+                        ...s,
+                        detail: detail ?? s.detail,
+                        elapsedSeconds: Math.max(s.elapsedSeconds, elapsed),
+                        isActive: true,
+                      }
+                    : s,
+                ),
+              )
+            } else if (event.subtype === 'completed') {
+              const startedAt = subagentStartedAtRef.current.get(event.taskId)
+              const elapsed = startedAt
+                ? Math.floor((Date.now() - startedAt) / 1000)
+                : 0
+              subagentStartedAtRef.current.delete(event.taskId)
+              setActivitySteps((prev) =>
+                prev.map((s) =>
+                  s.toolUseId === subagentStepId
+                    ? {
+                        ...s,
+                        detail: event.summary ?? s.detail,
+                        elapsedSeconds: Math.max(s.elapsedSeconds, elapsed),
+                        isActive: false,
+                      }
+                    : s,
+                ),
+              )
+            }
           } else if (event.type === 'task_content_changed') {
             setLastContentChangeAt(Date.now())
           } else if (event.type === 'result') {
@@ -439,6 +510,7 @@ export function useRunActivity(isActive: boolean): RunActivityState {
             confirmedRunningRef.current.clear()
             blockLineCountRef.current.clear()
             lastToolStepRef.current = null
+            subagentStartedAtRef.current.clear()
           }
         }
       } catch (err) {


### PR DESCRIPTION
Closes #26

## Why

The server-side filter has been forwarding subagent lifecycle events (`task_started`, `task_progress`, `task_notification`) as `subagent_event` SSE messages for a while (`happyhq/lib/run/filter.server.ts:81-115`), but `useRunActivity` never grew a branch for them — only `partial`, `tool_progress`, `assistant`, `task_content_changed`, and `result` were handled. So whenever the agent invoked a subagent (the `Task` tool), the desktop run activity panel went silent for the entire subagent run, making each multi-step research task feel hung.

The fix adds a `subagent_event` branch that mirrors the chat-side handler (`happyhq/stores/chatStore.ts:786`): on `started` we push a step keyed by `subagent:<taskId>`, on `progress` we update its detail / elapsed time / status line, and on `completed` we mark it inactive while keeping the summary visible. We track `startedAt` per `taskId` client-side so we can compute `elapsedSeconds` (the wire payload doesn't include it) and clear that ref on the same boundaries as the existing tracking refs (run end, iteration `result`, hook teardown).

Scope is intentionally narrow: this surfaces top-level subagent steps. The secondary concern in the issue — whether nested `tool_use` blocks (with `parentToolUseId` set) should render as children of the Task step, in a separate lane, or folded into the parent's detail — is left as a follow-up since it's a UX decision rather than a correctness gap.

## Regression test

`happyhq/components/features/desktop/hooks/use-run-activity.test.ts:38` covers four cases against a mocked NDJSON stream:

- `started` produces an active step labelled with the subagent description
- `progress` updates the step's detail
- `completed` marks the step inactive and surfaces the summary
- `result` clears subagent steps at the iteration boundary

All four fail before the fix and pass after.

## Verification

From `happyhq/`:

- `pnpm format` — clean
- `pnpm lint` — no warnings
- `pnpm check-types` — clean
- `pnpm --filter=happyhq test` — 1337 / 1337 pass

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. The maintainer reviews every Ralphie PR before merge.