### PR TITLE
fix: clamp tool detail strings + stop chat row from overflowing (#32)

### DIFF
--- a/happyhq/components/features/chat/messages/tool-progress-indicator.test.tsx
+++ b/happyhq/components/features/chat/messages/tool-progress-indicator.test.tsx
@@ -120,4 +120,103 @@ describe('ToolProgressIndicator', () => {
       expect(screen.queryByRole('button')).toBeNull()
     })
   })
+
+  // Regression for #32: long tool details overflowed the chat container,
+  // pushing the whole conversation sideways. The header row must opt into
+  // shrinking (min-w-0) and the detail itself must truncate, not expand.
+  describe('long detail overflow (issue #32)', () => {
+    it('applies min-w-0 + truncate to a long Grep pattern so the row can shrink', () => {
+      const longPattern = 'needle'.repeat(40) // ~240 chars before any cap
+      const steps = [makeStep('Grep')]
+      const toolCalls = [makeToolCall('Grep', { pattern: longPattern })]
+
+      const { container } = render(
+        <ToolProgressIndicator
+          steps={steps}
+          toolCalls={toolCalls}
+          isStreaming={true}
+        />,
+      )
+
+      const headerRow = container.querySelector('div.flex.items-baseline')
+      expect(headerRow).not.toBeNull()
+      expect(headerRow!.className).toMatch(/\bmin-w-0\b/)
+
+      // The detail text the user sees is capped, not raw — but whatever made
+      // it through must still be in a truncating element.
+      const detail = headerRow!.querySelector(
+        '.font-mono.text-xs',
+      ) as HTMLElement | null
+      expect(detail).not.toBeNull()
+      expect(detail!.className).toMatch(/\btruncate\b/)
+      expect(detail!.className).toMatch(/\bmin-w-0\b/)
+    })
+
+    it('applies truncate to a long file-link button for Read', () => {
+      const longName = 'a'.repeat(120) + '.ts'
+      const steps = [makeStep('Read')]
+      const toolCalls = [
+        makeToolCall('Read', { file_path: `/deep/${longName}` }),
+      ]
+
+      const { container } = render(
+        <ToolProgressIndicator
+          steps={steps}
+          toolCalls={toolCalls}
+          isStreaming={true}
+        />,
+      )
+
+      const linkButton = container.querySelector(
+        'button.font-mono',
+      ) as HTMLElement | null
+      expect(linkButton).not.toBeNull()
+      expect(linkButton!.className).toMatch(/\btruncate\b/)
+      expect(linkButton!.className).toMatch(/\bmin-w-0\b/)
+    })
+
+    it('keeps the elapsed timer chip from being squeezed by truncation', () => {
+      const longCmd = 'echo ' + 'x'.repeat(200)
+      const steps = [makeStep('Bash(echo:*)', 'step-1', 7)]
+      const toolCalls = [makeToolCall('Bash(echo:*)', { command: longCmd })]
+
+      const { container } = render(
+        <ToolProgressIndicator
+          steps={steps}
+          toolCalls={toolCalls}
+          isStreaming={true}
+        />,
+      )
+
+      const elapsed = screen.queryByText(/^\d+s$/)
+      expect(elapsed).not.toBeNull()
+      expect((elapsed as HTMLElement).className).toMatch(/\bshrink-0\b/)
+
+      const headerRow = container.querySelector('div.flex.items-baseline')
+      expect(headerRow!.className).toMatch(/\bmin-w-0\b/)
+    })
+
+    // The detail string itself must reach the DOM in a bounded form — CSS
+    // truncate handles visual overflow, but the cap protects screen readers,
+    // tooltips, and any consumer reading textContent.
+    it('caps the rendered detail length even for huge inputs', () => {
+      const huge = 'q'.repeat(500)
+      const steps = [makeStep('WebSearch')]
+      const toolCalls = [makeToolCall('WebSearch', { query: huge })]
+
+      render(
+        <ToolProgressIndicator
+          steps={steps}
+          toolCalls={toolCalls}
+          isStreaming={true}
+        />,
+      )
+
+      const detail = screen
+        .getAllByText(/q+/)
+        .find((el) => el.classList.contains('font-mono')) as HTMLElement
+      expect(detail.textContent!.length).toBeLessThan(huge.length)
+      expect(detail.textContent!.endsWith('...')).toBe(true)
+    })
+  })
 })

