### PR TITLE
chore: add CodeQL sanitizer for safePath() in path-injection

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,12 +1,17 @@
 name: HappyHQ CodeQL config
 
-# Replaces "default setup" with a workflow we own (`.github/workflows/codeql.yml`)
-# so we can layer on custom sanitizer models for js/path-injection in a
-# follow-up. This file deliberately runs the same query suite default setup
-# was running — it's pure plumbing, no semantic change.
-
 queries:
   - uses: security-and-quality
+  - uses: ./queries
+
+# Replace the default `js/path-injection` with our custom version
+# (`./queries/PathInjection.ql`, id `js/happyhq/path-injection`) which
+# recognises `safePath()` as a sanitiser barrier. Without this exclude
+# we'd see two streams of alerts — the conservative default plus our
+# saner version.
+query-filters:
+  - exclude:
+      id: js/path-injection
 
 paths-ignore:
   - '**/node_modules/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,7 +2,7 @@ name: HappyHQ CodeQL config
 
 queries:
   - uses: security-and-quality
-  - uses: ./queries
+  - uses: ./.github/codeql/queries
 
 # Replace the default `js/path-injection` with our custom version
 # (`./queries/PathInjection.ql`, id `js/happyhq/path-injection`) which

--- a/.github/codeql/queries/PathInjection.ql
+++ b/.github/codeql/queries/PathInjection.ql
@@ -18,8 +18,9 @@
  */
 
 import javascript
+import semmle.javascript.security.dataflow.TaintedPathCustomizations
 import semmle.javascript.security.dataflow.TaintedPathQuery
-import TaintedPath::PathGraph
+import DataFlow::DeduplicatePathGraph<TaintedPathFlow::PathNode, TaintedPathFlow::PathGraph>
 
 private class HappyHQSafePathSanitizer extends TaintedPath::Sanitizer {
   HappyHQSafePathSanitizer() {
@@ -30,7 +31,8 @@ private class HappyHQSafePathSanitizer extends TaintedPath::Sanitizer {
   }
 }
 
-from TaintedPath::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from PathNode source, PathNode sink
+where
+  TaintedPathFlow::flowPath(source.getAnOriginalPathNode(), sink.getAnOriginalPathNode())
 select sink.getNode(), source, sink, "This path depends on a $@.", source.getNode(),
   "user-provided value"

--- a/.github/codeql/queries/PathInjection.ql
+++ b/.github/codeql/queries/PathInjection.ql
@@ -1,0 +1,36 @@
+/**
+ * @name Uncontrolled data used in path expression
+ * @description Same analysis as the standard js/path-injection, with HappyHQ's
+ *              `safePath()` recognised as a sanitiser barrier. Replaces the
+ *              default query (the default is excluded via query-filters in
+ *              codeql-config.yml).
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 7.5
+ * @precision high
+ * @id js/happyhq/path-injection
+ * @tags security
+ *       external/cwe/cwe-022
+ *       external/cwe/cwe-023
+ *       external/cwe/cwe-036
+ *       external/cwe/cwe-073
+ *       external/cwe/cwe-099
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.TaintedPathQuery
+import TaintedPath::PathGraph
+
+private class HappyHQSafePathSanitizer extends TaintedPath::Sanitizer {
+  HappyHQSafePathSanitizer() {
+    exists(DataFlow::CallNode call |
+      call.getCalleeName() = "safePath" and
+      this = call
+    )
+  }
+}
+
+from TaintedPath::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "This path depends on a $@.", source.getNode(),
+  "user-provided value"

--- a/.github/codeql/queries/qlpack.yml
+++ b/.github/codeql/queries/qlpack.yml
@@ -1,0 +1,5 @@
+name: happyhq/codeql-customizations
+version: 0.0.1
+library: false
+dependencies:
+  codeql/javascript-queries: '*'


### PR DESCRIPTION
## Why

The default `js/path-injection` query has no way to know that our `safePath()` ([lib/fs/paths.ts](happyhq/lib/fs/paths.ts)) returns a canonicalised, root-bounded path, so it flags every fs op downstream as tainted. PR #112 confirmed this empirically — refactoring 26 call sites to thread `safePath`'s return value only dropped the count from 73 to 71. PR #114 migrated us to advanced setup so we could ship a model. This PR is the substantive fix.

## What this does

A tiny CodeQL query pack that mirrors the default path-injection analysis but extends `TaintedPath::Sanitizer` to recognise calls to `safePath` as barriers. The default query is excluded via `query-filters` so we get one alert stream, not two.

## Files

- `.github/codeql/queries/qlpack.yml` — pack metadata
- `.github/codeql/queries/PathInjection.ql` — custom query, id `js/happyhq/path-injection`, with the sanitizer extension
- `.github/codeql/codeql-config.yml` — load the pack and exclude the default `js/path-injection`

## Expected impact

71 open `js/path-injection` alerts → significantly fewer (most go through `safePath`). The exact number depends on whether CodeQL's API graph resolves our local `safePath` calls cleanly via the simple `getCalleeName()` match.

## Iteration risk

I have no local CodeQL CLI to validate the QL syntax, so the first run may need a fixup commit. Failure modes to watch for in the workflow logs:
- QL compile error → fix syntax in `PathInjection.ql`
- Sanitizer matches nothing → broaden the matcher (add file-path constraint or use API graph)
- Default query still firing → adjust `query-filters` syntax

If the count doesn't drop enough, follow-up: add a `BarrierGuard` extension for the `assertSafe*` family (sites that don't yet route through `safePath`).

## Test plan

- [ ] CodeQL workflow run completes successfully on this PR
- [ ] Alert delta on the PR comments — expect a meaningful drop
- [ ] Post-merge: re-pull the count from main and confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)