### PR TITLE
chore: add three generic principles to Ralphie's loop

### DIFF
--- a/happyhq/.dev/PROMPT_bugs_fix.md
+++ b/happyhq/.dev/PROMPT_bugs_fix.md
@@ -36,3 +36,4 @@
 **[6]** If you discover the fix requires a schema migration / new env var / new dep / CI change mid-implementation, stop, revert your changes (`git checkout main && git branch -D fix/${ISSUE_NUMBER}-...`), apply `ralphie:skip-out-of-scope`, exit.
 **[7]** AI disclosure in the PR body is required by @CONTRIBUTING.md. Never omit it.
 **[8]** When applying any `ralphie:skip-*` label, the comment uses the rubric's "Comment shape" format. Always.
+**[9]** Question the shape of the fix before committing to it. If the fix is purely a constraint (cap, limit, truncate, hide), the unbounded behavior has a cause — find it and fix it, even when it lives in nearby code. Scope follows the cause: touch nearby code when it's the cause, leave it when it's just adjacent and looks improvable. If you're adding a new element to an existing UI surface, check it's distinguishable from neighbors of similar shape.

--- a/happyhq/.dev/bugs-rubric.md
+++ b/happyhq/.dev/bugs-rubric.md
@@ -45,6 +45,14 @@ Comments are for the human reading the queue. The label is for the next Ralphie.
 - PRs always target `main`, branch from `main`, use the `fix/` prefix, and include `Closes #<issue>` plus an AI-assistance disclosure (per `CONTRIBUTING.md`).
 - One outcome per session. After labeling or opening a PR, exit.
 
+## Principles
+
+These are guidance, not gates. The rubric above is pass/fail; these tune _how_ the allowed work gets done.
+
+**Look around before you write.** Before drafting a fix or skip, scan for prior art on the concern: existing consumers/handlers of the same data shape, recent open/closed issues with the same shape, in-flight PRs touching the same surface, specs documenting the affected behavior. Anchor the work to what's already there. Most "we keep fixing this" pain comes from rederiving in isolation when a reference exists that would have constrained the fix.
+
+**A fix isn't just the diff.** Leave the surrounding system coherent. If the fix changes documented behavior, update the spec/doc in the same PR. If you notice a pattern that spans multiple recent issues, surface it for the maintainer rather than fixing one instance silently. If you skip, leave a rationale specific enough that a human can act on it without re-investigating.
+
 ## Tuning signal
 
 When Ralphie gets it wrong — labels something `skip-too-big` that wasn't, opens a PR that shouldn't have been opened, misses an `ee/` touch — that's a rubric-tuning signal, not a one-off correction. Edit this file. The next run will pick up the change.


### PR DESCRIPTION
## Summary

Three lessons from a recent review session, captured generically rather than tied to specific bugs. The goal is to make Ralphie's output better across all future runs without overfitting to any one PR.

- **`bugs-rubric.md`** gains a new **Principles** section. Both `PROMPT_bugs_triage.md` and `PROMPT_bugs_fix.md` already load the rubric, so these two principles auto-propagate to both phases:
  - **Look around before you write** — scan for prior art (existing consumers/handlers of the same shape, recent issues, in-flight PRs, related specs) before drafting. Anchor to what exists. Most "we keep fixing this" pain is from rederiving in isolation.
  - **A fix isn't just the diff** — keep the surrounding system coherent. Update specs/docs when behavior changes, surface cross-issue patterns for the maintainer, leave actionable rationale on skips.
- **`PROMPT_bugs_fix.md`** gains a fix-time-only principle as `**[9]**`:
  - **Question the shape of the fix before committing** — constraint fixes (cap, limit, truncate, hide) signal a cause that needs finding. Scope follows the cause: touch nearby code when it's the cause, leave it when it's just adjacent and looks improvable. New UI elements should be distinguishable from neighbors of similar shape.

These are guidance, not gates. The rubric table stays the pass/fail authority; the principles tune *how* the allowed work gets done.

## Why these placements

- The rubric file already says "Edit here, not in the prompts" — both prompts read it. Cross-phase principles belong there once.
- `[9]` is fix-time only (it's about draft-time shape decisions), so it lives in `PROMPT_bugs_fix.md` rather than the shared rubric.

## Test plan

Documentation only — no code paths to verify.

- [x] Markdown renders cleanly in GitHub preview
- [x] Rubric structure is intact (table + comment shape + hard constraints + new principles + tuning signal)
- [x] `[9]` slot in the fix prompt's numbered guardrails is unique and contiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)