### PR TITLE
fix: skip __proto__/constructor/prototype in deepMerge

### DIFF
--- a/happyhq/lib/config/config.server.test.ts
+++ b/happyhq/lib/config/config.server.test.ts
@@ -101,6 +101,41 @@ describe('writeConfig', () => {
     expect(mockWriteTextFile).toHaveBeenCalledOnce()
   })
 
+  it('drops __proto__ keys so attackers cannot pollute the prototype chain', async () => {
+    mockReadTextFile.mockResolvedValue('{}')
+    mockWriteTextFile.mockResolvedValue(undefined)
+
+    // JSON.parse is the only way to get __proto__ as an own enumerable
+    // property — TS won't let us write the literal directly, but a server
+    // action receives parsed JSON.
+    const malicious = JSON.parse(
+      '{"__proto__":{"polluted":"top"},"models":{"learning":{"__proto__":{"polluted":"nested"}}}}',
+    )
+
+    const merged = await writeConfig(malicious)
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype)
+    expect(Object.getPrototypeOf(merged.models?.learning ?? {})).toBe(
+      Object.prototype,
+    )
+  })
+
+  it('drops constructor and prototype keys so attackers cannot reach Object.prototype via the constructor chain', async () => {
+    mockReadTextFile.mockResolvedValue('{}')
+    mockWriteTextFile.mockResolvedValue(undefined)
+
+    const malicious = JSON.parse(
+      '{"constructor":{"polluted":"yes"},"prototype":{"polluted":"yes"}}',
+    )
+
+    const merged = await writeConfig(malicious)
+
+    expect(Object.hasOwn(merged, 'constructor')).toBe(false)
+    expect(Object.hasOwn(merged, 'prototype')).toBe(false)
+    expect(Object.prototype.constructor).toBe(Object)
+  })
+
   it('deep-merges nested model config without losing sibling keys', async () => {
     mockReadTextFile.mockResolvedValue(
       JSON.stringify({

--- a/happyhq/lib/config/config.server.ts
+++ b/happyhq/lib/config/config.server.ts
@@ -44,10 +44,18 @@ export async function writeConfig(update: AppConfig): Promise<AppConfig> {
   return merged
 }
 
+// Skipping these keys at every merge boundary keeps an attacker who controls
+// the source payload from reaching Object.prototype via __proto__ or
+// constructor.prototype.
+function isUnsafeKey(key: PropertyKey): boolean {
+  return key === '__proto__' || key === 'constructor' || key === 'prototype'
+}
+
 /** Two-level deep merge — handles the nested sections of AppConfig. */
 function deepMerge(target: AppConfig, source: AppConfig): AppConfig {
   const result = { ...target }
   for (const key of Object.keys(source) as (keyof AppConfig)[]) {
+    if (isUnsafeKey(key)) continue
     const sourceVal = source[key]
     if (sourceVal === undefined) continue
     const targetVal = result[key]
@@ -75,6 +83,7 @@ function deepMergeObject(
 ): Record<string, unknown> {
   const result = { ...target }
   for (const key of Object.keys(source)) {
+    if (isUnsafeKey(key)) continue
     const sourceVal = source[key]
     if (sourceVal === undefined) continue
     const targetVal = result[key]


### PR DESCRIPTION
Closes #117

## Why

`writeConfig` is exposed via server actions and accepts `AppConfig` updates that originate as JSON. `Object.keys(source)` returns whatever own keys the parsed payload carries, including `__proto__` (which `JSON.parse` materialises as an own data property). Both `deepMerge` and `deepMergeObject` then did `result[key] = sourceVal` without filtering, which is the classic prototype-pollution shape that CodeQL flags as `js/remote-property-injection` (alerts #121–#124). On a single-tenant local server the blast radius is bounded — a malicious page or extension would have to reach `writeConfig` — but the fix is small and prototype pollution tends to enable other bugs.

The fix is option 1 from the issue: skip `__proto__`, `constructor`, `prototype` at the top of each loop body. This is the standard CodeQL-recognised barrier for `js/remote-property-injection`.

## Regression test

`happyhq/lib/config/config.server.test.ts:104` and `:124` cover both attack shapes (top-level and nested `__proto__`, plus `constructor`/`prototype`). Verified that both fail before the fix and pass after by stashing the source change and re-running.

## Test plan

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm --filter=happyhq test` (1447 passed)

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.