### PR TITLE
fix: have assertSafe* return validated value, recognise as CodeQL sanitizers

### DIFF
--- a/.github/codeql/queries/PathInjection.ql
+++ b/.github/codeql/queries/PathInjection.ql
@@ -1,13 +1,15 @@
 /**
  * @name Uncontrolled data used in path expression
  * @description Same analysis as the standard js/path-injection, with HappyHQ's
- *              local sanitisers recognised:
- *                - `safePath()` return value (Sanitizer)
+ *              local path-helpers recognised as sanitisers — their return
+ *              values are validated paths:
+ *                - `safePath()` — canonical resolve + root-bounded
  *                - `assertSafeTaskSlug` / `assertSafeStreamName` /
- *                  `assertSafeSessionId` / `assertSafePathSegment` —
- *                  void-returning, throw-on-bad-input regex validators; we
- *                  mark the call's argument node so taint flowing into the
- *                  validator is sanitised at the use site.
+ *                  `assertSafeSessionId` / `assertSafePathSegment` — regex
+ *                  validators that return their input on success, throw on
+ *                  bad input
+ *                - `streamPath` / `taskPath` / `chatPath` — build paths
+ *                  through the assertSafe* validators
  *              Replaces the default query (excluded via query-filters in
  *              codeql-config.yml).
  * @kind path-problem
@@ -28,28 +30,17 @@ import semmle.javascript.security.dataflow.TaintedPathCustomizations
 import semmle.javascript.security.dataflow.TaintedPathQuery
 import DataFlow::DeduplicatePathGraph<TaintedPathFlow::PathNode, TaintedPathFlow::PathGraph>
 
-private class HappyHQSafePathSanitizer extends TaintedPath::Sanitizer {
-  HappyHQSafePathSanitizer() {
+private class HappyHQPathHelperSanitizer extends TaintedPath::Sanitizer {
+  HappyHQPathHelperSanitizer() {
     exists(DataFlow::CallNode call |
-      call.getCalleeName() = "safePath" and
+      call.getCalleeName() =
+        [
+          "safePath", "assertSafeTaskSlug", "assertSafeStreamName",
+          "assertSafeSessionId", "assertSafePathSegment", "streamPath", "taskPath",
+          "chatPath"
+        ] and
       this = call
     )
-  }
-}
-
-private class HappyHQAssertSafeBarrierGuard extends TaintedPath::BarrierGuard instanceof DataFlow::CallNode
-{
-  HappyHQAssertSafeBarrierGuard() {
-    this.(DataFlow::CallNode).getCalleeName() =
-      [
-        "assertSafeTaskSlug", "assertSafeStreamName", "assertSafeSessionId",
-        "assertSafePathSegment"
-      ]
-  }
-
-  override predicate blocksExpr(boolean outcome, Expr e) {
-    outcome = true and
-    e = this.(DataFlow::CallNode).getArgument(0).asExpr()
   }
 }
 

--- a/happyhq/lib/fs/paths.ts
+++ b/happyhq/lib/fs/paths.ts
@@ -3,8 +3,7 @@ import path from 'path'
 import { HAPPYHQ_ROOT } from '@/lib/constants.server'
 
 export function streamPath(streamName: string): string {
-  assertSafeStreamName(streamName)
-  return path.join(HAPPYHQ_ROOT, streamName)
+  return path.join(HAPPYHQ_ROOT, assertSafeStreamName(streamName))
 }
 
 /** Q's memory directory. */
