### PR TITLE
chore: extend CodeQL model with assertSafe* barrier guards

### DIFF
--- a/.github/codeql/queries/PathInjection.ql
+++ b/.github/codeql/queries/PathInjection.ql
@@ -1,8 +1,14 @@
 /**
  * @name Uncontrolled data used in path expression
  * @description Same analysis as the standard js/path-injection, with HappyHQ's
- *              `safePath()` recognised as a sanitiser barrier. Replaces the
- *              default query (the default is excluded via query-filters in
+ *              local sanitisers recognised:
+ *                - `safePath()` return value (Sanitizer)
+ *                - `assertSafeTaskSlug` / `assertSafeStreamName` /
+ *                  `assertSafeSessionId` / `assertSafePathSegment` —
+ *                  void-returning, throw-on-bad-input regex validators; we
+ *                  mark the call's argument node so taint flowing into the
+ *                  validator is sanitised at the use site.
+ *              Replaces the default query (excluded via query-filters in
  *              codeql-config.yml).
  * @kind path-problem
  * @problem.severity error
@@ -28,6 +34,22 @@ private class HappyHQSafePathSanitizer extends TaintedPath::Sanitizer {
       call.getCalleeName() = "safePath" and
       this = call
     )
+  }
+}
+
+private class HappyHQAssertSafeBarrierGuard extends TaintedPath::BarrierGuard instanceof DataFlow::CallNode
+{
+  HappyHQAssertSafeBarrierGuard() {
+    this.(DataFlow::CallNode).getCalleeName() =
+      [
+        "assertSafeTaskSlug", "assertSafeStreamName", "assertSafeSessionId",
+        "assertSafePathSegment"
+      ]
+  }
+
+  override predicate blocksExpr(boolean outcome, Expr e) {
+    outcome = true and
+    e = this.(DataFlow::CallNode).getArgument(0).asExpr()
   }
 }
 


### PR DESCRIPTION
## Why

PR #115 shipped a `safePath()` `Sanitizer` for `js/happyhq/path-injection` and dropped the count from 71 → 36 (49%). The 36 survivors are sites where validation flows through the `assertSafe*` family (regex-tested then thrown if bad) without a subsequent `safePath()` wrap — runtime-safe, but the void-returning, throw-style validator is invisible to CodeQL.

## What this does

Adds a `BarrierGuard` for the four `assertSafe*` functions:
- `assertSafeTaskSlug`
- `assertSafeStreamName`
- `assertSafeSessionId`
- `assertSafePathSegment`

The guard's `outcome = true` branch (post-call dominator — i.e. we didn't throw) marks the argument expression as blocked.

## Risk

The `BarrierGuard` pattern in CodeQL is most commonly used for `if (guard(x)) { ... }` shapes where there's a literal boolean outcome. Using it to model assert-throw style is non-standard. Two failure modes:

1. **QL compiles but doesn't fire** — the dataflow library doesn't interpret the post-call dominator as a guard outcome. We'd see the count unchanged.
2. **QL fails to compile** — wrong API. One iteration commit to fix.

## Stop rule

If one iteration doesn't drop the count meaningfully, fall back to a small **code change**: refactor `assertSafe*` to return their input value (currently void). Then call sites bind the return to a fresh variable, and CodeQL recognises the lineage replacement automatically — same shape as `safePath()` works today. That's a real code change but it's clean and predictable.

## Test plan

- [ ] CodeQL workflow run completes successfully on this PR
- [ ] Post-merge: re-pull the count from main; expect ≤10 path-injection survivors

🤖 Generated with [Claude Code](https://claude.com/claude-code)