### PR TITLE
fix: escape backslashes before quotes in web-input YAML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/happyhq/lib/actions/web-input.ts
+++ b/happyhq/lib/actions/web-input.ts
@@ -66,9 +66,11 @@ export async function addWebInput(
     `url: ${normalizedUrl}`,
     `saved: ${new Date().toISOString()}`,
   ]
-  if (title) lines.push(`title: "${title.replace(/"/g, '\\"')}"`)
+  const yamlEscape = (s: string) =>
+    s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  if (title) lines.push(`title: "${yamlEscape(title)}"`)
   if (unfurl?.description)
-    lines.push(`description: "${unfurl.description.replace(/"/g, '\\"')}"`)
+    lines.push(`description: "${yamlEscape(unfurl.description)}"`)
   if (unfurl?.image) lines.push(`image: ${unfurl.image}`)
   if (unfurl?.favicon) lines.push(`favicon: ${unfurl.favicon}`)
   lines.push('---', '')


### PR DESCRIPTION
## Why

CodeQL flagged 2 `js/incomplete-sanitization` alerts in `lib/actions/web-input.ts` (referenced in #90). On inspection these aren't HTML sanitization — they're YAML quote-escaping in frontmatter, and the escape is genuinely wrong: only `\"` is replaced, so a literal backslash-before-quote in the input survives as `\\"` on disk, which YAML decodes as a backslash followed by end-of-string.

Escape `\` first, then `"`, so backslashes and quotes both round-trip cleanly.

## Summary

- Replace inline `.replace(/"/g, '\\"')` with a small `yamlEscape` helper that handles `\` then `"`
- Applies to both the `title` and `description` frontmatter values

## Test plan

- [x] `pnpm check-types` clean
- [x] `pnpm lint` — no warnings
- [x] `pnpm format` — no diffs
- [ ] CodeQL re-scan: 2 alerts on `web-input.ts` should drop

## Related

Resolves the 2 `web-input.ts` alerts (L63, L65) listed in #90. The remaining 4 alerts in `extract-text.server.ts` are being closed out separately as won't-fix false positives — output is rendered as a JSX text child, not as HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)