### PR TITLE
fix: harden unfurl against SSRF and double-decoding

### DIFF
--- a/happyhq/lib/actions/unfurl.test.ts
+++ b/happyhq/lib/actions/unfurl.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockLookup } = vi.hoisted(() => ({
+  mockLookup: vi.fn(),
+}))
+
+vi.mock('dns/promises', () => ({
+  default: { lookup: mockLookup },
+  lookup: mockLookup,
+}))
+
+import { unfurlUrl } from './unfurl'
+
+const PUBLIC_IP = { address: '93.184.216.34', family: 4 }
+const PRIVATE_IP = { address: '127.0.0.1', family: 4 }
+
+function htmlResponse(html: string) {
+  return new Response(html, {
+    status: 200,
+    headers: { 'content-type': 'text/html' },
+  })
+}
+
+function redirectResponse(location: string) {
+  return new Response(null, {
+    status: 302,
+    headers: { location },
+  })
+}
+
+beforeEach(() => {
+  mockLookup.mockReset()
+  // Default: every hostname is public unless a test overrides it.
+  mockLookup.mockResolvedValue(PUBLIC_IP)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('unfurlUrl: SSRF gate', () => {
+  it.each([
+    ['file:///etc/passwd'],
+    ['ftp://example.com/x'],
+    ['javascript:alert(1)'],
+    ['data:text/html,<script>'],
+  ])('rejects non-http(s) scheme %s without fetching', async (input) => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await unfurlUrl(input)
+
+    expect(result.success).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects URLs with embedded credentials', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await unfurlUrl('http://user:pass@example.com/')
+
+    expect(result.success).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects hostnames that resolve to a private/loopback IP', async () => {
+    mockLookup.mockResolvedValue(PRIVATE_IP)
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await unfurlUrl('http://internal.local/')
+
+    expect(result.success).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a redirect that lands on a non-http(s) scheme', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('file:///etc/passwd'))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await unfurlUrl('https://example.com/')
+
+    expect(result.success).toBe(false)
+    // First hop fetched, redirect target rejected before second fetch.
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a redirect chain ending at a private IP', async () => {
+    mockLookup.mockImplementation(async (host: string) =>
+      host === 'evil.example' ? PRIVATE_IP : PUBLIC_IP,
+    )
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('https://evil.example/'))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await unfurlUrl('https://example.com/')
+
+    expect(result.success).toBe(false)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a redirect that introduces credentials', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('https://user:pass@example.com/'))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await unfurlUrl('https://example.com/')
+
+    expect(result.success).toBe(false)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts a normal https URL and returns parsed metadata', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse('<html><head><title>Hello</title></head></html>'),
+      )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await unfurlUrl('https://example.com/')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.title).toBe('Hello')
+    }
+  })
+})
+
+describe('unfurlUrl: entity decoding', () => {
+  it('decodes HTML entities in a single pass', async () => {
+    // Input has `&amp;lt;` — that's a literal `&lt;` after one decode pass.
+    // A naive sequential `.replace(&amp;).replace(&lt;)` would over-decode it
+    // to `<`, opening an XSS path for downstream renderers.
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(
+          '<html><head><title>foo &amp;lt;bar&amp;gt; baz</title></head></html>',
+        ),
+      )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await unfurlUrl('https://example.com/')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.title).toBe('foo &lt;bar&gt; baz')
+    }
+  })
+})

