### PR TITLE
fix: restrict task file pickers to supported intake types

### DIFF
--- a/happyhq/components/features/chat/composer.tsx
+++ b/happyhq/components/features/chat/composer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useConfig } from '@/lib/config/use-config'
+import { ALLOWED_INPUT_ACCEPT, isAllowedInputFilename } from '@/lib/file-types'
 import { cn } from '@/lib/utils'
 import type { StagedFile } from '@/stores/chatStore'
 import { ArrowUp, Plus, Square } from 'lucide-react'
@@ -103,12 +104,9 @@ export const Composer = memo(function Composer({
 
   const handleFiles = useCallback((files: FileList) => {
     // Filter to supported types — the <input> has accept but drag-and-drop bypasses it
-    const allowed = Array.from(files).filter((f) => {
-      const name = f.name.toLowerCase()
-      return (
-        name.endsWith('.pdf') || name.endsWith('.eml') || name.endsWith('.docx')
-      )
-    })
+    const allowed = Array.from(files).filter((f) =>
+      isAllowedInputFilename(f.name),
+    )
     for (const file of allowed) {
       setStagedFiles((prev) => [
         ...prev,
@@ -218,7 +216,7 @@ export const Composer = memo(function Composer({
       ref={fileInputRef}
       type="file"
       multiple
-      accept=".pdf,.eml,.docx"
+      accept={ALLOWED_INPUT_ACCEPT}
       className="hidden"
       onChange={(e) => {
         if (e.target.files?.length) handleFiles(e.target.files)

--- a/happyhq/components/features/tasks/card/attachments-section.tsx
+++ b/happyhq/components/features/tasks/card/attachments-section.tsx
@@ -2,6 +2,7 @@
 
 import { useOptimisticUploads } from '@/components/features/tasks/hooks/use-optimistic-uploads'
 import { deleteTaskInput } from '@/lib/actions'
+import { ALLOWED_INPUT_ACCEPT } from '@/lib/file-types'
 import { useTaskStore } from '@/stores/taskStore'
 import { useCallback } from 'react'
 import { AttachmentList } from '../atoms/attachment-list'
@@ -36,6 +37,7 @@ export function AttachmentsSection() {
         ref={fileInputRef}
         type="file"
         multiple
+        accept={ALLOWED_INPUT_ACCEPT}
         className="hidden"
         onChange={(e) => {
           if (e.target.files) handleFiles(e.target.files)

--- a/happyhq/components/features/tasks/create/dialog.tsx
+++ b/happyhq/components/features/tasks/create/dialog.tsx
@@ -8,6 +8,7 @@ import { useFileDrop } from '@/components/features/desktop/windows/shared/use-fi
 import { StreamPicker } from '@/components/features/tasks/atoms/stream-picker'
 import { useCurrentUser } from '@/lib/accounts/hooks'
 import { createTask, ingestTaskInput } from '@/lib/actions'
+import { ALLOWED_INPUT_ACCEPT } from '@/lib/file-types'
 import { generateTaskSlug } from '@/lib/format'
 import { taskItemsKey } from '@/lib/swr-keys'
 import { useStreams } from '@/stores/streamsStore'
@@ -118,6 +119,7 @@ export function TaskCreateDialog({
             ref={fileInputRef}
             type="file"
             multiple
+            accept={ALLOWED_INPUT_ACCEPT}
             className="hidden"
             onChange={(e) => {
               if (e.target.files) addFiles(e.target.files)

--- a/happyhq/components/features/tasks/create/quick-add.tsx
+++ b/happyhq/components/features/tasks/create/quick-add.tsx
@@ -8,6 +8,7 @@ import { useFileDrop } from '@/components/features/desktop/windows/shared/use-fi
 import { StreamPicker } from '@/components/features/tasks/atoms/stream-picker'
 import { useCurrentUser } from '@/lib/accounts/hooks'
 import { createTask, ingestTaskInput } from '@/lib/actions'
+import { ALLOWED_INPUT_ACCEPT } from '@/lib/file-types'
 import { toSlug } from '@/lib/format'
 import { taskItemsKey } from '@/lib/swr-keys'
 import { useStreams } from '@/stores/streamsStore'
@@ -139,6 +140,7 @@ export function TaskQuickAdd({
         ref={fileInputRef}
         type="file"
         multiple
+        accept={ALLOWED_INPUT_ACCEPT}
         className="hidden"
         onChange={(e) => {
           if (e.target.files) addFiles(e.target.files)

--- a/happyhq/components/features/tasks/panel/index.tsx
+++ b/happyhq/components/features/tasks/panel/index.tsx
@@ -48,6 +48,7 @@ import {
   writeTaskDescription,
   writeTaskTitle,
 } from '@/lib/actions'
+import { ALLOWED_INPUT_ACCEPT } from '@/lib/file-types'
 import { displayTitle } from '@/lib/format'
 import type { FileItem } from '@/lib/fs/types'
 import { invalidateStream } from '@/lib/swr-helpers'
@@ -254,6 +255,7 @@ export function TaskPanel({
         ref={fileInputRef}
         type="file"
         multiple
+        accept={ALLOWED_INPUT_ACCEPT}
         className="hidden"
         onChange={(e) => {
           if (e.target.files) handleFiles(e.target.files)

--- a/happyhq/lib/actions/ingestion.test.ts
+++ b/happyhq/lib/actions/ingestion.test.ts
@@ -110,7 +110,7 @@ vi.mock('@/ee/lib/billing/limits.server', () => ({
 
 const MOCK_TOKEN = 'test-refresh-token'
 
-import { setupTaskFromChat, uploadFile } from './ingestion'
+import { ingestTaskInput, setupTaskFromChat, uploadFile } from './ingestion'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -169,7 +169,7 @@ describe('uploadFile', () => {
     mockMkdir.mockResolvedValue(undefined)
     mockWriteFile.mockResolvedValue(undefined)
 
-    const fd = makeFormData('data.CSV', 'content')
+    const fd = makeFormData('data.PDF', 'content')
     const result = await uploadFile('sess-1', fd)
 
     expect(result).toBe('data')
@@ -180,7 +180,7 @@ describe('uploadFile', () => {
         'sess-1',
         'uploads',
         'data',
-        'original.CSV',
+        'original.PDF',
       ),
       expect.any(Buffer),
     )
@@ -309,13 +309,16 @@ describe('uploadFile', () => {
     warnSpy.mockRestore()
   })
 
-  it('does not run extraction for unsupported file types', async () => {
+  it('rejects unsupported file types before writing to disk', async () => {
     mockMkdir.mockResolvedValue(undefined)
     mockWriteFile.mockResolvedValue(undefined)
 
-    const fd = makeFormData('data.csv', 'csv-content')
-    await uploadFile('sess-1', fd)
+    const fd = makeFormData('clip.mp4', 'mp4-bytes')
+    await expect(uploadFile('sess-1', fd)).rejects.toThrow(
+      'Unsupported file type "clip.mp4"',
+    )
 
+    expect(mockWriteFile).not.toHaveBeenCalled()
     expect(mockExtractTextFromPdf).not.toHaveBeenCalled()
     expect(mockExtractContentFromEml).not.toHaveBeenCalled()
   })
@@ -487,6 +490,57 @@ describe('setupTaskFromChat', () => {
 
     expect(mockCommitGitState).toHaveBeenCalledWith(
       '[tasks/my-task-01abc] Chat inputs',
+    )
+  })
+})
+
+// --- ingestTaskInput ---
+
+describe('ingestTaskInput', () => {
+  function makeFormData(name: string, content: string): FormData {
+    const encoder = new TextEncoder()
+    const bytes = encoder.encode(content)
+    const fileMock = {
+      name,
+      arrayBuffer: async () => bytes.buffer,
+    }
+    return {
+      get: (key: string) => (key === 'file' ? fileMock : null),
+    } as unknown as FormData
+  }
+
+  it('rejects unsupported file types so drag-and-drop cannot bypass the picker accept list', async () => {
+    mockMkdir.mockResolvedValue(undefined)
+    mockWriteFile.mockResolvedValue(undefined)
+
+    const fd = makeFormData('clip.mp4', 'mp4-bytes')
+    await expect(ingestTaskInput('my-task', fd)).rejects.toThrow(
+      'Unsupported file type "clip.mp4"',
+    )
+
+    expect(mockWriteFile).not.toHaveBeenCalled()
+    expect(mockCommitGitState).not.toHaveBeenCalled()
+  })
+
+  it('accepts the canonical allowed types regardless of extension casing', async () => {
+    mockMkdir.mockResolvedValue(undefined)
+    mockWriteFile.mockResolvedValue(undefined)
+    mockExtractTextFromPdf.mockResolvedValue('text')
+
+    const fd = makeFormData('Report.PDF', 'pdf-bytes')
+    const result = await ingestTaskInput('my-task', fd)
+
+    expect(result.slug).toBe('report')
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      path.join(
+        MOCK_ROOT,
+        'tasks',
+        'my-task',
+        'inputs',
+        'report',
+        'original.PDF',
+      ),
+      expect.any(Buffer),
     )
   })
 })

--- a/happyhq/lib/actions/ingestion.ts
+++ b/happyhq/lib/actions/ingestion.ts
@@ -7,6 +7,10 @@ import path from 'node:path'
 import { HAPPYHQ_ROOT } from '@/lib/constants.server'
 import { extractContentFromDocx } from '@/lib/docx/extract-text.server'
 import { extractContentFromEml } from '@/lib/eml/extract-text.server'
+import {
+  ALLOWED_INPUT_EXTENSIONS,
+  isAllowedInputExtension,
+} from '@/lib/file-types'
 import type { InputQuality } from '@/lib/fs/assess-quality.server'
 import { assessTextQuality } from '@/lib/fs/assess-quality.server'
 import { streamPath, taskPath, validatePath } from '@/lib/fs/paths'
@@ -17,6 +21,11 @@ import { extractTextFromPdf } from '@/lib/pdf/extract-text.server'
 import { log } from '@/lib/log.server'
 
 import { deferredCommit, deleteFileItem } from './shared'
+
+function unsupportedTypeMessage(filename: string): string {
+  const allowed = ALLOWED_INPUT_EXTENSIONS.join(', ')
+  return `Unsupported file type "${filename}". Allowed: ${allowed}.`
+}
 
 /**
  * Stage an uploaded file to the chat's uploads/ directory.
@@ -34,6 +43,10 @@ export async function uploadFile(
   const file = formData.get('file') as File
   if (!file) {
     throw new Error('No file provided in FormData')
+  }
+
+  if (!isAllowedInputExtension(path.extname(file.name))) {
+    throw new Error(unsupportedTypeMessage(file.name))
   }
 
   // Billing limit check — dynamic import to keep core/EE separation.
@@ -221,6 +234,9 @@ async function ingestFile(
   }
 
   const ext = path.extname(file.name)
+  if (!isAllowedInputExtension(ext)) {
+    throw new Error(unsupportedTypeMessage(file.name))
+  }
 
   // Billing limit check
   if (opts.streamName) {

--- a/happyhq/lib/agents/tools.server.ts
+++ b/happyhq/lib/agents/tools.server.ts
@@ -9,6 +9,7 @@ import { setSessionMode } from '@/lib/chat/session-mode'
 import type { ChatStreamEvent } from '@/lib/chat/types'
 import { extractContentFromDocx } from '@/lib/docx/extract-text.server'
 import { extractContentFromEml } from '@/lib/eml/extract-text.server'
+import { isAllowedInputExtension } from '@/lib/file-types'
 import { chatPath, streamPath } from '@/lib/fs/paths'
 import { listDirectory, readStreamContent } from '@/lib/fs/read.server'
 import { extractTextFromPdf } from '@/lib/pdf/extract-text.server'
@@ -129,8 +130,7 @@ export function createQsMcpServer(
 
           // 3. Validate file is a supported format
           const ext = path.extname(originalFile).toLowerCase()
-          const supportedExts = ['.pdf', '.eml', '.docx']
-          if (!supportedExts.includes(ext)) {
+          if (!isAllowedInputExtension(ext)) {
             return {
               content: [
                 {

--- a/happyhq/lib/file-types.ts
+++ b/happyhq/lib/file-types.ts
@@ -1,0 +1,25 @@
+/**
+ * Single source of truth for file types accepted across upload surfaces:
+ * task file pickers, chat composer, sample intake, and the agent's intake tool.
+ *
+ * Eager extraction in `lib/actions/ingestion.ts` only knows how to read these
+ * three formats — adding others requires extending the extraction pipeline first.
+ */
+export const ALLOWED_INPUT_EXTENSIONS = ['.pdf', '.eml', '.docx'] as const
+
+export type AllowedInputExtension = (typeof ALLOWED_INPUT_EXTENSIONS)[number]
+
+/** Value for `<input accept="...">`. */
+export const ALLOWED_INPUT_ACCEPT = ALLOWED_INPUT_EXTENSIONS.join(',')
+
+export function isAllowedInputExtension(ext: string): boolean {
+  return (ALLOWED_INPUT_EXTENSIONS as readonly string[]).includes(
+    ext.toLowerCase(),
+  )
+}
+
+export function isAllowedInputFilename(filename: string): boolean {
+  const dot = filename.lastIndexOf('.')
+  if (dot < 0) return false
+  return isAllowedInputExtension(filename.slice(dot))
+}


### PR DESCRIPTION
Closes #21

## Why

The four task file pickers (attachments, panel, create dialog, quick-add) had no `accept` attribute, so the OS file dialog let users pick any file (`.mp4`, `.zip`, `.exe`). Downstream extraction in `lib/actions/ingestion.ts` only handles `.pdf`/`.eml`/`.docx`, so anything else silently landed on disk with no agent-readable form. The chat composer was already restricted to the same set, but each surface hardcoded its own list.

Per the maintainer's decision in #21, the canonical allowed-list is `.pdf, .eml, .docx` — the set the existing extraction pipelines support. Extending to images/audio/video would require new pipelines that don't exist.

## What changed

- New `happyhq/lib/file-types.ts` is the single source of truth: `ALLOWED_INPUT_EXTENSIONS`, `ALLOWED_INPUT_ACCEPT`, and helpers.
- The four task pickers now set `accept={ALLOWED_INPUT_ACCEPT}`.
- The chat composer and the agent's sample-intake tool (`lib/agents/tools.server.ts`) reuse the same constant in place of inline string lists.
- `ingestFile` and `uploadFile` reject unsupported extensions before writing to disk, so drag-and-drop can't bypass the picker. The thrown error flows through the existing `toastError` path in `useOptimisticUploads` and the create-task flows.

## Regression test

`happyhq/lib/actions/ingestion.test.ts:506` — `ingestTaskInput > rejects unsupported file types so drag-and-drop cannot bypass the picker accept list`. Also adds a parallel test for `uploadFile` at `happyhq/lib/actions/ingestion.test.ts:312`. Both fail on `main` and pass with this change.

## How I tested

- `pnpm format` / `pnpm lint` / `pnpm check-types` — clean.
- `pnpm --filter=happyhq test` — 1370 tests pass.
- Verified the new tests fail without the `ingestion.ts` change by stashing only that file and re-running the suite.

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.