### PR TITLE
fix: drop dead truthy checks on stream in /api/run/start

### DIFF
--- a/happyhq/app/api/run/start/route.ts
+++ b/happyhq/app/api/run/start/route.ts
@@ -34,6 +34,7 @@ export async function POST(request: Request) {
       { status: 400 },
     )
   }
+  const planAcceptedMessage = `[${stream}/${task}] Plan accepted`
 
   // Verify task directory exists on filesystem (always root)
   const content = await readTaskContent(task)
@@ -78,8 +79,7 @@ export async function POST(request: Request) {
         const result = await canStartTask(userId)
         if (!result.allowed) {
           if (mode === 'working' && content.run?.status !== 'stopped') {
-            const prefix = stream ? `${stream}/` : ''
-            commitGitState(`[${prefix}${task}] Plan accepted`)
+            commitGitState(planAcceptedMessage)
             const now = new Date().toISOString()
             const runInfo: RunInfo = {
               status: 'stopped',
@@ -116,7 +116,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    await startRun(stream ?? '', task, mode, userId, body.resume)
+    await startRun(stream, task, mode, userId, body.resume)
   } catch (error) {
     if (error instanceof Error && error.message.includes('already active')) {
       return Response.json({ error: error.message }, { status: 409 })
@@ -138,8 +138,7 @@ export async function POST(request: Request) {
   // Placed after startRun so a failed start (409) doesn't create a stale commit.
   // Skip when resuming from stopped — plan was already accepted.
   if (mode === 'working' && content.run?.status !== 'stopped') {
-    const prefix = stream ? `${stream}/` : ''
-    commitGitState(`[${prefix}${task}] Plan accepted`)
+    commitGitState(planAcceptedMessage)
   }
 
   return Response.json({


### PR DESCRIPTION
## Why

CodeQL flagged three "useless conditional" findings on `stream` in `happyhq/app/api/run/start/route.ts`. The handler early-returns 400 when `!stream`, which narrows `stream` to a non-empty string for the rest of the function. The subsequent `stream ? \`${stream}/\` : ''` fallbacks (L81, L141) and the `stream ?? ''` guard at the `startRun` call (L119) could never take their alternate branch. They're leftovers from before the early return existed and mislead readers into thinking the handler still tolerates a missing stream.

## Change

- Lifted the duplicated `[${stream}/${task}] Plan accepted` template into a single `planAcceptedMessage` const declared right after the early return, used at both call sites.
- Pass `stream` to `startRun` directly (its signature is already `streamName: string`).

## Tests

No new regression test. The meaningful contract — "missing stream returns 400" — is already pinned by `app/api/run/start/route.test.ts` ("returns 400 when stream is missing"). The removed branches are unreachable under TypeScript's narrowing; a test asserting "the dead branch is gone" would only catch a literal revert (vanity test per `bugs-rubric.md` guideline #3).

## Verification

From `happyhq/`:

- `pnpm format`
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm check-types` — clean
- `pnpm test` — 120 files / 1404 tests pass

Closes #97

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.