### PR TITLE
fix: close TOCTOU windows in 3 fs helpers

### DIFF
--- a/happyhq/app/api/fs/download/route.test.ts
+++ b/happyhq/app/api/fs/download/route.test.ts
@@ -4,15 +4,13 @@ vi.mock('@/lib/constants.server', () => ({
   HAPPYHQ_ROOT: '/mock/home/HappyHQ',
 }))
 
-const { mockReadFile, mockStat } = vi.hoisted(() => ({
+const { mockReadFile } = vi.hoisted(() => ({
   mockReadFile: vi.fn(),
-  mockStat: vi.fn(),
 }))
 
 vi.mock('node:fs/promises', () => ({
-  default: { readFile: mockReadFile, stat: mockStat },
+  default: { readFile: mockReadFile },
   readFile: mockReadFile,
-  stat: mockStat,
 }))
 
 import { GET } from './route'
@@ -36,7 +34,6 @@ describe('GET /api/fs/download', () => {
 
   it('serves the raw file with Content-Disposition header', async () => {
     const fileContent = Buffer.from('Hello, world!')
-    mockStat.mockResolvedValue({ isFile: () => true })
     mockReadFile.mockResolvedValue(fileContent)
 
     const response = await GET(
@@ -57,7 +54,7 @@ describe('GET /api/fs/download', () => {
   it('returns 404 when file does not exist', async () => {
     const error = new Error('ENOENT') as NodeJS.ErrnoException
     error.code = 'ENOENT'
-    mockStat.mockRejectedValue(error)
+    mockReadFile.mockRejectedValue(error)
 
     const response = await GET(
       makeRequest({ path: 'my-stream/outputs/missing.md' }),
@@ -77,7 +74,9 @@ describe('GET /api/fs/download', () => {
   })
 
   it('returns 400 when path points to a directory', async () => {
-    mockStat.mockResolvedValue({ isFile: () => false })
+    const error = new Error('EISDIR') as NodeJS.ErrnoException
+    error.code = 'EISDIR'
+    mockReadFile.mockRejectedValue(error)
 
     const response = await GET(makeRequest({ path: 'my-stream/outputs' }))
     const body = await response.json()

--- a/happyhq/app/api/fs/download/route.ts
+++ b/happyhq/app/api/fs/download/route.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { HAPPYHQ_ROOT } from '@/lib/constants.server'
@@ -20,11 +20,8 @@ export async function GET(request: Request) {
   }
 
   try {
-    const fileStat = await stat(fullPath)
-    if (!fileStat.isFile()) {
-      return Response.json({ error: 'Not a file' }, { status: 400 })
-    }
-
+    // Single readFile call avoids the stat/read TOCTOU window where a
+    // symlink swap could redirect the read after the canonical-path check.
     const buffer = await readFile(fullPath)
     const fileName = path.basename(fullPath)
     const ext = path.extname(fullPath).toLowerCase()
@@ -61,8 +58,12 @@ export async function GET(request: Request) {
       },
     })
   } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') {
       return Response.json({ error: 'File not found' }, { status: 404 })
+    }
+    if (code === 'EISDIR') {
+      return Response.json({ error: 'Not a file' }, { status: 400 })
     }
     log('api.error', {
       route: '/api/fs/download',

--- a/happyhq/lib/agents/tools.server.ts
+++ b/happyhq/lib/agents/tools.server.ts
@@ -181,15 +181,20 @@ export function createQsMcpServer(
           }
           const categoryDir = path.join(streamRoot, 'samples', category)
           fs.mkdirSync(categoryDir, { recursive: true })
-          // Write category display title if provided and no .meta.json exists yet
+          // Write category display title if provided and no .meta.json exists yet.
+          // The 'wx' flag fails atomically with EEXIST if the file already exists,
+          // closing the existsSync/writeFileSync TOCTOU window where a concurrent
+          // writer could have created the file between the two calls.
           if (categoryTitle) {
             const metaPath = path.join(categoryDir, '.meta.json')
-            if (!fs.existsSync(metaPath)) {
+            try {
               fs.writeFileSync(
                 metaPath,
                 JSON.stringify({ title: categoryTitle }),
-                'utf-8',
+                { encoding: 'utf-8', flag: 'wx' },
               )
+            } catch (err) {
+              if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
             }
           }
           try {

--- a/happyhq/lib/fs/read.server.test.ts
+++ b/happyhq/lib/fs/read.server.test.ts
@@ -9,21 +9,37 @@ vi.mock('@/lib/constants.server', () => ({
 const MOCK_ROOT = '/mock/home/HappyHQ'
 
 // vi.hoisted() runs before vi.mock hoisting, so these are available in the factory
-const { mockAccess, mockReadFile, mockReaddir, mockStat } = vi.hoisted(() => ({
-  mockAccess: vi.fn(),
-  mockReadFile: vi.fn(),
-  mockReaddir: vi.fn(),
-  mockStat: vi.fn(),
-}))
+const { mockAccess, mockOpen, mockReadFile, mockReaddir, mockStat } =
+  vi.hoisted(() => {
+    const mockReadFile = vi.fn()
+    const mockStat = vi.fn()
+    // open() returns a FileHandle — fake one whose stat/readFile/close delegate
+    // to the same mocks the rest of the suite drives, so listWebInputItems'
+    // open+stat+readFile+close flow works without separate mock plumbing.
+    const mockOpen = vi.fn(async (filePath: unknown) => ({
+      stat: () => mockStat(filePath),
+      readFile: (encoding: unknown) => mockReadFile(filePath, encoding),
+      close: vi.fn().mockResolvedValue(undefined),
+    }))
+    return {
+      mockAccess: vi.fn(),
+      mockOpen,
+      mockReadFile,
+      mockReaddir: vi.fn(),
+      mockStat,
+    }
+  })
 
 vi.mock('node:fs/promises', () => ({
   default: {
     access: mockAccess,
+    open: mockOpen,
     readFile: mockReadFile,
     readdir: mockReaddir,
     stat: mockStat,
   },
   access: mockAccess,
+  open: mockOpen,
   readFile: mockReadFile,
   readdir: mockReaddir,
   stat: mockStat,

--- a/happyhq/lib/fs/read.server.ts
+++ b/happyhq/lib/fs/read.server.ts
@@ -1,5 +1,5 @@
 import type { Dirent } from 'node:fs'
-import { readdir, readFile, stat } from 'node:fs/promises'
+import { open, readdir, readFile, stat } from 'node:fs/promises'
 import path from 'node:path'
 
 import { HAPPYHQ_ROOT } from '@/lib/constants.server'
@@ -178,10 +178,19 @@ async function listWebInputItems(webDir: string): Promise<FileItem[]> {
         continue
       }
       const filePath = path.join(domainPath, file)
-      const [fileStat, content] = await Promise.all([
-        stat(filePath),
-        readFile(filePath, 'utf-8'),
-      ])
+      // Open once and share the fd between stat and read so a symlink swap
+      // between operations cannot redirect one without the other.
+      const handle = await open(filePath, 'r')
+      let fileStat
+      let content
+      try {
+        ;[fileStat, content] = await Promise.all([
+          handle.stat(),
+          handle.readFile('utf-8'),
+        ])
+      } finally {
+        await handle.close()
+      }
       items.push({
         name: `web/${domainDir.name}`,
         title: extractTitle(content),


### PR DESCRIPTION
Closes #118

## Why

CodeQL flagged three `js/file-system-race` alerts where a filesystem inspection runs separately from the operation it gates, leaving a window where the path could be replaced (most concerning: a symlink swap escaping `HAPPYHQ_ROOT` after the canonical-path check). The practical risk on a single-tenant local app is low, but the patterns are textbook unsafe and the fix per site is mechanical: drop the pre-check or share an fd / file flag with the operation so they're atomic with respect to each other.

## What changed

- **`app/api/fs/download/route.ts`** — drop the `stat`+`isFile` pre-check before `readFile`. Same observable contract: `ENOENT` → 404, `EISDIR` → 400 "Not a file", other errors → 500.
- **`lib/fs/read.server.ts`** (`listWebInputItems`) — replace `Promise.all([stat(p), readFile(p)])` with `open(p, 'r')` + `handle.stat()` + `handle.readFile()` so both ops target one fd.
- **`lib/agents/tools.server.ts`** (`ProcessSample` category meta) — replace `existsSync` + `writeFileSync` with `writeFileSync({ flag: 'wx' })` and swallow `EEXIST`. Atomic write-or-skip with the same end state.

## Tests

No new regression tests added. The user-visible contracts (404 on missing, 400 on directory, web-input items return content + mtime, existing `.meta.json` preserved) didn't change — the existing test suites cover them, were updated to match the new mock surface (no pre-`stat` in download, `open` returning a handle in `read.server`), and pass. The actual race semantics are not reliably testable in unit tests, and a behavior-equivalent test for the user-facing contract would only catch a literal revert (vanity).

Verified locally: `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` (1445/1445 pass).

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.