### PR TITLE
fix: reconstruct subagent activity on chat reload

### DIFF
--- a/happyhq/lib/chat/parse-history.server.test.ts
+++ b/happyhq/lib/chat/parse-history.server.test.ts
@@ -660,6 +660,240 @@ describe('parseJournalEntries', () => {
     expect(messages).toHaveLength(1)
     expect(messages[0].toolCalls![0].answers).toBeUndefined()
   })
+
+  describe('subagent activities', () => {
+    function taskResultLine(opts: {
+      toolUseId: string
+      uuid?: string
+      timestamp?: string
+      status?: 'completed' | 'failed' | 'stopped'
+      totalDurationMs?: number
+      totalToolUseCount?: number
+      summaryText?: string
+    }) {
+      const {
+        toolUseId,
+        uuid = 'tr1',
+        timestamp = '2025-01-01T00:00:02Z',
+        status = 'completed',
+        totalDurationMs = 77000,
+        totalToolUseCount = 26,
+        summaryText = 'subagent finished',
+      } = opts
+      return JSON.stringify({
+        type: 'user',
+        uuid,
+        timestamp,
+        toolUseResult: {
+          status,
+          totalDurationMs,
+          totalToolUseCount,
+        },
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: toolUseId,
+              content: [{ type: 'text', text: summaryText }],
+            },
+          ],
+        },
+      })
+    }
+
+    it('reconstructs a completed Task subagent activity with description, tool count, and duration', () => {
+      const content = [
+        assistantLine('Delegating to subagent', {
+          uuid: 'a1',
+          toolCalls: [
+            {
+              id: 'task-1',
+              name: 'Task',
+              input: {
+                description: 'Read all specs',
+                subagent_type: 'Explore',
+                prompt: 'Read X, Y, Z',
+              },
+            },
+          ],
+        }),
+        taskResultLine({
+          toolUseId: 'task-1',
+          totalDurationMs: 77000,
+          totalToolUseCount: 26,
+        }),
+      ].join('\n')
+
+      const messages = parseJournalEntries(content)
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0].subagentActivities).toEqual([
+        expect.objectContaining({
+          taskId: 'task-1',
+          description: 'Read all specs',
+          isComplete: true,
+          toolUses: 26,
+          durationMs: 77000,
+        }),
+      ])
+    })
+
+    it('also reconstructs activities for the Agent tool name', () => {
+      const content = [
+        assistantLine('Delegating', {
+          uuid: 'a1',
+          toolCalls: [
+            {
+              id: 'agent-1',
+              name: 'Agent',
+              input: { description: 'Review the diff' },
+            },
+          ],
+        }),
+        taskResultLine({
+          toolUseId: 'agent-1',
+          totalDurationMs: 12000,
+          totalToolUseCount: 4,
+        }),
+      ].join('\n')
+
+      const messages = parseJournalEntries(content)
+
+      expect(messages[0].subagentActivities).toEqual([
+        expect.objectContaining({
+          taskId: 'agent-1',
+          description: 'Review the diff',
+          isComplete: true,
+          toolUses: 4,
+          durationMs: 12000,
+        }),
+      ])
+    })
+
+    it('attaches multiple subagent activities spawned from the same assistant message', () => {
+      const content = [
+        assistantLine('Two delegations', {
+          uuid: 'a1',
+          toolCalls: [
+            {
+              id: 'task-a',
+              name: 'Task',
+              input: { description: 'Read playbook' },
+            },
+            {
+              id: 'task-b',
+              name: 'Task',
+              input: { description: 'Read crm spec' },
+            },
+          ],
+        }),
+        taskResultLine({
+          toolUseId: 'task-a',
+          uuid: 'tr-a',
+          totalDurationMs: 1000,
+          totalToolUseCount: 1,
+        }),
+        taskResultLine({
+          toolUseId: 'task-b',
+          uuid: 'tr-b',
+          totalDurationMs: 2000,
+          totalToolUseCount: 2,
+        }),
+      ].join('\n')
+
+      const messages = parseJournalEntries(content)
+
+      expect(messages[0].subagentActivities).toHaveLength(2)
+      expect(messages[0].subagentActivities![0]).toEqual(
+        expect.objectContaining({
+          taskId: 'task-a',
+          description: 'Read playbook',
+          isComplete: true,
+          toolUses: 1,
+          durationMs: 1000,
+        }),
+      )
+      expect(messages[0].subagentActivities![1]).toEqual(
+        expect.objectContaining({
+          taskId: 'task-b',
+          description: 'Read crm spec',
+          isComplete: true,
+          toolUses: 2,
+          durationMs: 2000,
+        }),
+      )
+    })
+
+    it('completes activities when the tool_result arrives in a later assistant turn', () => {
+      const content = [
+        assistantLine('Spawning subagent', {
+          uuid: 'a1',
+          toolCalls: [
+            {
+              id: 'task-x',
+              name: 'Task',
+              input: { description: 'Long-running work' },
+            },
+          ],
+        }),
+        assistantLine('Thinking aloud while subagent runs', { uuid: 'a2' }),
+        taskResultLine({
+          toolUseId: 'task-x',
+          totalDurationMs: 30000,
+          totalToolUseCount: 9,
+        }),
+      ].join('\n')
+
+      const messages = parseJournalEntries(content)
+
+      expect(messages).toHaveLength(2)
+      expect(messages[0].subagentActivities).toEqual([
+        expect.objectContaining({
+          taskId: 'task-x',
+          description: 'Long-running work',
+          isComplete: true,
+          toolUses: 9,
+          durationMs: 30000,
+        }),
+      ])
+      expect(messages[1].subagentActivities).toBeUndefined()
+    })
+
+    it('marks an activity incomplete if no tool_result arrives (interrupted run)', () => {
+      const content = assistantLine('Just spawned, never finished', {
+        uuid: 'a1',
+        toolCalls: [
+          {
+            id: 'task-pending',
+            name: 'Task',
+            input: { description: 'Will be cut off' },
+          },
+        ],
+      })
+
+      const messages = parseJournalEntries(content)
+
+      expect(messages[0].subagentActivities).toEqual([
+        expect.objectContaining({
+          taskId: 'task-pending',
+          description: 'Will be cut off',
+          isComplete: false,
+        }),
+      ])
+    })
+
+    it('does not create a subagent activity for non-Task tool calls', () => {
+      const content = assistantLine('Just reading a file', {
+        uuid: 'a1',
+        toolCalls: [{ id: 'tc-read', name: 'Read', input: { path: '/foo' } }],
+      })
+
+      const messages = parseJournalEntries(content)
+
+      expect(messages[0].subagentActivities).toBeUndefined()
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/happyhq/lib/chat/parse-history.server.ts
+++ b/happyhq/lib/chat/parse-history.server.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ToolCall } from '@/lib/chat/types'
+import type { ChatMessage, SubagentActivity, ToolCall } from '@/lib/chat/types'
 import { stripMcpPrefix } from '@/lib/run/filter.server'
 
 /**
@@ -23,7 +23,19 @@ interface JournalEntry {
       content?: string | Array<{ type: string; text?: string }> // tool_result content
     }>
   }
+  // Top-level metadata the SDK attaches to user entries that carry a Task
+  // tool_result. The live `task_notification` system event isn't persisted to
+  // JSONL, so this aggregate is the only source of truth for tool count and
+  // duration on the reload path.
+  toolUseResult?: {
+    status?: 'completed' | 'failed' | 'stopped'
+    totalDurationMs?: number
+    totalToolUseCount?: number
+  }
 }
+
+/** Tool names the SDK uses to spawn subagents. */
+const SUBAGENT_TOOL_NAMES = new Set(['Task', 'Agent'])
 
 type ChatMessageWithRequestId = ChatMessage & { _requestId?: string }
 
@@ -112,6 +124,39 @@ function extractFilesFromContent(content: string): {
 }
 
 /**
+ * Find the SubagentActivity seeded by a Task/Agent tool_use and merge in the
+ * completion metrics from the tool_result entry. Returns true when an activity
+ * was matched (so the caller can short-circuit AskUserQuestion handling).
+ *
+ * The SDK's live `task_notification` system events aren't persisted to JSONL,
+ * so durations and tool counts come from the entry's top-level `toolUseResult`.
+ */
+function completeSubagentActivity(
+  rawMessages: ChatMessageWithRequestId[],
+  toolUseId: string,
+  entry: JournalEntry,
+): boolean {
+  for (let i = rawMessages.length - 1; i >= 0; i--) {
+    const msg = rawMessages[i]
+    if (msg.role !== 'assistant' || !msg.subagentActivities) continue
+    const activity = msg.subagentActivities.find((a) => a.taskId === toolUseId)
+    if (!activity) continue
+    activity.isComplete = true
+    const meta = entry.toolUseResult
+    if (meta) {
+      if (typeof meta.totalToolUseCount === 'number') {
+        activity.toolUses = meta.totalToolUseCount
+      }
+      if (typeof meta.totalDurationMs === 'number') {
+        activity.durationMs = meta.totalDurationMs
+      }
+    }
+    return true
+  }
+  return false
+}
+
+/**
  * Parse SDK session JSONL content into a ChatMessage array.
  *
  * Filters to user/assistant messages, extracts AskUserQuestion answers from
@@ -137,6 +182,7 @@ export function parseJournalEntries(content: string): ChatMessage[] {
 
     // Extract interactive tool state from tool_result entries, then skip them.
     // AskUserQuestion: populate tc.answers from the result text.
+    // Task/Agent: complete the matching SubagentActivity.
     // CreateTask taskStarted is annotated by the history route from chat.json, not here.
     if (entry.type === 'user') {
       const toolResults = entry.message.content.filter(
@@ -144,8 +190,14 @@ export function parseJournalEntries(content: string): ChatMessage[] {
       )
       if (toolResults.length > 0) {
         for (const tr of toolResults) {
+          if (!tr.tool_use_id) continue
+
+          if (completeSubagentActivity(rawMessages, tr.tool_use_id, entry)) {
+            continue
+          }
+
           const text = extractToolResultText(tr.content)
-          if (!text || !tr.tool_use_id) continue
+          if (!text) continue
 
           // AskUserQuestion: parse answers from result text
           const answers = parseAskAnswers(text)
@@ -208,6 +260,17 @@ export function parseJournalEntries(content: string): ChatMessage[] {
         .filter((block) => block.type === 'thinking' && block.thinking)
         .map((block) => ({ text: block.thinking! }))
 
+      const subagentActivities: SubagentActivity[] = toolCalls
+        .filter((tc) => SUBAGENT_TOOL_NAMES.has(tc.name))
+        .map((tc) => ({
+          taskId: tc.id,
+          description:
+            typeof tc.input.description === 'string' && tc.input.description
+              ? tc.input.description
+              : 'agent',
+          isComplete: false,
+        }))
+
       rawMessages.push({
         id: entry.uuid,
         role: 'assistant',
@@ -222,6 +285,8 @@ export function parseJournalEntries(content: string): ChatMessage[] {
                 elapsedSeconds: 0,
               }))
             : undefined,
+        subagentActivities:
+          subagentActivities.length > 0 ? subagentActivities : undefined,
         isHistorical: true,
         timestamp: new Date(entry.timestamp).getTime(),
         _requestId: entry.requestId,


### PR DESCRIPTION
## Summary

The live path populates `SubagentActivityIndicator` blocks from SDK `system` events with subtype `task_started` / `task_progress` / `task_notification`. Those events aren't persisted to the session JSONL, so the reload path in `lib/chat/parse-history.server.ts` had nothing to read — and silently dropped every subagent indicator on history round-trip.

The fix seeds an activity from each `Task`/`Agent` `tool_use` block in the parent transcript and completes it from the matching `tool_result`'s top-level `toolUseResult` metadata (`status`, `totalDurationMs`, `totalToolUseCount`), which the SDK *does* persist. The activity attaches to the assistant message that owned the `tool_use` — the same message the live `subagent_event` flow writes to in `chatStore.ts:786`.

`description` and the count/duration round-trip; `summary` (the live progress string) isn't in the JSONL, so reloaded indicators fall back to the existing `'done'` placeholder.

Closes #78

## Test plan

- [x] `pnpm --filter=happyhq test lib/chat/parse-history.server.test.ts` — 6 new regression tests covering single Task, Agent alias, multiple subagents on one message, completion in a later turn, interrupted (no result) activities, and non-Task tool calls. See `happyhq/lib/chat/parse-history.server.test.ts:664`.
- [x] `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` — all green (1374/1374).
- [ ] Manual smoke: trigger a chat that delegates to a subagent, observe the live indicator, reload, confirm the indicator persists with description / tool count / duration intact.

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.