--- a/happyhq/components/features/chat/messages/tool-progress-indicator.tsx
+++ b/happyhq/components/features/chat/messages/tool-progress-indicator.tsx
@@ -74,28 +74,36 @@ function ToolStep({
   return (
     <div className={isActive ? 'animate-fade-in' : ''}>
       {/* Header row — same for all tools */}
-      <div className="flex items-baseline gap-2">
+      {/* min-w-0 stops a long detail child from forcing the row past the chat width;
+          the detail itself truncates inside the remaining space. */}
+      <div className="flex min-w-0 items-baseline gap-2">
         {isActive ? (
           <Loader2 className="text-muted-foreground h-4 w-4 shrink-0 translate-y-[2px] animate-spin" />
         ) : (
           <Check className="text-muted-foreground h-4 w-4 shrink-0 translate-y-[2px]" />
         )}
-        <span className="text-foreground text-sm font-medium">{label}</span>
+        <span className="text-foreground shrink-0 text-sm font-medium">
+          {label}
+        </span>
         {detail && filePath ? (
           <button
             type="button"
             onClick={() => openFileWindow({ name: detail, path: filePath })}
-            className="text-muted-foreground hover:text-foreground cursor-pointer font-mono text-xs underline decoration-transparent transition-colors hover:decoration-current"
+            title={detail}
+            className="text-muted-foreground hover:text-foreground min-w-0 cursor-pointer truncate text-left font-mono text-xs underline decoration-transparent transition-colors hover:decoration-current"
           >
             {detail}
           </button>
         ) : detail ? (
-          <span className="text-muted-foreground font-mono text-xs">
+          <span
+            title={detail}
+            className="text-muted-foreground min-w-0 truncate font-mono text-xs"
+          >
             {detail}
           </span>
         ) : null}
         {isActive && elapsed > 0 && (
-          <span className="text-muted-foreground text-xs tabular-nums">
+          <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
             {elapsed}s
           </span>
         )}
@@ -104,7 +112,7 @@ function ToolStep({
           <button
             type="button"
             onClick={() => setShowDetail((prev) => !prev)}
-            className="text-muted-foreground/40 hover:text-muted-foreground ml-auto cursor-pointer transition-colors"
+            className="text-muted-foreground/40 hover:text-muted-foreground ml-auto shrink-0 cursor-pointer transition-colors"
           >
             <Info className="h-3.5 w-3.5" />
           </button>

--- a/happyhq/lib/chat/tool-labels.test.ts
+++ b/happyhq/lib/chat/tool-labels.test.ts
@@ -203,14 +203,6 @@ describe('getToolDetail', () => {
       )
     })
 
-    it('truncates long commands at 50 characters', () => {
-      const longCmd = 'a'.repeat(60)
-      const result = getToolDetail(
-        toolCall('Bash(cmd:*)', { command: longCmd }),
-      )
-      expect(result).toBe('a'.repeat(50) + '...')
-    })
-
     it('returns null when neither description nor command is present', () => {
       expect(getToolDetail(toolCall('Bash(cmd:*)', {}))).toBeNull()
     })
@@ -218,5 +210,63 @@ describe('getToolDetail', () => {
 
   it('returns null for unknown tools', () => {
     expect(getToolDetail(toolCall('UnknownTool', { foo: 'bar' }))).toBeNull()
+  })
+
+  // Regression for #32: long detail strings forced the chat layout wider than
+  // its container. Detail strings must be capped on the way out so neither the
+  // DOM nor accessibility tree carries unbounded values.
+  describe('detail length cap (issue #32)', () => {
+    const cap = 60
+    const longValue = 'x'.repeat(cap + 50)
+
+    it('caps Bash command details', () => {
+      const result = getToolDetail(
+        toolCall('Bash(cmd:*)', { command: longValue }),
+      )
+      expect(result).not.toBeNull()
+      expect(result!.length).toBeLessThanOrEqual(cap + 3)
+      expect(result!.endsWith('...')).toBe(true)
+    })
+
+    it('caps Bash description details', () => {
+      const result = getToolDetail(
+        toolCall('Bash(cmd:*)', { description: longValue }),
+      )
+      expect(result!.length).toBeLessThanOrEqual(cap + 3)
+      expect(result!.endsWith('...')).toBe(true)
+    })
+
+    it('caps Glob patterns', () => {
+      const result = getToolDetail(toolCall('Glob', { pattern: longValue }))
+      expect(result!.length).toBeLessThanOrEqual(cap + 3)
+    })
+
+    it('caps Grep patterns (including the surrounding quotes)', () => {
+      const result = getToolDetail(toolCall('Grep', { pattern: longValue }))
+      expect(result!.length).toBeLessThanOrEqual(cap + 3)
+    })
+
+    it('caps WebSearch queries', () => {
+      const result = getToolDetail(toolCall('WebSearch', { query: longValue }))
+      expect(result!.length).toBeLessThanOrEqual(cap + 3)
+    })
+
+    it('caps Task descriptions', () => {
+      const result = getToolDetail(toolCall('Task', { description: longValue }))
+      expect(result!.length).toBeLessThanOrEqual(cap + 3)
+    })
+
+    it('caps ProcessSample slugs', () => {
+      const result = getToolDetail(
+        toolCall('ProcessSample', { slug: longValue }),
+      )
+      expect(result!.length).toBeLessThanOrEqual(cap + 3)
+    })
+
+    it('leaves short values untouched', () => {
+      expect(getToolDetail(toolCall('Glob', { pattern: '**/*.tsx' }))).toBe(
+        '**/*.tsx',
+      )
+    })
   })
 })

--- a/happyhq/lib/chat/tool-labels.ts
+++ b/happyhq/lib/chat/tool-labels.ts
@@ -55,6 +55,17 @@ function fileName(filePath: string): string {
   return parts[parts.length - 1] || filePath
 }
 
+// Hard cap on the user-visible detail string. CSS truncate is the primary
+// guard against overflow; this cap keeps tooltips/screen readers sane and
+// prevents truly absurd values (multi-KB Grep patterns, paste-bombed URLs)
+// from ever reaching the DOM.
+const MAX_DETAIL_LENGTH = 60
+
+function clamp(value: string): string {
+  if (value.length <= MAX_DETAIL_LENGTH) return value
+  return value.slice(0, MAX_DETAIL_LENGTH) + '...'
+}
+
 /**
  * Extract a short detail string from a tool call's input.
  * Returns null if no meaningful detail can be derived.
@@ -65,6 +76,11 @@ function fileName(filePath: string): string {
  *   Grep { pattern: "useState" } → "useState"
  */
 export function getToolDetail(toolCall: ToolCall): string | null {
+  const raw = getRawDetail(toolCall)
+  return raw === null ? null : clamp(raw)
+}
+
+function getRawDetail(toolCall: ToolCall): string | null {
   const { name, input } = toolCall
   if (!input) return null
 
@@ -123,9 +139,7 @@ export function getToolDetail(toolCall: ToolCall): string | null {
         const desc = input.description as string | undefined
         if (desc) return desc
         const command = input.command as string | undefined
-        if (command) {
-          return command.length > 50 ? command.slice(0, 50) + '...' : command
-        }
+        if (command) return command
       }
       return null
     }


### PR DESCRIPTION
Closes #32

## Root cause

The tool progress row in `tool-progress-indicator.tsx` is a flex container (`flex items-baseline gap-2`). Without `min-w-0` it could not shrink below the intrinsic width of its children, so any long detail — a Grep pattern, a Bash `description`, a WebFetch URL path, a Task description — forced the row past the chat container's right edge. The whole conversation slid sideways and a horizontal scrollbar appeared.

A second, smaller cause: only the Bash `command` branch in `getToolDetail` capped its length (at 50 chars). Every other tool path returned the raw input, so even with CSS truncation in place the DOM and accessibility tree were carrying multi-KB strings.

## Fix

Two coordinated changes:

1. **`tool-progress-indicator.tsx`** — `min-w-0` on the flex row; `truncate min-w-0` on the detail span/button (with a `title` for the full value); `shrink-0` on the icon, label, elapsed chip, and info button so only the detail gives ground.
2. **`tool-labels.ts`** — single `clamp()` helper applies a 60-char cap to every tool's detail (Glob, Grep, ProcessSample, Task, WebSearch, Bash command **and** description). The previous 50-char Bash-only branch is gone.

CSS truncate handles visual overflow; the cap protects everything else (tooltips, screen readers, copy-paste of textContent) from absurd values.

## Regression tests

- `happyhq/components/features/chat/messages/tool-progress-indicator.test.tsx:124-225` — asserts the header row carries `min-w-0`, the detail span/button carries `truncate min-w-0`, and the elapsed chip stays `shrink-0`. Also asserts long detail input is capped in the rendered DOM.
- `happyhq/lib/chat/tool-labels.test.ts:215-275` — covers the 60-char cap across every tool path that returns a detail, plus a guard that short values are unchanged.

Without the component fix the new layout assertions fail; without the cap the new length assertions fail.

## Verification

From `happyhq/`:

```
pnpm format    # clean
pnpm lint      # clean
pnpm check-types
pnpm test      # 1344 passed
```

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.