### PR TITLE
fix: drop dead reads in chatStore and run loop

### DIFF
--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -334,7 +334,6 @@ async function runLoop(
 
   // Billing: start a task run record if billing is enabled and user is known
   let taskRunId: string | null = null
-  const runStartMs = Date.now()
   if (userId) {
     try {
       const { isBillingEnabled } = await import('@/ee/lib/billing/config')

--- a/happyhq/stores/chatStore.ts
+++ b/happyhq/stores/chatStore.ts
@@ -494,7 +494,6 @@ function processEvent(
               return { ...m, thinkingBlocks: blocks }
             }),
           }))
-          const msg = get().messages.find((m) => m.id === activeRef.id)
         }
         // Accumulate tool input JSON for AskUserQuestion so we can render
         // the question form on content_block_stop instead of waiting for assistant.
@@ -571,7 +570,6 @@ function processEvent(
               }
             }),
           }))
-          const msg = get().messages.find((m) => m.id === activeRef.id)
         }
         // Tool use blocks — add to toolProgress immediately so the UI shows
         // what Q is doing as soon as the model starts calling a tool.


### PR DESCRIPTION
## Summary
- Removes two unused `const msg = get().messages.find(...)` reads in [chatStore.ts](happyhq/stores/chatStore.ts) (thinking-delta and thinking-block-start branches). Nothing reads `msg`; no log, no derived state, no follow-up — they read like `console.log` leftovers.
- Removes `const runStartMs = Date.now()` in [loop.server.ts](happyhq/lib/run/loop.server.ts). The "missing instrumentation" hypothesis from the issue doesn't hold: the `taskRuns` record already captures wall-clock via `startedAt` (set in `startTaskRun`) and `endedAt` (set in `finalizeTaskRun`); `minutes` is the cost-derived metric. The local was redundant scaffold.
- Closes #95.

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 1445 tests pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)