### PR TITLE
fix: add explicit permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds top-level `permissions: contents: read` to `.github/workflows/ci.yml`, applying least-privilege to all 3 jobs (lint, check-types, test). None of them push commits, comment on PRs, or upload artifacts, so per-job overrides aren't needed.
- Closes #92 and resolves CodeQL alerts #1, #2, #3 (`actions/missing-workflow-permissions`).

## Test plan
- [ ] CI passes on this PR (lint, check-types, test) — confirms `contents: read` is sufficient for all 3 jobs.
- [ ] CodeQL alerts #1/#2/#3 transition to `fixed` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)