### PR TITLE
fix: drop unused locals and dead destructuring flagged by CodeQL

### DIFF
--- a/happyhq/app/(app)/tasks/[stream]/[task]/page.tsx
+++ b/happyhq/app/(app)/tasks/[stream]/[task]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({
 }: {
   params: Promise<{ stream: string; task: string }>
 }): Promise<Metadata> {
-  const { stream, task } = await params
+  const { task } = await params
   const taskMd = await readTaskMd(taskPath(task))
   const title = displayTitle(taskMd?.frontmatter.title ?? null, task)
   return { title: `${title} | HappyHQ` }

--- a/happyhq/app/(desktop)/[stream]/[task]/page.tsx
+++ b/happyhq/app/(desktop)/[stream]/[task]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({
 }: {
   params: Promise<{ stream: string; task: string }>
 }): Promise<Metadata> {
-  const { stream, task } = await params
+  const { task } = await params
   const taskMd = await readTaskMd(taskPath(task))
   return {
     title: `${displayTitle(taskMd?.frontmatter.title ?? null, task)} | HappyHQ`,

--- a/happyhq/app/api/chat/mode/route.ts
+++ b/happyhq/app/api/chat/mode/route.ts
@@ -4,7 +4,6 @@ import { log } from '@/lib/log.server'
 import path from 'path'
 
 interface ModeRequest {
-  streamSlug?: string
   sessionId: string
   mode: 'general' | 'learning'
   modeStreamSlug?: string
@@ -25,7 +24,7 @@ export async function POST(request: Request) {
     return Response.json({ error: 'Invalid JSON' }, { status: 400 })
   }
 
-  const { streamSlug, sessionId, mode, modeStreamSlug } = body
+  const { sessionId, mode, modeStreamSlug } = body
   if (!sessionId || (mode !== 'general' && mode !== 'learning')) {
     return Response.json({ error: 'Missing required fields' }, { status: 400 })
   }

--- a/happyhq/app/api/chat/stream-select/route.ts
+++ b/happyhq/app/api/chat/stream-select/route.ts
@@ -4,8 +4,6 @@ import { log } from '@/lib/log.server'
 import path from 'path'
 
 interface StreamSelectRequest {
-  /** The stream where the chat directory physically lives (origin stream). */
-  originStreamSlug?: string
   sessionId: string
   /** The stream the user selected (null = "something new"). */
   selectedStreamSlug: string | null
@@ -25,7 +23,7 @@ export async function POST(request: Request) {
     return Response.json({ error: 'Invalid JSON' }, { status: 400 })
   }
 
-  const { originStreamSlug, sessionId, selectedStreamSlug } = body
+  const { sessionId, selectedStreamSlug } = body
   if (!sessionId) {
     return Response.json({ error: 'Missing required fields' }, { status: 400 })
   }

--- a/happyhq/app/api/fs/task/route.test.ts
+++ b/happyhq/app/api/fs/task/route.test.ts
@@ -68,7 +68,6 @@ describe('GET /api/fs/task', () => {
     const response = await GET(
       makeRequest({ stream: 'some-stream', task: 'my-task' }),
     )
-    const body = await response.json()
 
     expect(response.status).toBe(200)
     // Verify readTaskContent was called with just the task slug

--- a/happyhq/components/features/desktop/hooks/use-chat-actions.test.ts
+++ b/happyhq/components/features/desktop/hooks/use-chat-actions.test.ts
@@ -54,8 +54,6 @@ describe('useChatActions contracts', () => {
   let chatStore: UseBoundStore<StoreApi<ChatState>>
   let sessionIdRef: { current: string | null }
 
-  const desktopStore = useDesktopStore
-
   beforeEach(() => {
     vi.clearAllMocks()
     fetchSpy.mockResolvedValue({ ok: true, status: 200, json: () => ({}) })

--- a/happyhq/components/features/desktop/shell.tsx
+++ b/happyhq/components/features/desktop/shell.tsx
@@ -82,7 +82,7 @@ export function DesktopShell({ children }: { children: ReactNode }) {
   const [desktopExpanded, setDesktopExpanded] = useDesktopExpanded()
   const [islandHidden, setIslandHidden] = useIslandHidden()
 
-  const [sidebarOpen, setSidebarOpen] = useSidebarOpen(openPanel.type)
+  const [sidebarOpen] = useSidebarOpen(openPanel.type)
 
   // ── Windows ───────────────────────────────────────────────────────
   const canvasRef = useRef<HTMLDivElement>(null)

--- a/happyhq/components/features/desktop/windows/email/email-window.tsx
+++ b/happyhq/components/features/desktop/windows/email/email-window.tsx
@@ -4,7 +4,6 @@ import type { EmailMetadata } from '@/lib/eml/types'
 import { useWindowStore } from '@/stores/windowStore'
 import { Loader2, Paperclip } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { getFileType } from '../shared/file-icon'
 import type { WindowComponentProps } from '../types'
 import { useFrameProps } from '../use-frame-props'
 import { WindowFileActions } from '../window-file-actions'
@@ -144,36 +143,24 @@ export function EmailWindow({
           {email.attachments.length > 0 && (
             <div className="shrink-0 border-t border-zinc-200 px-4 py-2.5">
               <div className="flex flex-wrap gap-1.5">
-                {email.attachments.map((filename) => {
-                  const isImage = getFileType(filename) === 'image'
-                  return (
-                    <button
-                      key={filename}
-                      type="button"
-                      onClick={() => {
-                        if (!dirPath) return
-                        const filePath = `${dirPath}/${filename}`
-                        if (isImage) {
-                          // Open a simple image window
-                          const imgWindowId = `file-${filePath}`
-                          openFileWindow({
-                            name: filename,
-                            path: filePath,
-                          })
-                        } else {
-                          openFileWindow({
-                            name: filename,
-                            path: filePath,
-                          })
-                        }
-                      }}
-                      className="flex items-center gap-1.5 rounded-md bg-zinc-100 px-2.5 py-1.5 text-xs text-zinc-600 transition-colors hover:bg-zinc-200"
-                    >
-                      <Paperclip className="h-3 w-3 text-zinc-400" />
-                      {filename}
-                    </button>
-                  )
-                })}
+                {email.attachments.map((filename) => (
+                  <button
+                    key={filename}
+                    type="button"
+                    onClick={() => {
+                      if (!dirPath) return
+                      const filePath = `${dirPath}/${filename}`
+                      openFileWindow({
+                        name: filename,
+                        path: filePath,
+                      })
+                    }}
+                    className="flex items-center gap-1.5 rounded-md bg-zinc-100 px-2.5 py-1.5 text-xs text-zinc-600 transition-colors hover:bg-zinc-200"
+                  >
+                    <Paperclip className="h-3 w-3 text-zinc-400" />
+                    {filename}
+                  </button>
+                ))}
               </div>
             </div>
           )}

--- a/happyhq/components/features/tasks/card/attachments-section.tsx
+++ b/happyhq/components/features/tasks/card/attachments-section.tsx
@@ -16,12 +16,11 @@ export function AttachmentsSection() {
   const visibleInputs =
     content?.inputs.filter((i) => i.name !== 'context') ?? []
 
-  const { pendingFiles, isUploading, handleFiles, fileInputRef } =
-    useOptimisticUploads({
-      taskSlug,
-      refresh,
-      resolvedNames: visibleInputs.map((i) => i.name),
-    })
+  const { pendingFiles, handleFiles, fileInputRef } = useOptimisticUploads({
+    taskSlug,
+    refresh,
+    resolvedNames: visibleInputs.map((i) => i.name),
+  })
 
   const handleDeleteInput = useCallback(
     async (inputName: string) => {

--- a/happyhq/components/features/tasks/card/index.tsx
+++ b/happyhq/components/features/tasks/card/index.tsx
@@ -7,7 +7,7 @@ import { useCurrentUser } from '@/lib/accounts/hooks'
 import { ingestTaskInput } from '@/lib/actions'
 import type { TaskItem } from '@/lib/fs/types'
 import { useTaskStore } from '@/stores/taskStore'
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import { useTaskData } from '../hooks/use-task-data'
 import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
 import { AttachmentsSection } from './attachments-section'
@@ -53,7 +53,6 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
   const isIdle = !runStatus
   const isPlanning = runStatus === 'planning'
   const isWorking = runStatus === 'working'
-  const isFinished = runStatus === 'completed' || runStatus === 'stopped'
   const isStopped = runStatus === 'stopped'
   const stoppedDuringPlanning =
     isStopped && content?.run?.stoppedDuring === 'planning'
@@ -75,12 +74,10 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
     (hasDescription || visibleInputs.length > 0)
 
   // ── Drag-and-drop file upload ─────────────────────────────────────
-  const [isUploading, setIsUploading] = useState(false)
   const handleFiles = useCallback(
     async (files: FileList) => {
       const fileList = Array.from(files)
       if (fileList.length === 0) return
-      setIsUploading(true)
       try {
         for (const file of fileList) {
           const formData = new FormData()
@@ -101,8 +98,6 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
         toastError(
           'Something went wrong adding this file. Files must be under 100MB.',
         )
-      } finally {
-        setIsUploading(false)
       }
     },
     [taskSlug, token, refresh],

--- a/happyhq/components/features/tasks/panel/index.tsx
+++ b/happyhq/components/features/tasks/panel/index.tsx
@@ -16,7 +16,6 @@ import { useBillingData } from '@/components/features/billing/use-billing-data'
 import {
   useActiveTask,
   useDesktopMutate,
-  useStreamTitle,
   useTaskContent,
   useTaskStatus,
 } from '@/components/features/desktop/hooks/use-desktop-data'
@@ -89,7 +88,6 @@ export function TaskPanel({
   const { mutate } = useSWRConfig()
   const taskContent = useTaskContent()
   const streamSlug = useStreamSlug()
-  const streamTitle = useStreamTitle()
   const runActions = useRunActions()
   const refresh = useDesktopMutate()
   const streams = useStreams()

--- a/happyhq/hooks/use-stick-to-bottom.ts
+++ b/happyhq/hooks/use-stick-to-bottom.ts
@@ -14,7 +14,6 @@ interface UseStickToBottomReturn {
 export function useStickToBottom(): UseStickToBottomReturn {
   // Store actual DOM elements in state so effects re-run when they mount/unmount
   const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null)
-  const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null)
   const [isAtBottom, setIsAtBottom] = useState(true)
   const isAtBottomRef = useRef(true)
 
@@ -23,10 +22,9 @@ export function useStickToBottom(): UseStickToBottomReturn {
     (el: HTMLDivElement | null) => setScrollEl(el),
     [],
   )
-  const contentRef = useCallback(
-    (el: HTMLDivElement | null) => setContentEl(el),
-    [],
-  )
+  // contentRef is exposed for callers that attach it to their content div, but
+  // the hook itself observes scrollEl rather than the content node.
+  const contentRef = useCallback((_el: HTMLDivElement | null) => {}, [])
 
   // Imperative scroll — for chat switches, initial load, or a future button
   const scrollToBottom = useCallback(

--- a/happyhq/lib/agents/prompts.server.ts
+++ b/happyhq/lib/agents/prompts.server.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 import { HAPPYHQ_ROOT } from '@/lib/constants.server'
@@ -128,33 +128,6 @@ export function learningLayerPrompt(streamName: string): string {
     .replaceAll('{{STREAM_NAME}}', streamName)
     .replaceAll('{{STREAM_SLUG}}', streamName)
     .replaceAll('{{Q_PATH}}', qPath())
-}
-
-/**
- * Pick the agent-readable extracted file inside a directory containing a
- * binary original. Each file type has its own extracted form:
- *   PDF  → raw.txt  (plain text extraction)
- *   EML  → email.json (structured email metadata)
- *
- * Fallback: any .md/.txt, then any non-hidden file so the agent at least
- * knows the input exists.
- *
- * Returns the filename (not full path), or null if directory is empty/unreadable.
- */
-function resolveReadable(dirPath: string): string | null {
-  if (existsSync(path.join(dirPath, 'content.md'))) return 'content.md'
-  if (existsSync(path.join(dirPath, 'raw.txt'))) return 'raw.txt'
-  if (existsSync(path.join(dirPath, 'email.json'))) return 'email.json'
-  try {
-    const all = readdirSync(dirPath).filter((n) => !n.startsWith('.'))
-    const text = all.filter((n) => n.endsWith('.md') || n.endsWith('.txt'))
-    if (text.length > 0) return text[0]
-    // Fallback: return the original file so the agent at least knows it exists
-    if (all.length > 0) return all[0]
-  } catch {
-    // skip unreadable
-  }
-  return null
 }
 
 /**

--- a/happyhq/lib/agents/tools.server.ts
+++ b/happyhq/lib/agents/tools.server.ts
@@ -182,7 +182,7 @@ export function createQsMcpServer(
           const originalPath = path.join(sampleDir, originalFile)
 
           // 5. Extract agent-readable form if not already present
-          //    PDF → raw.txt, EML → email.json, DOCX → content.md (see resolveReadable)
+          //    PDF → raw.txt, EML → email.json, DOCX → content.md
           const hasExtracted =
             fs.existsSync(path.join(sampleDir, 'raw.txt')) ||
             fs.existsSync(path.join(sampleDir, 'email.json')) ||

--- a/happyhq/lib/format.test.ts
+++ b/happyhq/lib/format.test.ts
@@ -107,10 +107,6 @@ describe('generateTaskSlug', () => {
   it('works with special characters in title', () => {
     const slug = generateTaskSlug('Q&A — Draft #3')
     expect(slug).toMatch(/^q-a-draft-3-/)
-    const suffix = slug.slice(slug.lastIndexOf('-') + 1)
-    // The suffix is the last 8 chars after the final hyphen... but wait,
-    // the title "q-a-draft-3" has hyphens too. Let's just verify the full
-    // slug ends with an 8-char Crockford suffix.
     const fullSuffix = slug.slice('q-a-draft-3-'.length)
     expect(fullSuffix).toHaveLength(9)
     expect(fullSuffix).toMatch(CROCKFORD_RE)

--- a/happyhq/lib/git/log.server.ts
+++ b/happyhq/lib/git/log.server.ts
@@ -8,7 +8,6 @@ export interface GitLogEntry {
   date: string
 }
 
-const SEPARATOR = '---GIT-LOG-SEP---'
 const FIELD_SEP = '---FIELD---'
 
 /**

--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -641,7 +641,6 @@ async function runWorkingLoop(
   taskRunId?: string | null,
   remainingBudgetUsd?: number,
 ): Promise<RunInfo['status']> {
-  const taskDir = taskPath(taskName)
   const config = resolveConfig(await readConfig())
   const maxIterations = config.limits.maxIterations
 

--- a/happyhq/specs/input-types.md
+++ b/happyhq/specs/input-types.md
@@ -19,7 +19,7 @@ Every input type follows the same structure on disk:
   {additional files...}   # Optional — e.g., attachments extracted from an email
 ```
 
-The **original** is the source of truth. The **extracted form** is the agent-readable version — what `resolveReadable()` returns and what the agent reads first. The extracted form varies by type because different formats have different structures worth preserving.
+The **original** is the source of truth. The **extracted form** is the agent-readable version — what `listFileItems()` records as `rawPath` and what the agent reads first. The extracted form varies by type because different formats have different structures worth preserving.
 
 ## Current Input Types
 
@@ -118,7 +118,7 @@ When adding support for a new file format:
 
 3. **Update ProcessSample** — Add the new extension to the `supportedExts` array in `tools.server.ts`. Add an extraction branch in the fallback section.
 
-4. **Update resolveReadable** — Add the new extracted filename to `resolveReadable()` in `lib/agents/prompts.server.ts` and update `listFileItems()` in `lib/fs/read.server.ts` to recognise it.
+4. **Update listFileItems** — Update `listFileItems()` in `lib/fs/read.server.ts` to recognise the new extracted filename (so `rawPath` points at it).
 
 5. **Composer** — Add the extension to `accept` and the drag-drop filter in `composer.tsx`. Add the file type to `FileIcon` in `file-icon.tsx`.
 
@@ -138,8 +138,8 @@ When adding support for a new file format:
 | `lib/pdf/extract-text.server.ts`                             | PDF text extraction                                                     |
 | `lib/actions.ts`                                             | `uploadFile()` / `ingestFile()` — wires extraction into upload pipeline |
 | `lib/agents/tools.server.ts`                                 | `ProcessSample` — validates extensions, fallback extraction             |
-| `lib/agents/prompts.server.ts`                               | `resolveReadable()` — picks agent-readable file per directory           |
-| `lib/fs/read.server.ts`                                      | `listFileItems()` — discovers extracted form for UI (`rawPath` field)   |
+| `lib/agents/prompts.server.ts`                               | `buildReadingList()` — emits agent-readable paths for prompts           |
+| `lib/fs/read.server.ts`                                      | `listFileItems()` — discovers extracted form (`rawPath` field)          |
 | `components/features/chat/composer.tsx`                      | File accept filter + drag-drop filter + `FileCard` icon                 |
 | `components/features/desktop/windows/shared/file-icon.tsx`   | `getFileType()` + icon/color mapping                                    |
 | `components/features/desktop/windows/use-desktop-windows.ts` | `openFileWindow()` — routes by extension                                |

--- a/happyhq/specs/prompts.md
+++ b/happyhq/specs/prompts.md
@@ -131,7 +131,7 @@ Tasks: write-sow (completed, has plan)
 
 For a brand-new stream: `"This is a brand new stream. No playbook, specs, samples, or uploads yet."`
 
-**`{{READING_LIST}}`** (planning and working prompts). A server-built list of exact file paths the agent should read, replacing the old `{{CONTEXT}}` presence summary. Built by `buildReadingList()` in `lib/agents/prompts.server.ts`, which walks the stream's specs, samples, and task inputs to produce a bulleted markdown list of concrete paths. For each directory (samples, inputs), `resolveReadable()` picks the agent-readable extracted form of the file — each input type has its own convention:
+**`{{READING_LIST}}`** (planning and working prompts). A server-built list of exact file paths the agent should read, replacing the old `{{CONTEXT}}` presence summary. Built by `buildReadingList()` in `lib/agents/prompts.server.ts`, which walks the stream's specs, samples, and task inputs to produce a bulleted markdown list of concrete paths. For samples and inputs, the entry's `rawPath` (set by `listFileItems()`) points at the agent-readable extracted form — each input type has its own convention:
 
 - **PDF** → `raw.txt` (plain text extraction via pdfium)
 - **EML** → `email.json` (structured email metadata: subject, from, to, body, attachments)


### PR DESCRIPTION
## Summary

Closes #94

CodeQL flagged 17 cases of unused variables, destructured-but-not-read fields, dead `useState` setters, and one orphaned function. Each one is small, but together they make the code harder to read — readers have to mentally track values that don't matter, and they bury more interesting CodeQL findings in noise. This PR sweeps them all in one pass since they're the same shape.

The orphaned `resolveReadable()` in `lib/agents/prompts.server.ts` was no longer called by `buildReadingList()` (which now uses `s.rawPath` set by `listFileItems()` directly). Removing the dead function meant patching three references — `specs/input-types.md`, `specs/prompts.md`, and a comment in `lib/agents/tools.server.ts` — to point at the actual mechanism (`listFileItems()`'s `rawPath` field) instead of a function that no longer exists.

A few collateral simplifications followed naturally once a binding was removed:
- `email-window.tsx`: removing the unused `imgWindowId` collapsed two identical branches; `isImage`/`getFileType` then became dead too.
- `tasks/card/index.tsx`: `isUploading` value was unread, so the whole `useState` (and the setter calls in `handleFiles`) went; `useState` import dropped.
- `hooks/use-stick-to-bottom.ts`: the `contentEl` state had no readers, so the state went; `contentRef` is now a no-op callback, kept to preserve the public API used by chat surfaces.

## Test plan

- [x] `pnpm format` from repo root — clean
- [x] `pnpm lint` from `happyhq/` — no warnings or errors
- [x] `pnpm check-types` from `happyhq/` — clean
- [x] `pnpm --filter=happyhq test` — 1416/1416 passing

No regression test added: per the rubric's litmus test ("what bug would this catch?"), the only bug a regression test could catch here is "someone reverted this exact deletion", which is a vanity test. The fixes are mechanical dead-code removals validated by type-checking and the existing test suite.

## AI assistance disclosure

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge. Maintainer invoked `--override`; size/repro/verification self-skip gates were bypassed for this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)