--- a/happyhq/lib/actions/unfurl.ts
+++ b/happyhq/lib/actions/unfurl.ts
@@ -90,6 +90,33 @@ async function isPrivateIp(hostname: string): Promise<boolean> {
 }
 
 /**
+ * Parse user-supplied input into a URL, defaulting to https:// when no scheme
+ * is present. Any value that can't be coerced into a valid URL returns null.
+ */
+function parseInputUrl(input: string): URL | null {
+  const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(input)
+  const candidate = hasScheme ? input : `https://${input}`
+  try {
+    return new URL(candidate)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * SSRF gate: only http(s), no embedded credentials, hostname must not resolve
+ * to a private/loopback range. Applied to the initial URL and every redirect
+ * target so a 302 can't slip past the initial check.
+ */
+async function validateUrl(parsed: URL | null): Promise<URL | null> {
+  if (!parsed) return null
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  if (parsed.username || parsed.password) return null
+  if (await isPrivateIp(parsed.hostname)) return null
+  return parsed
+}
+
+/**
  * Resolve a potentially relative URL to an absolute URL
  */
 function resolveUrl(href: string, baseUrl: string): string {
@@ -104,17 +131,24 @@ function resolveUrl(href: string, baseUrl: string): string {
   }
 }
 
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&nbsp;': ' ',
+}
+
 /**
- * Decode common HTML entities
+ * Decode common HTML entities in a single pass so already-decoded entities in
+ * the input (e.g. `&amp;lt;` meaning a literal `&lt;`) are not re-decoded.
  */
 function decodeHtmlEntities(str: string): string {
-  return str
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
+  return str.replace(
+    /&(?:amp|lt|gt|quot|#39|nbsp);/g,
+    (match) => HTML_ENTITIES[match] ?? match,
+  )
 }
 
 /**
@@ -122,23 +156,21 @@ function decodeHtmlEntities(str: string): string {
  */
 export async function unfurlUrl(url: string): Promise<UnfurlResponse> {
   try {
-    const normalizedUrl = url.match(/^https?:\/\//) ? url : `https://${url}`
-    const hostname = new URL(normalizedUrl).hostname
-
-    if (await isPrivateIp(hostname)) {
+    let current = await validateUrl(parseInputUrl(url))
+    if (!current) {
       return { success: false, error: 'Invalid URL' }
     }
 
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 5000)
 
-    // Follow redirects manually to validate each target against SSRF
-    let currentUrl = normalizedUrl
+    // Follow redirects manually so the same SSRF/scheme/credential gate
+    // applies to every hop, not just the initial URL.
     const maxRedirects = 5
     let response: Response | undefined
 
     for (let i = 0; i <= maxRedirects; i++) {
-      response = await fetch(currentUrl, {
+      response = await fetch(current.href, {
         signal: controller.signal,
         redirect: 'manual',
         headers: {
@@ -148,22 +180,23 @@ export async function unfurlUrl(url: string): Promise<UnfurlResponse> {
         },
       })
 
-      // Not a redirect — done
       if (response.status < 300 || response.status >= 400) break
 
       const location = response.headers.get('location')
       if (!location) break
 
-      // Resolve relative redirect URLs
-      const redirectUrl = new URL(location, currentUrl).href
-      const redirectHostname = new URL(redirectUrl).hostname
-
-      // SSRF check on redirect target
-      if (await isPrivateIp(redirectHostname)) {
+      let redirectParsed: URL | null
+      try {
+        redirectParsed = new URL(location, current.href)
+      } catch {
         return { success: false, error: 'Invalid URL' }
       }
 
-      currentUrl = redirectUrl
+      const next = await validateUrl(redirectParsed)
+      if (!next) {
+        return { success: false, error: 'Invalid URL' }
+      }
+      current = next
     }
 
     clearTimeout(timeout)
@@ -209,15 +242,15 @@ export async function unfurlUrl(url: string): Promise<UnfurlResponse> {
 
     const imageRaw =
       html.match(OG_IMAGE_REGEX)?.[1] || html.match(OG_IMAGE_REGEX_ALT)?.[1]
-    const image = imageRaw ? resolveUrl(imageRaw, normalizedUrl) : null
+    const image = imageRaw ? resolveUrl(imageRaw, current.href) : null
 
     const faviconRaw =
       html.match(FAVICON_REGEX)?.[1] ||
       html.match(FAVICON_REGEX_ALT)?.[1] ||
       html.match(SHORTCUT_ICON_REGEX)?.[1]
     const favicon = faviconRaw
-      ? resolveUrl(faviconRaw, normalizedUrl)
-      : `https://www.google.com/s2/favicons?domain=${new URL(normalizedUrl).hostname}&sz=32`
+      ? resolveUrl(faviconRaw, current.href)
+      : `https://www.google.com/s2/favicons?domain=${current.hostname}&sz=32`
 
     return {
       success: true,


### PR DESCRIPTION
Closes #91

## Why

`lib/actions/unfurl.ts` fetches user-supplied URLs (link paste, web input). CodeQL flagged two issues that survived the existing private-IP check:

- **SSRF (`js/request-forgery`).** Pre-fix, the only protocol gate was a regex that prepended `https://` when the input didn't start with `http(s)://`. That left `file://`, `ftp://`, embedded credentials (`http://user:pass@host`), and redirect targets that switched scheme/credentials all reachable. `isPrivateIp` blocked private hostnames, but a same-public-DNS `file:///etc/passwd`-style URL (or a 302 to one) still hit `fetch`.
- **Double-decoding (`js/double-escaping`).** `decodeHtmlEntities` ran sequential `.replace()` calls. `&amp;lt;` (a literal `&lt;` after one decode) became `&lt;` then `<`, smuggling tag-like content into title/description for downstream renderers.

## What changed

- New `parseInputUrl` + `validateUrl` gate the initial URL on scheme (`http:`/`https:` only), rejects embedded credentials, and runs the existing `isPrivateIp` check. The same gate now runs on every redirect target before assignment, and `fetch` uses the validated `URL.href`.
- `decodeHtmlEntities` now does one pass with a single regex + lookup table, so an entity introduced by an earlier replacement can't be re-decoded.

## Regression test

`happyhq/lib/actions/unfurl.test.ts` (new, 11 tests) — covers non-http(s) schemes, embedded credentials, private-IP hostnames, redirect-to-bad-scheme, redirect-to-private-IP, redirect-introducing-credentials, the happy path, and the single-pass decoding contract. Each SSRF-gate test asserts `fetch` was not called past the rejection point — that's the contract that catches the bug, regardless of which validator implementation enforces it.

## Verified

- `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` (1400 pass) all green from `happyhq/`.

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.