### PR TITLE
chore: add --override flag to bugs.sh

### DIFF
--- a/happyhq/.dev/PROMPT_bugs_fix.md
+++ b/happyhq/.dev/PROMPT_bugs_fix.md
@@ -26,7 +26,9 @@
 
 10. ${DRY_RUN_NOTE}
 
-11. Exit.
+11. ${OVERRIDE_NOTE}
+
+12. Exit.
 
 **[1]** ONE issue per session. Do not pick up other issues, do not chain. The orchestrator handles the next one.
 **[2]** Hard constraints from @bugs-rubric.md are non-negotiable: never push to `main`, never modify `happyhq/ee/`, `.github/`, CI workflows, lockfiles (beyond what the focused fix demands), or licensing files. If the fix would require any of these, apply `ralphie:skip-out-of-scope` and exit.

--- a/happyhq/.dev/bugs.sh
+++ b/happyhq/.dev/bugs.sh
@@ -6,6 +6,7 @@ set -o pipefail
 #   ./bugs.sh --triage-only            # Phase 1 only
 #   ./bugs.sh --fix-only               # skip Phase 1, run the fix loop on the queue
 #   ./bugs.sh --issue 42               # skip triage; one fix session against #42
+#   ./bugs.sh --issue 42 --override    # bypass Ralphie's self-skip rules (size, repro, verification, out-of-scope)
 #   ./bugs.sh --dry-run                # Phase 1 preview only, no writes
 #   ./bugs.sh --issue 42 --dry-run     # preview a single fix session, no writes
 
@@ -22,6 +23,7 @@ TRIAGE_ONLY=0
 FIX_ONLY=0
 SINGLE_ISSUE=""
 DRY_RUN=""
+OVERRIDE=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -45,8 +47,12 @@ while [ $# -gt 0 ]; do
             DRY_RUN=1
             shift
             ;;
+        --override)
+            OVERRIDE=1
+            shift
+            ;;
         -h|--help)
-            sed -n '3,10p' "$0" | sed 's/^# \?//'
+            sed -n '3,11p' "$0" | sed 's/^# \?//'
             exit 0
             ;;
         *)
@@ -64,6 +70,10 @@ if [ $FIX_ONLY -eq 1 ] && [ -n "$DRY_RUN" ]; then
     echo "Error: --fix-only --dry-run isn't supported (dry-run on fixes wastes a real session). Use --issue <#> --dry-run to preview a single fix." >&2
     exit 1
 fi
+if [ -n "$OVERRIDE" ] && [ -z "$SINGLE_ISSUE" ]; then
+    echo "Error: --override is only valid with --issue <#>. The Phase 2 auto-loop must always respect skip labels." >&2
+    exit 1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1
@@ -79,6 +89,12 @@ if [ -n "$DRY_RUN" ]; then
     export DRY_RUN_NOTE="**DRY RUN MODE**: For every action that would write to GitHub or the repo (labels, comments, branches, commits, pushes, PRs), print one line prefixed with 'DRY-RUN:' describing what you WOULD do, then SKIP the actual call. Do not invoke any 'gh issue edit', 'gh issue comment', 'gh pr create', 'git commit', 'git push', or filesystem write. Reads (gh issue view/list, code search, file reads) are fine."
 else
     export DRY_RUN_NOTE=""
+fi
+
+if [ -n "$OVERRIDE" ]; then
+    export OVERRIDE_NOTE="**OVERRIDE MODE**: The maintainer invoked --override on this single-issue session. Skip the soft self-skip checks: do NOT apply ralphie:skip-too-big, ralphie:skip-not-reproducible, ralphie:skip-verification-failed, or ralphie:skip-out-of-scope, and do NOT exit early on those conditions — push and open the PR anyway. Hard constraints from guardrail [2] (no push to main, no edits to happyhq/ee/, .github/, CI workflows, lockfiles beyond focused fix demands, or licensing files) remain non-negotiable. Note the override in the PR body's AI-disclosure paragraph: 'Maintainer invoked --override; size/repro/verification self-skip gates were bypassed.'"
+else
+    export OVERRIDE_NOTE=""
 fi
 
 run_session() {


### PR DESCRIPTION
## Why

Closes nothing — pure dev-loop ergonomics. When Ralphie's triage applies `ralphie:skip-too-big` (or any other `ralphie:skip-*`), there was no clean way for the maintainer to say "do this one anyway" short of removing the label and accepting that the fix prompt's own size gate at step 5 would still re-skip. This adds a single, explicit override.

## Design

- `--override` is only valid with `--issue <#>`. The Phase 2 auto-loop never overrides — it must always respect skip labels.
- Sets `OVERRIDE_NOTE` env var consumed by [PROMPT_bugs_fix.md](happyhq/.dev/PROMPT_bugs_fix.md) at step 11. The note tells Ralphie to skip the soft self-skip checks (size, not-reproducible, verification-failed, out-of-scope) and to push + open the PR anyway.
- **Hard constraints in guardrail [2]** (no push to main, no edits to `happyhq/ee/`, `.github/`, CI workflows, lockfiles beyond focused fix demands, or licensing files) remain **non-negotiable** regardless of override.
- The PR body must disclose the override in the AI-assistance paragraph.

The skip rules are labor-saving filters, not security boundaries — actual safety lives at PR review + CI + branch protection on `main`. The override only changes what reaches the PR stage; review and merge still gate the rest.

## Why a CLI flag, not a label

A GitHub label-based override could in principle be applied by anyone with the Triage role. The CLI flag keeps override authority on the maintainer's terminal — same machine that's already auth'd as them for `gh` and `git push`. Compromise of the repo's label state can't escalate.

## Test plan

- [ ] `./bugs.sh --override` (no `--issue`) errors out — confirmed locally
- [ ] `./bugs.sh --help` shows the new row — confirmed locally
- [ ] `./bugs.sh --issue <#> --override` will be exercised against #94 next

🤖 Generated with [Claude Code](https://claude.com/claude-code)