### PR TITLE
fix: thread assertSafe* return values through residual path-injection sites

### DIFF
--- a/happyhq/lib/actions/ingestion.ts
+++ b/happyhq/lib/actions/ingestion.ts
@@ -18,6 +18,7 @@ import {
   assertSafeSessionId,
   assertSafeStreamName,
   assertSafeTaskSlug,
+  chatPath,
   safePath,
   streamPath,
   taskPath,
@@ -49,7 +50,7 @@ export async function uploadFile(
   token?: string,
   streamSlug?: string | null,
 ): Promise<string> {
-  assertSafeSessionId(sessionId)
+  const safeSessionId = assertSafeSessionId(sessionId)
 
   const file = formData.get('file') as File
   if (!file) {
@@ -92,7 +93,7 @@ export async function uploadFile(
   if (!slug) slug = 'upload'
 
   // Handle slug collisions within this chat session
-  const chatDir = path.join(HAPPYHQ_ROOT, '.chats', sessionId)
+  const chatDir = chatPath(safeSessionId)
   const uploadsDir = path.join(chatDir, 'uploads')
   let finalSlug = slug
   let counter = 2
@@ -221,9 +222,9 @@ export async function setupTaskFromChat(
   textContext: string,
   files: string[],
 ): Promise<void> {
-  assertSafeTaskSlug(taskSlug)
-  assertSafeSessionId(sessionId)
-  const taskDir = taskPath(taskSlug)
+  const safeTaskSlug = assertSafeTaskSlug(taskSlug)
+  const safeSessionId = assertSafeSessionId(sessionId)
+  const taskDir = taskPath(safeTaskSlug)
 
   await Promise.all([
     ensureDirectory(path.join(taskDir, 'inputs')),
@@ -232,7 +233,7 @@ export async function setupTaskFromChat(
   ])
 
   // Move upload directories from root .chats/{sessionId}/uploads/ to inputs/
-  const uploadsDir = path.join(HAPPYHQ_ROOT, '.chats', sessionId, 'uploads')
+  const uploadsDir = path.join(chatPath(safeSessionId), 'uploads')
   const validFiles: { from: string; to: string }[] = []
   const seen = new Set<string>()
   for (const fileRef of files) {

--- a/happyhq/lib/actions/samples.ts
+++ b/happyhq/lib/actions/samples.ts
@@ -46,20 +46,23 @@ export async function moveSampleCategory(
   toCategory: string,
   token?: string,
 ): Promise<void> {
-  assertSafeStreamName(streamName)
-  assertSafePathSegment(sampleName, 'sample name')
-  assertSafePathSegment(fromCategory, 'sample category')
+  const safeStream = assertSafeStreamName(streamName)
+  const safeName = assertSafePathSegment(sampleName, 'sample name')
+  const safeFromCategory = assertSafePathSegment(
+    fromCategory,
+    'sample category',
+  )
   // Slugify the target type
   const targetCategory = toCategory
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '')
   if (!targetCategory) throw new Error('Invalid type name')
-  if (targetCategory === fromCategory) return
+  if (targetCategory === safeFromCategory) return
 
-  const samplesRoot = path.join(streamPath(streamName), 'samples')
-  const fromDir = safePath(path.join(samplesRoot, fromCategory, sampleName))
-  const toDir = safePath(path.join(samplesRoot, targetCategory, sampleName))
+  const samplesRoot = path.join(streamPath(safeStream), 'samples')
+  const fromDir = safePath(path.join(samplesRoot, safeFromCategory, safeName))
+  const toDir = safePath(path.join(samplesRoot, targetCategory, safeName))
 
   // Verify source exists
   await access(fromDir)
@@ -70,11 +73,11 @@ export async function moveSampleCategory(
 
   // Clean up empty source type directory
   try {
-    const remaining = await readdir(path.join(samplesRoot, fromCategory))
+    const remaining = await readdir(path.join(samplesRoot, safeFromCategory))
     // Remove if only INDEX.md or nothing remains
     const nonIndex = remaining.filter((f) => f !== 'INDEX.md')
     if (nonIndex.length === 0) {
-      await rm(path.join(samplesRoot, fromCategory), {
+      await rm(path.join(samplesRoot, safeFromCategory), {
         recursive: true,
         force: true,
       })
@@ -94,22 +97,22 @@ export async function deleteSample(
   category: string,
   token?: string,
 ): Promise<void> {
-  assertSafeStreamName(streamName)
-  assertSafePathSegment(sampleName, 'sample name')
-  assertSafePathSegment(category, 'sample category')
-  const samplesRoot = path.join(streamPath(streamName), 'samples')
-  const sampleDir = safePath(path.join(samplesRoot, category, sampleName))
+  const safeStream = assertSafeStreamName(streamName)
+  const safeName = assertSafePathSegment(sampleName, 'sample name')
+  const safeCategory = assertSafePathSegment(category, 'sample category')
+  const samplesRoot = path.join(streamPath(safeStream), 'samples')
+  const sampleDir = safePath(path.join(samplesRoot, safeCategory, safeName))
 
-  await deleteFileItem(sampleDir, `[${streamName}] Delete sample ${sampleName}`)
+  await deleteFileItem(sampleDir, `[${safeStream}] Delete sample ${safeName}`)
 
   // Clean up empty type directory
   try {
-    const remaining = await readdir(path.join(samplesRoot, category))
+    const remaining = await readdir(path.join(samplesRoot, safeCategory))
     const meaningful = remaining.filter(
       (f) => f !== 'INDEX.md' && f !== '.meta.json',
     )
     if (meaningful.length === 0) {
-      await rm(path.join(samplesRoot, category), {
+      await rm(path.join(samplesRoot, safeCategory), {
         recursive: true,
         force: true,
       })


### PR DESCRIPTION
## Why

PR #134 made the `assertSafe*` validators return their input value. The model now recognises 8 helper functions as path-injection sanitisers, and the surviving 10 `js/happyhq/path-injection` alerts are concentrated in two files:
- \`lib/actions/samples.ts\` (4 alerts) — validators called for side-effect; the unbound variable is used downstream
- \`lib/actions/ingestion.ts\` (6 alerts) — same shape, plus two manual \`path.join(HAPPYHQ_ROOT, '.chats', sessionId, …)\` reconstructions instead of using \`chatPath()\`

This PR threads the returns through and swaps the manual reconstructions for the helper.

## Summary

- \`samples.ts\` (\`moveSampleCategory\`, \`deleteSample\`): bind \`assertSafeStreamName\` / \`assertSafePathSegment\` returns to \`safeStream\` / \`safeName\` / \`safe(From)Category\`, use those in subsequent \`path.join\`s
- \`ingestion.ts\` (\`uploadFile\`, \`setupTaskFromChat\`): bind \`assertSafeSessionId\` / \`assertSafeTaskSlug\` returns; replace manual \`.chats\` joins with \`chatPath(safeSessionId)\`

No behaviour change — same regex check, same throw on bad input, same canonical paths produced. Just gives CodeQL a clean lineage replacement.

## Test plan

- [x] \`pnpm check-types\` — clean
- [x] \`pnpm lint\` — no warnings
- [x] \`pnpm test\` — 1445 pass (was 1445)
- [x] \`pnpm format\` — no diffs
- [ ] Post-merge: re-pull alert count from main; expect path-injection survivors to drop from 10 to ≤2

🤖 Generated with [Claude Code](https://claude.com/claude-code)