### PR TITLE
test: cover positive render branch of TaskSetupChecklist

### DIFF
--- a/happyhq/components/features/chat/interaction/task-setup-checklist.test.tsx
+++ b/happyhq/components/features/chat/interaction/task-setup-checklist.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const useTaskStatus = vi.hoisted(() => vi.fn())
@@ -44,5 +44,14 @@ describe('TaskSetupChecklist', () => {
     const { container } = render(<TaskSetupChecklist />)
 
     expect(container.firstChild).toBeNull()
+  })
+
+  it('renders one actionable step per setup field when the task is ready', async () => {
+    setupReady()
+    const { TaskSetupChecklist } = await import('./task-setup-checklist')
+
+    render(<TaskSetupChecklist />)
+
+    expect(screen.getAllByRole('button')).toHaveLength(3)
   })
 })


### PR DESCRIPTION
## Summary

Closes #98

The existing `task-setup-checklist.test.tsx` only covered the hide branch (`taskStatus === 'working'` → component returns `null`). The positive render branch — that the checklist actually presents the user with three actionable setup steps when the task is in the ready state — had no test, so a regression that broke that branch (returning null inappropriately, rendering an empty wrapper, losing the buttons) would slip through.

## Why this shape of test

The issue body sketched assertions on hardcoded copy text (`'Name your task'`, etc.) using `toBeInTheDocument()`. Two reasons the implementation diverges from that sketch:

1. `@testing-library/jest-dom` is not installed (per `happyhq/testing.md`), so `toBeInTheDocument()` would not compile.
2. `testing.md` explicitly lists "specific UI copy" under **Don't test these** — copy assertions break on copy tweaks without catching real behavior regressions.

The user-visible contract being defended is "in the ready state, the user is presented with one actionable step per setup field." Asserting `screen.getAllByRole('button')` returns 3 captures that contract structurally: it fails on null returns, empty wrappers, and lost buttons, while remaining stable across copy/styling changes.

## Test plan

- [x] `pnpm --filter=happyhq test task-setup-checklist` — both tests pass
- [x] `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` — full suite green (1405 tests)

Regression test: `happyhq/components/features/chat/interaction/task-setup-checklist.test.tsx:49`

## AI assistance disclosure

Authored by Ralphie, the autonomous bug-fix loop (Claude Opus 4.7). Reviewed by maintainer before merge.