### PR TITLE
chore: exclude *.md/*.mdx from bugs.sh size gate

### DIFF
--- a/happyhq/.dev/PROMPT_bugs_fix.md
+++ b/happyhq/.dev/PROMPT_bugs_fix.md
@@ -10,7 +10,7 @@
 
 4. **Verify.** From the `happyhq/` directory, run `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test`. If any fail, fix and re-run. If they fail twice, apply `ralphie:skip-verification-failed` (rubric rule 8), post the rubric-shaped comment with the failing output included, exit.
 
-5. **Size gate.** After the fix is in, check the diff: `git diff --stat main...HEAD`. If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` (rubric rule 6/9), post the rubric-shaped comment summarizing what the fix would have entailed, leave the branch in place (do not push), exit.
+5. **Size gate.** After the fix is in, check the diff: `git diff --stat main...HEAD -- ':!*.md' ':!*.mdx'`. If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` (rubric rule 6/9), post the rubric-shaped comment summarizing what the fix would have entailed, leave the branch in place (do not push), exit. Spec/doc updates (`*.md`/`*.mdx`) are excluded from the count — they don't carry the same review burden as code, and bundling them with the fix keeps design and implementation in sync.
 
 6. **Commit.** `git add -A && git commit -m "fix: <one-line summary>\n\nCloses #${ISSUE_NUMBER}"`.
 

--- a/happyhq/.dev/bugs-rubric.md
+++ b/happyhq/.dev/bugs-rubric.md
@@ -12,17 +12,17 @@ Source of truth for how Ralphie judges open `bug`-labeled issues. Both `PROMPT_b
 
 Apply in order — bail at the earliest stop. The first six are evaluable from the issue text alone (Phase 1 — triage). The last three only show up after attempting a fix (Phase 2).
 
-| #   | Condition                                                                                              | Label applied                      | What unblocks it                                                      |
-| --- | ------------------------------------------------------------------------------------------------------ | ---------------------------------- | --------------------------------------------------------------------- |
-| 1   | Fix would touch `happyhq/ee/`                                                                          | `ralphie:skip-ee`                  | Maintainer decides whether to take it on; remove label after deciding |
-| 2   | Author is not OWNER/MEMBER and the report lacks repro details a third party would need to provide      | `ralphie:skip-third-party-unclear` | Add repro details or escalate; remove label                           |
-| 3   | Issue body or comments contain unresolved questions for the maintainer                                 | `ralphie:skip-needs-decision`      | Answer the question in a comment, remove label                        |
-| 4   | Requires a schema migration, new env var, new dependency, or `.github/`/CI/workflow change             | `ralphie:skip-out-of-scope`        | Maintainer scopes and does it; remove label if the work was decoupled |
-| 5   | No reasonable repro can be inferred from issue + linked logs                                           | `ralphie:skip-not-reproducible`    | Reporter or maintainer adds repro/logs, remove label                  |
-| 6   | Estimated >10 files or >300 LoC after a quick code search                                              | `ralphie:skip-too-big`             | Scope it down (split issue) or do it manually                         |
-| 7   | (Phase 2) Repro could not be established locally                                                       | `ralphie:skip-not-reproducible`    | Same as #5                                                            |
-| 8   | (Phase 2) `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` failed twice | `ralphie:skip-verification-failed` | Read the comment Ralphie left; fix locally                            |
-| 9   | (Phase 2) Fix shipped                                                                                  | `ralphie:fixed-in-pr`              | Terminal — the linked PR closes the loop                              |
+| #   | Condition                                                                                                                         | Label applied                      | What unblocks it                                                      |
+| --- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------- |
+| 1   | Fix would touch `happyhq/ee/`                                                                                                     | `ralphie:skip-ee`                  | Maintainer decides whether to take it on; remove label after deciding |
+| 2   | Author is not OWNER/MEMBER and the report lacks repro details a third party would need to provide                                 | `ralphie:skip-third-party-unclear` | Add repro details or escalate; remove label                           |
+| 3   | Issue body or comments contain unresolved questions for the maintainer                                                            | `ralphie:skip-needs-decision`      | Answer the question in a comment, remove label                        |
+| 4   | Requires a schema migration, new env var, new dependency, or `.github/`/CI/workflow change                                        | `ralphie:skip-out-of-scope`        | Maintainer scopes and does it; remove label if the work was decoupled |
+| 5   | No reasonable repro can be inferred from issue + linked logs                                                                      | `ralphie:skip-not-reproducible`    | Reporter or maintainer adds repro/logs, remove label                  |
+| 6   | Estimated >10 files or >300 LoC after a quick code search (excludes `*.md`/`*.mdx` — spec/doc updates don't count toward the cap) | `ralphie:skip-too-big`             | Scope it down (split issue) or do it manually                         |
+| 7   | (Phase 2) Repro could not be established locally                                                                                  | `ralphie:skip-not-reproducible`    | Same as #5                                                            |
+| 8   | (Phase 2) `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` failed twice                            | `ralphie:skip-verification-failed` | Read the comment Ralphie left; fix locally                            |
+| 9   | (Phase 2) Fix shipped                                                                                                             | `ralphie:fixed-in-pr`              | Terminal — the linked PR closes the loop                              |
 
 ## Comment shape (for skips)
 


### PR DESCRIPTION
## Why

The size gate in Ralphie's fix prompt counts every file in `git diff --stat` toward the 10-file / 300-LoC cap, including markdown. That means a code fix that legitimately needs a spec update is penalized for the spec weight — and the perverse incentive is to land code with a stale spec. Spec/doc updates don't carry the same review burden as code; bundling them with the fix keeps design and implementation in sync.

## What changed

- [`PROMPT_bugs_fix.md` step 5](happyhq/.dev/PROMPT_bugs_fix.md): diff command now excludes `*.md`/`*.mdx` via pathspec, with a one-line rationale.
- [`bugs-rubric.md` rule 6](happyhq/.dev/bugs-rubric.md): exclusion noted in the criterion text.

## Edge case

PROMPT files (`PROMPT_bugs_fix.md`, `PROMPT_bugs_triage.md`) are technically `.md` but they're behavior, not docs. The carve-out lets a large prompt rewrite slip past the gate — in practice fine, those are maintainer-only one-offs that run with `--override` anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)