### PR TITLE
chore: tighten Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-    groups:
-      npm-minor-patch:
-        update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: npm
     directory: /happyhq
     schedule:
       interval: weekly
@@ -29,6 +18,15 @@ updates:
         update-types:
           - version-update:semver-major
       - dependency-name: react-dom
+        update-types:
+          - version-update:semver-major
+      - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
+      - dependency-name: eslint-config-next
+        update-types:
+          - version-update:semver-major
+      - dependency-name: typescript
         update-types:
           - version-update:semver-major
 


### PR DESCRIPTION
## Summary
First Dependabot run on the new config produced 14 open PRs and leaked an ignored framework bump. Two root causes:

1. The `/` and `/happyhq` npm blocks both crawled the same workspace (pnpm workspaces let the root block reach into `happyhq/`), producing duplicate group PRs and overlapping coverage.
2. The `next`/`react`/`react-dom` ignore list lived only on the `/happyhq` block, so #130 (`next` 15→16) was filed by the `/` block and slipped past the ignore.

This PR:
- Drops the `/` npm block — `/happyhq` already covers the workspace.
- Extends the ignore list with `eslint`, `eslint-config-next`, `typescript` — major bumps on these are real migration work and we want to drive them manually.

## Test plan
- [ ] Merge and let Dependabot reconcile on the next scheduled tick.
- [ ] Confirm only one `npm-minor-patch` group PR is opened (no duplicate from `/`).
- [ ] Confirm no major-version PRs are opened for next, react, react-dom, eslint, eslint-config-next, or typescript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)