### PR TITLE
fix: switch shell exec to execFile in git/run helpers

### DIFF
--- a/happyhq/app/api/fs/reveal/route.test.ts
+++ b/happyhq/app/api/fs/reveal/route.test.ts
@@ -13,12 +13,12 @@ vi.mock('node:fs/promises', () => ({
   stat: mockStat,
 }))
 
-const { mockExecSync } = vi.hoisted(() => ({
-  mockExecSync: vi.fn(),
+const { mockExecFileSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
 }))
 
 vi.mock('node:child_process', () => ({
-  execSync: mockExecSync,
+  execFileSync: mockExecFileSync,
 }))
 
 import { POST } from './route'
@@ -88,29 +88,31 @@ describe('POST /api/fs/reveal', () => {
 
       expect(response.status).toBe(501)
       expect(body).toEqual({ error: 'Not supported on this platform' })
-      expect(mockExecSync).not.toHaveBeenCalled()
+      expect(mockExecFileSync).not.toHaveBeenCalled()
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform })
     }
   })
 
-  it('calls open -R and returns ok for a valid file', async () => {
+  it('spawns open without a shell, passing the path as a discrete argv element', async () => {
+    // Security contract: the path must reach `open` as its own argv slot so
+    // shell metacharacters in a filename can never be interpreted as a command.
     mockStat.mockResolvedValue({ isFile: () => true })
-    mockExecSync.mockReturnValue(undefined)
+    mockExecFileSync.mockReturnValue(undefined)
     const originalPlatform = process.platform
     Object.defineProperty(process, 'platform', { value: 'darwin' })
 
     try {
-      const response = await POST(
-        makeRequest({ path: 'my-stream/outputs/report.md' }),
-      )
+      const hostile = 'my-stream/outputs/"; touch /tmp/pwn; "weird.md'
+      const response = await POST(makeRequest({ path: hostile }))
       const body = await response.json()
 
       expect(response.status).toBe(200)
       expect(body).toEqual({ ok: true })
-      expect(mockExecSync).toHaveBeenCalledWith(
-        'open -R "/mock/home/HappyHQ/my-stream/outputs/report.md"',
-      )
+      expect(mockExecFileSync).toHaveBeenCalledTimes(1)
+      const [file, args] = mockExecFileSync.mock.calls[0]
+      expect(file).toBe('open')
+      expect(args).toEqual(['-R', `/mock/home/HappyHQ/${hostile}`])
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform })
     }

--- a/happyhq/app/api/fs/reveal/route.ts
+++ b/happyhq/app/api/fs/reveal/route.ts
@@ -48,11 +48,12 @@ export async function POST(request: Request) {
     )
   }
 
-  // Reveal in Finder (macOS). execSync is intentional here — we need
-  // the shell to invoke `open -R` and this is a user-triggered action.
-  const { execSync } = await import('node:child_process')
+  // Reveal in Finder (macOS). execFileSync passes args directly to the
+  // child process — no shell, so metacharacters in the path can't be
+  // interpreted as commands.
+  const { execFileSync } = await import('node:child_process')
   try {
-    execSync(`open -R "${fullPath}"`)
+    execFileSync('open', ['-R', fullPath])
   } catch (err) {
     log('api.error', {
       route: '/api/fs/reveal',

--- a/happyhq/lib/git/log.server.test.ts
+++ b/happyhq/lib/git/log.server.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/constants.server', () => ({
+  HAPPYHQ_ROOT: '/mock/home/HappyHQ',
+}))
+
+const { mockExecFileSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+}))
+
+vi.mock('node:child_process', () => ({
+  default: { execFileSync: mockExecFileSync },
+  execFileSync: mockExecFileSync,
+}))
+
+import {
+  getFileHistory,
+  getGitLog,
+  isFileDirty,
+  readFileAtRef,
+} from './log.server'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+// These tests pin the security contract introduced in #89: user-controlled
+// inputs (file paths, refs, grep patterns) must reach git as their own argv
+// elements so that shell metacharacters in the value cannot be interpreted.
+
+describe('isFileDirty', () => {
+  it('returns true when git reports the file as changed', () => {
+    mockExecFileSync.mockReturnValue('path/to/file.md\n')
+
+    expect(isFileDirty('path/to/file.md')).toBe(true)
+  })
+
+  it('returns false on empty output', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    expect(isFileDirty('path/to/file.md')).toBe(false)
+  })
+
+  it('returns false when git throws', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('not a repo')
+    })
+
+    expect(isFileDirty('any.md')).toBe(false)
+  })
+
+  it('passes a hostile-looking path as a discrete argv element', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    isFileDirty('weird; rm -rf ~/HappyHQ.md')
+
+    const [file, args] = mockExecFileSync.mock.calls[0]
+    expect(file).toBe('git')
+    expect(args).toEqual([
+      'diff',
+      'HEAD',
+      '--name-only',
+      '--',
+      'weird; rm -rf ~/HappyHQ.md',
+    ])
+  })
+})
+
+describe('getFileHistory', () => {
+  it('parses git output into entries', () => {
+    mockExecFileSync.mockReturnValue(
+      'abc1234---FIELD---first commit---FIELD---2 days ago\n' +
+        'def5678---FIELD---second commit---FIELD---1 day ago\n',
+    )
+
+    expect(getFileHistory('readme.md')).toEqual([
+      { hash: 'abc1234', subject: 'first commit', date: '2 days ago' },
+      { hash: 'def5678', subject: 'second commit', date: '1 day ago' },
+    ])
+  })
+
+  it('returns an empty array when git throws', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('git error')
+    })
+
+    expect(getFileHistory('readme.md')).toEqual([])
+  })
+
+  it('passes filePath as a discrete argv element', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    getFileHistory('weird; rm -rf ~.md', 5)
+
+    const [file, args] = mockExecFileSync.mock.calls[0]
+    expect(file).toBe('git')
+    expect(args).toContain('--')
+    expect(args[args.length - 1]).toBe('weird; rm -rf ~.md')
+    expect(args).toContain('-5')
+  })
+})
+
+describe('readFileAtRef', () => {
+  it('returns the file contents on success', () => {
+    mockExecFileSync.mockReturnValue('hello world\n')
+
+    expect(readFileAtRef('HEAD~1', 'readme.md')).toBe('hello world\n')
+  })
+
+  it('returns null when git fails', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('bad ref')
+    })
+
+    expect(readFileAtRef('does-not-exist', 'readme.md')).toBeNull()
+  })
+
+  it('combines ref and path into a single argv element so neither can break out', () => {
+    mockExecFileSync.mockReturnValue('contents')
+
+    readFileAtRef('main', 'weird; rm -rf ~.md')
+
+    const [file, args] = mockExecFileSync.mock.calls[0]
+    expect(file).toBe('git')
+    expect(args).toEqual(['show', 'main:weird; rm -rf ~.md'])
+  })
+})
+
+describe('getGitLog', () => {
+  it('parses git output into entries', () => {
+    mockExecFileSync.mockReturnValue(
+      'abc1234---FIELD---feat: x---FIELD---3 hours ago\n',
+    )
+
+    expect(getGitLog(10)).toEqual([
+      { hash: 'abc1234', subject: 'feat: x', date: '3 hours ago' },
+    ])
+  })
+
+  it('returns an empty array when git throws', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('git error')
+    })
+
+    expect(getGitLog()).toEqual([])
+  })
+
+  it('omits grep flags when no grep is supplied', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    getGitLog(7)
+
+    const [, args] = mockExecFileSync.mock.calls[0]
+    expect(args).not.toContain('--extended-regexp')
+    expect(args.some((a: string) => a.startsWith('--grep'))).toBe(false)
+  })
+
+  it('passes the grep pattern as a discrete --grep=<value> argv element', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    getGitLog(7, '^\\[my-stream/my-task\\]')
+
+    const [file, args] = mockExecFileSync.mock.calls[0]
+    expect(file).toBe('git')
+    expect(args).toContain('--extended-regexp')
+    expect(args).toContain('--grep=^\\[my-stream/my-task\\]')
+  })
+})

