### PR TITLE
feat: add --fix-only flag to bugs.sh

### DIFF
--- a/happyhq/.dev/WOW.md
+++ b/happyhq/.dev/WOW.md
@@ -67,6 +67,7 @@ Different shape from the build loop. Reads GitHub issues, opens PRs.
 ```bash
 ./bugs.sh                  # triage everything, then fix up to 3 eligible bugs
 ./bugs.sh --triage-only    # just label/comment, don't touch code
+./bugs.sh --fix-only       # skip Phase 1, run the fix loop on the existing queue
 ./bugs.sh --issue 42       # skip triage, attempt one fix on #42
 ./bugs.sh --dry-run        # Phase 1 preview only (no writes); add --issue <#> to preview a fix
 ```
@@ -90,6 +91,7 @@ Edit `bugs-rubric.md` when Ralphie misjudges. Same model as `specs/` for the bui
 | `./loop.sh 20`                      | Build mode, max 20 iterations             |
 | `./bugs.sh`                         | Triage + fix up to 3 bugs                 |
 | `./bugs.sh --triage-only`           | Just triage, no code                      |
+| `./bugs.sh --fix-only`              | Skip triage, fix loop on existing queue   |
 | `./bugs.sh --issue <#>`             | Fix one specific issue                    |
 | `./bugs.sh --dry-run`               | Phase 1 preview only, no writes           |
 

--- a/happyhq/.dev/bugs.sh
+++ b/happyhq/.dev/bugs.sh
@@ -4,6 +4,7 @@ set -o pipefail
 #   ./bugs.sh                          # triage + fix loop, default --max-bugs 3
 #   ./bugs.sh --max-bugs 5             # cap Phase 2 attempts at 5
 #   ./bugs.sh --triage-only            # Phase 1 only
+#   ./bugs.sh --fix-only               # skip Phase 1, run the fix loop on the queue
 #   ./bugs.sh --issue 42               # skip triage; one fix session against #42
 #   ./bugs.sh --dry-run                # Phase 1 preview only, no writes
 #   ./bugs.sh --issue 42 --dry-run     # preview a single fix session, no writes
@@ -18,6 +19,7 @@ RESET='\033[0m'
 
 MAX_BUGS=3
 TRIAGE_ONLY=0
+FIX_ONLY=0
 SINGLE_ISSUE=""
 DRY_RUN=""
 
@@ -31,6 +33,10 @@ while [ $# -gt 0 ]; do
             TRIAGE_ONLY=1
             shift
             ;;
+        --fix-only)
+            FIX_ONLY=1
+            shift
+            ;;
         --issue)
             SINGLE_ISSUE="$2"
             shift 2
@@ -40,7 +46,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -h|--help)
-            sed -n '3,9p' "$0" | sed 's/^# \?//'
+            sed -n '3,10p' "$0" | sed 's/^# \?//'
             exit 0
             ;;
         *)
@@ -49,6 +55,15 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+if [ $TRIAGE_ONLY -eq 1 ] && [ $FIX_ONLY -eq 1 ]; then
+    echo "Error: --triage-only and --fix-only are mutually exclusive" >&2
+    exit 1
+fi
+if [ $FIX_ONLY -eq 1 ] && [ -n "$DRY_RUN" ]; then
+    echo "Error: --fix-only --dry-run isn't supported (dry-run on fixes wastes a real session). Use --issue <#> --dry-run to preview a single fix." >&2
+    exit 1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1
@@ -97,22 +112,24 @@ if [ -n "$SINGLE_ISSUE" ]; then
     exit $?
 fi
 
-# ── Phase 1: Triage (one session, walks the whole queue) ──
-run_session "PROMPT_bugs_triage.md" "Phase 1 · Triage"
-TRIAGE_EXIT=$?
-if [ $TRIAGE_EXIT -ne 0 ]; then
-    echo -e "  ${RED}Triage exited with status $TRIAGE_EXIT — stopping${RESET}"
-    exit $TRIAGE_EXIT
-fi
+# ── Phase 1: Triage (skipped with --fix-only) ──
+if [ $FIX_ONLY -eq 0 ]; then
+    run_session "PROMPT_bugs_triage.md" "Phase 1 · Triage"
+    TRIAGE_EXIT=$?
+    if [ $TRIAGE_EXIT -ne 0 ]; then
+        echo -e "  ${RED}Triage exited with status $TRIAGE_EXIT — stopping${RESET}"
+        exit $TRIAGE_EXIT
+    fi
 
-if [ $TRIAGE_ONLY -eq 1 ]; then
-    echo -e "\n  ${GREEN}✓${RESET} Triage complete (--triage-only). Exiting."
-    exit 0
-fi
+    if [ $TRIAGE_ONLY -eq 1 ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Triage complete (--triage-only). Exiting."
+        exit 0
+    fi
 
-if [ -n "$DRY_RUN" ]; then
-    echo -e "\n  ${GREEN}✓${RESET} Phase 1 preview complete. Skipping Phase 2 in --dry-run (labels weren't applied, so the fix queue would re-pick the same bugs). Use --issue <#> --dry-run to preview a fix session."
-    exit 0
+    if [ -n "$DRY_RUN" ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Phase 1 preview complete. Skipping Phase 2 in --dry-run (labels weren't applied, so the fix queue would re-pick the same bugs). Use --issue <#> --dry-run to preview a fix session."
+        exit 0
+    fi
 fi
 
 # ── Phase 2: Fix loop (one session per bug) ──


### PR DESCRIPTION
## Summary

- Adds `--fix-only` to `bugs.sh` — mirror of `--triage-only`, skips Phase 1 and runs the fix loop on the existing labeled queue.
- Solves a real waste: re-running `./bugs.sh` after a fresh triage would re-evaluate already-judged-eligible bugs in Phase 1, because the queue filter (`no:label:ralphie`) can't tell "new" from "judged eligible."
- Mutually exclusive with `--triage-only`; disallowed with `--dry-run` (we already exit Phase 1 in dry-run for the same wasted-session reason).

## Test plan

- [x] `./bugs.sh --help` lists the new flag
- [x] `./bugs.sh --fix-only --triage-only` errors with mutual-exclusion message
- [x] `./bugs.sh --fix-only --dry-run` errors with the dry-run-on-fixes message
- [x] `./bugs.sh --fix-only --max-bugs 100` runs the fix loop on the existing queue and stops on "queue empty"

🤖 Generated with [Claude Code](https://claude.com/claude-code)