@@ -19,14 +18,12 @@ export function tasksDir(): string {
 
 /** Path to a specific task directory (~/HappyHQ/tasks/{slug}). */
 export function taskPath(taskSlug: string): string {
-  assertSafeTaskSlug(taskSlug)
-  return path.join(HAPPYHQ_ROOT, 'tasks', taskSlug)
+  return path.join(HAPPYHQ_ROOT, 'tasks', assertSafeTaskSlug(taskSlug))
 }
 
 /** Resolve chat directory path — always at root. */
 export function chatPath(sessionId: string): string {
-  assertSafeSessionId(sessionId)
-  return path.join(HAPPYHQ_ROOT, '.chats', sessionId)
+  return path.join(HAPPYHQ_ROOT, '.chats', assertSafeSessionId(sessionId))
 }
 
 /** Daily log files directory (~/HappyHQ/.logs/). */
@@ -66,10 +63,11 @@ export function validatePath(targetPath: string): void {
  * malformed (or hostile) request — refuse before the value reaches `path.join`.
  */
 const SESSION_ID_RE = /^[a-zA-Z0-9-]{1,64}$/
-export function assertSafeSessionId(sessionId: string): void {
+export function assertSafeSessionId(sessionId: string): string {
   if (!SESSION_ID_RE.test(sessionId)) {
     throw new Error('Invalid session id')
   }
+  return sessionId
 }
 
 /**
@@ -82,16 +80,18 @@ export function assertSafeSessionId(sessionId: string): void {
  */
 const SAFE_PATH_SEGMENT_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/
 
-export function assertSafeStreamName(streamName: string): void {
+export function assertSafeStreamName(streamName: string): string {
   if (!SAFE_PATH_SEGMENT_RE.test(streamName)) {
     throw new Error('Invalid stream name')
   }
+  return streamName
 }
 
-export function assertSafeTaskSlug(taskSlug: string): void {
+export function assertSafeTaskSlug(taskSlug: string): string {
   if (!SAFE_PATH_SEGMENT_RE.test(taskSlug)) {
     throw new Error('Invalid task slug')
   }
+  return taskSlug
 }
 
 /**
@@ -102,8 +102,9 @@ export function assertSafeTaskSlug(taskSlug: string): void {
 export function assertSafePathSegment(
   value: string,
   label = 'path segment',
-): void {
+): string {
   if (!SAFE_PATH_SEGMENT_RE.test(value)) {
     throw new Error(`Invalid ${label}`)
   }
+  return value
 }


### PR DESCRIPTION
## Why

PR #123 tried to teach CodeQL about our `assertSafe*` family via a `BarrierGuard` extension. The QL compiled but didn't fire — `BarrierGuard`'s `outcome = true` semantics expect a literal boolean-producing guard, not a void function that throws on bad input. Count stayed at **36 surviving path-injection alerts**.

Per the stop rule from #123: fall back to a code-shaped fix.

## What this does

Two-line semantic change to four validators, plus an ergonomic cleanup of three path builders, plus the QL matcher update:

1. **`assertSafeSessionId`, `assertSafeStreamName`, `assertSafeTaskSlug`, `assertSafePathSegment`** now return their input value on success (still throw on bad input — same regex check, same error). Adds a `return` line; signature changes from `void` to `string`. Existing call sites that ignore the return value continue to work unchanged.

2. **`streamPath`, `taskPath`, `chatPath`** thread the validator's return into `path.join` so the canonical path is built from the validated value:
   ```ts
   // Before
   assertSafeStreamName(streamName)
   return path.join(HAPPYHQ_ROOT, streamName)

   // After
   return path.join(HAPPYHQ_ROOT, assertSafeStreamName(streamName))
   ```

3. **QL Sanitizer matcher** broadened to recognise all eight helpers (the four `assertSafe*` + the three path builders + the existing `safePath`). Drop the dead `BarrierGuard` from #123.

## Why this works for CodeQL

The existing `Sanitizer` pattern (shipped in #115 for `safePath`) keys on a call's return value. By giving the four validators and three path builders meaningful return values, every site that uses them gets a clean lineage replacement — exactly what CodeQL recognises.

## Test plan

- [x] `pnpm check-types` — clean
- [x] `pnpm lint` — no warnings
- [x] `pnpm test` — 1445 pass (was 1445)
- [x] `pnpm format` — no diffs
- [ ] Post-merge: re-pull alert count from main; expect substantial drop from 36 (target: ≤10 survivors). Survivors after this would be sites that genuinely don't go through any of our helpers — those are the candidates for direct dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)