--- a/happyhq/lib/git/log.server.ts
+++ b/happyhq/lib/git/log.server.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 
 import { HAPPYHQ_ROOT } from '@/lib/constants.server'
 
@@ -11,18 +11,14 @@ export interface GitLogEntry {
 const SEPARATOR = '---GIT-LOG-SEP---'
 const FIELD_SEP = '---FIELD---'
 
-/** Wrap a value in single quotes, escaping any embedded single quotes. */
-function shellEscape(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`
-}
-
 /**
  * Check if a file has uncommitted changes (staged or unstaged).
  */
 export function isFileDirty(filePath: string): boolean {
   try {
-    const out = execSync(
-      `git diff HEAD --name-only -- ${shellEscape(filePath)}`,
+    const out = execFileSync(
+      'git',
+      ['diff', 'HEAD', '--name-only', '--', filePath],
       { cwd: HAPPYHQ_ROOT, encoding: 'utf8', timeout: 5000, stdio: 'pipe' },
     ).trim()
     return out.length > 0
@@ -37,8 +33,16 @@ export function isFileDirty(filePath: string): boolean {
  */
 export function getFileHistory(filePath: string, limit = 20): GitLogEntry[] {
   try {
-    const raw = execSync(
-      `git log --format='%h${FIELD_SEP}%s${FIELD_SEP}%ar' -${limit} --no-merges -- ${shellEscape(filePath)}`,
+    const raw = execFileSync(
+      'git',
+      [
+        'log',
+        `--format=%h${FIELD_SEP}%s${FIELD_SEP}%ar`,
+        `-${limit}`,
+        '--no-merges',
+        '--',
+        filePath,
+      ],
       {
         cwd: HAPPYHQ_ROOT,
         encoding: 'utf8',
@@ -64,7 +68,7 @@ export function getFileHistory(filePath: string, limit = 20): GitLogEntry[] {
  */
 export function readFileAtRef(ref: string, filePath: string): string | null {
   try {
-    return execSync(`git show ${shellEscape(ref)}:${shellEscape(filePath)}`, {
+    return execFileSync('git', ['show', `${ref}:${filePath}`], {
       cwd: HAPPYHQ_ROOT,
       encoding: 'utf8',
       timeout: 5000,
@@ -84,18 +88,21 @@ export function readFileAtRef(ref: string, filePath: string): string | null {
  */
 export function getGitLog(limit = 50, grep?: string): GitLogEntry[] {
   try {
-    const grepFlag = grep
-      ? ` --extended-regexp --grep=${shellEscape(grep)}`
-      : ''
-    const raw = execSync(
-      `git log --format='%h${FIELD_SEP}%s${FIELD_SEP}%ar' -${limit} --no-merges${grepFlag}`,
-      {
-        cwd: HAPPYHQ_ROOT,
-        encoding: 'utf8',
-        timeout: 5000,
-        stdio: 'pipe',
-      },
-    ).trim()
+    const args = [
+      'log',
+      `--format=%h${FIELD_SEP}%s${FIELD_SEP}%ar`,
+      `-${limit}`,
+      '--no-merges',
+    ]
+    if (grep) {
+      args.push('--extended-regexp', `--grep=${grep}`)
+    }
+    const raw = execFileSync('git', args, {
+      cwd: HAPPYHQ_ROOT,
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: 'pipe',
+    }).trim()
 
     if (!raw) return []
 

--- a/happyhq/lib/git/sync.server.test.ts
+++ b/happyhq/lib/git/sync.server.test.ts
@@ -6,13 +6,15 @@ vi.mock('@/lib/constants.server', () => ({
 
 const MOCK_ROOT = '/mock/home/HappyHQ'
 
-const { mockExecSync } = vi.hoisted(() => ({
+const { mockExecSync, mockExecFileSync } = vi.hoisted(() => ({
   mockExecSync: vi.fn(),
+  mockExecFileSync: vi.fn(),
 }))
 
 vi.mock('node:child_process', () => ({
-  default: { execSync: mockExecSync },
+  default: { execSync: mockExecSync, execFileSync: mockExecFileSync },
   execSync: mockExecSync,
+  execFileSync: mockExecFileSync,
 }))
 
 import { commitGitState, isTaskCompleted, syncGitState } from './sync.server'
@@ -115,7 +117,7 @@ describe('syncGitState', () => {
 
 describe('isTaskCompleted', () => {
   it('returns true when latest commit subject contains [done]', () => {
-    mockExecSync.mockReturnValue(
+    mockExecFileSync.mockReturnValue(
       '[my-stream/my-task] [done] Final deliverables\n',
     )
 
@@ -123,76 +125,104 @@ describe('isTaskCompleted', () => {
   })
 
   it('returns false when latest commit subject does not contain [done]', () => {
-    mockExecSync.mockReturnValue('[my-stream/my-task] Work in progress\n')
+    mockExecFileSync.mockReturnValue('[my-stream/my-task] Work in progress\n')
 
     expect(isTaskCompleted('my-task')).toBe(false)
   })
 
   it('returns false when git log returns empty output (no commits)', () => {
-    mockExecSync.mockReturnValue('')
+    mockExecFileSync.mockReturnValue('')
 
     expect(isTaskCompleted('my-task')).toBe(false)
   })
 
-  it('returns false when execSync throws (git error)', () => {
-    mockExecSync.mockImplementation(() => {
+  it('returns false when execFileSync throws (git error)', () => {
+    mockExecFileSync.mockImplementation(() => {
       throw new Error('not a git repository')
     })
 
     expect(isTaskCompleted('my-task')).toBe(false)
   })
 
-  it('runs git log from workspace root scoped to the task directory', () => {
-    mockExecSync.mockReturnValue('')
+  it('passes the task path as a discrete argv element so a hostile task name cannot inject shell args', () => {
+    // Security contract: taskName flows through `--` as a positional argument,
+    // never interpolated into a shell command line.
+    mockExecFileSync.mockReturnValue('')
 
-    isTaskCompleted('my-task')
+    isTaskCompleted('my-task; rm -rf /')
 
-    expect(mockExecSync).toHaveBeenCalledWith(
-      "git log --format='%s' -1 -- tasks/my-task",
-      expect.objectContaining({
-        cwd: MOCK_ROOT,
-        encoding: 'utf8',
-        timeout: 5000,
-      }),
-    )
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1)
+    const [file, args, opts] = mockExecFileSync.mock.calls[0]
+    expect(file).toBe('git')
+    expect(args).toEqual([
+      'log',
+      '--format=%s',
+      '-1',
+      '--',
+      'tasks/my-task; rm -rf /',
+    ])
+    expect(opts).toMatchObject({ cwd: MOCK_ROOT, encoding: 'utf8' })
   })
 })
 
 describe('commitGitState', () => {
   it('skips commit when working tree is clean', () => {
-    mockExecSync.mockReturnValue(Buffer.from(''))
+    mockExecFileSync.mockReturnValue(Buffer.from(''))
 
     commitGitState('[my-stream] Create stream')
 
-    expect(mockExecSync).toHaveBeenCalledTimes(1)
-    expect(mockExecSync).toHaveBeenCalledWith('git status --porcelain', {
-      cwd: MOCK_ROOT,
-      stdio: 'pipe',
-    })
-  })
-
-  it('commits with the provided message when tree has changes', () => {
-    mockExecSync.mockReturnValue(Buffer.from('?? new-dir/'))
-
-    commitGitState('[my-stream] Create stream')
-
-    expect(mockExecSync).toHaveBeenCalledTimes(2)
-    expect(mockExecSync).toHaveBeenCalledWith(
-      'git add -A && git commit -m "[my-stream] Create stream"',
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1)
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['status', '--porcelain'],
       { cwd: MOCK_ROOT, stdio: 'pipe' },
     )
   })
 
+  it('commits with the provided message when tree has changes', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('?? new-dir/'))
+
+    commitGitState('[my-stream] Create stream')
+
+    // status + add + commit = 3 calls (no shell, so add and commit are split)
+    expect(mockExecFileSync).toHaveBeenCalledTimes(3)
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(2, 'git', ['add', '-A'], {
+      cwd: MOCK_ROOT,
+      stdio: 'pipe',
+    })
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      3,
+      'git',
+      ['commit', '-m', '[my-stream] Create stream'],
+      { cwd: MOCK_ROOT, stdio: 'pipe' },
+    )
+  })
+
+  it('passes the message as a discrete argv element so shell metacharacters cannot inject commands', () => {
+    // Security contract: the commit message is never interpolated into a shell
+    // command — it travels as its own argv slot to `git commit -m`.
+    mockExecFileSync.mockReturnValue(Buffer.from('M file.txt'))
+
+    const hostile = '" && rm -rf $HOME && echo "'
+    commitGitState(hostile)
+
+    const commitCall = mockExecFileSync.mock.calls.find(
+      (c) => Array.isArray(c[1]) && c[1][0] === 'commit',
+    )
+    expect(commitCall).toBeDefined()
+    expect(commitCall![1]).toEqual(['commit', '-m', hostile])
+  })
+
   it('treats whitespace-only status as clean', () => {
-    mockExecSync.mockReturnValue(Buffer.from('   \n  \n'))
+    mockExecFileSync.mockReturnValue(Buffer.from('   \n  \n'))
 
     commitGitState('[my-stream] Delete stream')
 
-    expect(mockExecSync).toHaveBeenCalledTimes(1)
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1)
   })
 
   it('does not throw when git status fails', () => {
-    mockExecSync.mockImplementation(() => {
+    mockExecFileSync.mockImplementation(() => {
       throw new Error('git not found')
     })
 
@@ -200,8 +230,9 @@ describe('commitGitState', () => {
   })
 
   it('does not throw when git commit fails', () => {
-    mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith('git status')) return Buffer.from('M file.txt')
+    mockExecFileSync.mockImplementation((_file: string, args: string[]) => {
+      if (args[0] === 'status') return Buffer.from('M file.txt')
+      if (args[0] === 'add') return Buffer.from('')
       throw new Error('commit failed')
     })
 
@@ -210,7 +241,7 @@ describe('commitGitState', () => {
 
   it('logs a warning when an error occurs', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    mockExecSync.mockImplementation(() => {
+    mockExecFileSync.mockImplementation(() => {
       throw new Error('repository corrupt')
     })
 
@@ -224,12 +255,12 @@ describe('commitGitState', () => {
   })
 
   it('runs all commands in HAPPYHQ_ROOT', () => {
-    mockExecSync.mockReturnValue(Buffer.from('D deleted-file.txt'))
+    mockExecFileSync.mockReturnValue(Buffer.from('D deleted-file.txt'))
 
     commitGitState('[my-stream] Delete stream')
 
-    for (const call of mockExecSync.mock.calls) {
-      expect(call[1]).toHaveProperty('cwd', MOCK_ROOT)
+    for (const call of mockExecFileSync.mock.calls) {
+      expect(call[2]).toHaveProperty('cwd', MOCK_ROOT)
     }
   })
 })

--- a/happyhq/lib/git/sync.server.ts
+++ b/happyhq/lib/git/sync.server.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 
 import { HAPPYHQ_ROOT } from '@/lib/constants.server'
 
@@ -22,7 +22,7 @@ import { HAPPYHQ_ROOT } from '@/lib/constants.server'
  */
 export function commitGitState(message: string): void {
   try {
-    const status = execSync('git status --porcelain', {
+    const status = execFileSync('git', ['status', '--porcelain'], {
       cwd: HAPPYHQ_ROOT,
       stdio: 'pipe',
     })
@@ -31,7 +31,8 @@ export function commitGitState(message: string): void {
 
     if (!status) return
 
-    execSync(`git add -A && git commit -m "${message}"`, {
+    execFileSync('git', ['add', '-A'], { cwd: HAPPYHQ_ROOT, stdio: 'pipe' })
+    execFileSync('git', ['commit', '-m', message], {
       cwd: HAPPYHQ_ROOT,
       stdio: 'pipe',
     })
@@ -53,12 +54,16 @@ export function commitGitState(message: string): void {
 export function isTaskCompleted(taskName: string): boolean {
   try {
     const taskDir = `tasks/${taskName}`
-    const subject = execSync(`git log --format='%s' -1 -- ${taskDir}`, {
-      cwd: HAPPYHQ_ROOT,
-      encoding: 'utf8',
-      timeout: 5000,
-      stdio: 'pipe',
-    }).trim()
+    const subject = execFileSync(
+      'git',
+      ['log', '--format=%s', '-1', '--', taskDir],
+      {
+        cwd: HAPPYHQ_ROOT,
+        encoding: 'utf8',
+        timeout: 5000,
+        stdio: 'pipe',
+      },
+    ).trim()
     return subject.includes('[done]')
   } catch {
     return false

--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -3,7 +3,7 @@ import type {
   SDKResultMessage,
 } from '@anthropic-ai/claude-agent-sdk'
 import { query } from '@anthropic-ai/claude-agent-sdk'
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
@@ -130,8 +130,8 @@ export async function startRun(
     s.activeRunTask = taskName
     startKeepalives(s)
 
-    // Defer heavy work (commitGitState uses execSync) with setImmediate so
-    // the HTTP response is sent before we block the event loop.
+    // Defer heavy work (commitGitState shells out to git synchronously) with
+    // setImmediate so the HTTP response is sent before we block the event loop.
     s.loopPromise = new Promise<void>((resolve) => {
       setImmediate(() => {
         ;(async () => {
@@ -1100,12 +1100,13 @@ async function readRunInfo(taskName: string): Promise<RunInfo | null> {
 function restorePlanFromGit(taskName: string): void {
   try {
     const taskRelPath = `tasks/${taskName}/plan.md`
-    const hash = execSync(
-      `git log --format='%H' --grep='Plan accepted' -1 -- ${taskRelPath}`,
+    const hash = execFileSync(
+      'git',
+      ['log', '--format=%H', '--grep=Plan accepted', '-1', '--', taskRelPath],
       { cwd: HAPPYHQ_ROOT, encoding: 'utf8', stdio: 'pipe' },
     ).trim()
     if (!hash) return
-    execSync(`git restore --source=${hash} -- ${taskRelPath}`, {
+    execFileSync('git', ['restore', `--source=${hash}`, '--', taskRelPath], {
       cwd: HAPPYHQ_ROOT,
       stdio: 'pipe',
     })


### PR DESCRIPTION
Closes #89.

## Why

CodeQL flagged 9 `js/command-line-injection` alerts in our shell-out paths. Each one interpolated a user-influenced value (task slug, file path, ref, commit message) into a string that `execSync` then handed to `/bin/sh`. A value containing `;`, backticks, or `$()` would be interpreted as additional commands, executing as the HappyHQ user. The agent tools shell out via the same surfaces, so a hostile or buggy agent prompt could reach this code path.

## What changed

Each tainted call site now uses `execFileSync` with an args array — Node spawns the child process directly, no shell, so metacharacters in the value remain literal data. The `git add -A && git commit -m "..."` chain in `commitGitState` was split into two discrete `git add` / `git commit` calls because `&&` itself requires a shell. Static-string `execSync` calls in `syncGitState` and `init.server.ts` were left untouched — they have no taint and weren't part of the alert set, so they're outside the focused fix.

## Files

- `happyhq/lib/git/log.server.ts` — `isFileDirty`, `getFileHistory`, `readFileAtRef`, `getGitLog` (4 alerts)
- `happyhq/lib/git/sync.server.ts` — `commitGitState`, `isTaskCompleted` (2 alerts)
- `happyhq/lib/run/loop.server.ts` — `restorePlanFromGit` (2 alerts)
- `happyhq/app/api/fs/reveal/route.ts` — `open -R` invocation (1 alert)

## Tests

Added/updated tests pin the security contract: a hostile-looking input flows through as its own argv element, never as part of a shell command line. The mock-call-shape assertion is the contract here, not implementation snooping — if someone reverts to `execSync` with string interpolation, every one of these tests fails.

- `happyhq/lib/git/log.server.test.ts:53` — `isFileDirty` argv shape with shell metacharacters
- `happyhq/lib/git/log.server.test.ts:90` — `getFileHistory` argv shape
- `happyhq/lib/git/log.server.test.ts:115` — `readFileAtRef` ref/path argv shape
- `happyhq/lib/git/log.server.test.ts:148` — `getGitLog` `--grep` argv shape
- `happyhq/lib/git/sync.server.test.ts:142` — `isTaskCompleted` task name argv shape
- `happyhq/lib/git/sync.server.test.ts:194` — `commitGitState` message argv shape
- `happyhq/app/api/fs/reveal/route.test.ts:97` — `open` argv shape

`pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` all pass (1404 tests).

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by the maintainer before merge.