### PR TITLE
chore: add Ralphie dependency-upgrade loop

### DIFF
--- a/happyhq/.dev/PROMPT_dependency_triage.md
+++ b/happyhq/.dev/PROMPT_dependency_triage.md
@@ -3,25 +3,23 @@
 
 1. Get the queue: `gh pr list --author "app/dependabot" --state open --limit 100 --json number,title,headRefName,labels,createdAt --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)] | sort_by(.createdAt)'`. Empty → exit cleanly.
 
-2. For each PR in the queue (oldest first), in parallel where it makes sense (use Sonnet subagents for changelog reads / code searches), evaluate against tier rules 1–10. For each PR:
+2. For each PR in the queue (oldest first), in parallel where it makes sense (use Sonnet subagents for changelog reads / code searches), evaluate against rules 1–3 (the Phase 1 entries). For each PR:
    - Read the PR body and labels: `gh pr view <#> --comments`.
-   - Read the diff to confirm protected-path checks and the dep type (runtime vs dev vs types vs actions): `gh pr diff <#>`.
+   - Read the diff to confirm protected-path checks: `gh pr diff <#>`.
    - Check CI status: `gh pr checks <#>`.
-   - Read the upstream changelog for the version delta. For npm packages: the package's GitHub releases page or the CHANGELOG.md in their repo (linked from the registry). For GitHub Actions: the action's release notes.
-   - For runtime majors, grep the repo for callers of the changed APIs to gauge fixup surface.
+   - For runtime majors (rule 3), read the upstream changelog to confirm whether the bump fits the framework / security-sensitive / pre-1.0 → 1.0 categories.
 
-3. For each PR, choose ONE outcome per the rules table:
-   - **Skip** (matches a skip rule): apply the matching `ralphie:skip-*` label and post the rules-shape skip comment. Use `gh pr edit <#> --add-label "<label>"` and `gh pr comment <#> --body "..."`.
-   - **Tier 1/2/3**: apply the matching `ralphie:tier-{1,2,3}-*` label and post the rules-shape classification comment. Both label and comment are required.
+3. For each PR, choose ONE outcome:
+   - **Skip** (matches a rule): apply the matching `ralphie:skip-*` label and post the rules-shape skip comment. Use `gh pr edit <#> --add-label "<label>"` and `gh pr comment <#> --body "..."`.
+   - **Eligible** (passes rules 1–3): leave the PR untouched. Unlabeled = queued for Phase 2.
 
 4. ${DRY_RUN_NOTE}
 
-5. When the queue is exhausted, print a one-line summary: `Triaged N PRs: T1=<n> tier-1-safe, T2=<n> tier-2-adapt, T3=<n> tier-3-manual, S=<n> skipped.` Exit.
+5. When the queue is exhausted, print a one-line summary: `Triaged N PRs: X skipped, Y eligible.` Exit.
 
-**[1]** Apply rules in order — first match wins. Don't evaluate later rules if an earlier one trips.
+**[1]** Apply rules in order — first match wins. Don't evaluate rule 3 if rule 1 already trips.
 **[2]** Never write code in this phase. Never branch, commit, push, merge, or open a PR. Triage is read-only on the repo and write-only on GitHub metadata (labels + comments).
-**[3]** A skip comment is for the human; the label is for the next run. Both are required for a skip.
-**[4]** A tier comment is for the human reviewing the queue and for the Phase 2 session that picks up the PR. Both the comment and the label are required.
+**[3]** A skip comment is for the human; the label is for the next Ralphie. Both are required for a skip.
+**[4]** If the rules are ambiguous about a PR, lean toward eligible — Phase 2 has its own gates (rules 4–5). False eligibility is cheaper than false skip.
 **[5]** Never apply two `ralphie:*` labels to the same PR. First match wins.
 **[6]** If `gh` returns an empty queue, exit 0 silently. No error, no comment.
-**[7]** When the rules are ambiguous about a PR's tier, lean toward the higher tier (more human review). False tier-3 is cheaper than false tier-1.

--- a/happyhq/.dev/PROMPT_dependency_triage.md
+++ b/happyhq/.dev/PROMPT_dependency_triage.md
@@ -1,0 +1,27 @@
+0a. Read @dependency-rules.md — this is the spec. Apply it literally.
+0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rules.
+
+1. Get the queue: `gh pr list --author "app/dependabot" --state open --limit 100 --json number,title,headRefName,labels,createdAt --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)] | sort_by(.createdAt)'`. Empty → exit cleanly.
+
+2. For each PR in the queue (oldest first), in parallel where it makes sense (use Sonnet subagents for changelog reads / code searches), evaluate against tier rules 1–10. For each PR:
+   - Read the PR body and labels: `gh pr view <#> --comments`.
+   - Read the diff to confirm protected-path checks and the dep type (runtime vs dev vs types vs actions): `gh pr diff <#>`.
+   - Check CI status: `gh pr checks <#>`.
+   - Read the upstream changelog for the version delta. For npm packages: the package's GitHub releases page or the CHANGELOG.md in their repo (linked from the registry). For GitHub Actions: the action's release notes.
+   - For runtime majors, grep the repo for callers of the changed APIs to gauge fixup surface.
+
+3. For each PR, choose ONE outcome per the rules table:
+   - **Skip** (matches a skip rule): apply the matching `ralphie:skip-*` label and post the rules-shape skip comment. Use `gh pr edit <#> --add-label "<label>"` and `gh pr comment <#> --body "..."`.
+   - **Tier 1/2/3**: apply the matching `ralphie:tier-{1,2,3}-*` label and post the rules-shape classification comment. Both label and comment are required.
+
+4. ${DRY_RUN_NOTE}
+
+5. When the queue is exhausted, print a one-line summary: `Triaged N PRs: T1=<n> tier-1-safe, T2=<n> tier-2-adapt, T3=<n> tier-3-manual, S=<n> skipped.` Exit.
+
+**[1]** Apply rules in order — first match wins. Don't evaluate later rules if an earlier one trips.
+**[2]** Never write code in this phase. Never branch, commit, push, merge, or open a PR. Triage is read-only on the repo and write-only on GitHub metadata (labels + comments).
+**[3]** A skip comment is for the human; the label is for the next run. Both are required for a skip.
+**[4]** A tier comment is for the human reviewing the queue and for the Phase 2 session that picks up the PR. Both the comment and the label are required.
+**[5]** Never apply two `ralphie:*` labels to the same PR. First match wins.
+**[6]** If `gh` returns an empty queue, exit 0 silently. No error, no comment.
+**[7]** When the rules are ambiguous about a PR's tier, lean toward the higher tier (more human review). False tier-3 is cheaper than false tier-1.

--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -1,0 +1,65 @@
+0a. Read @dependency-rules.md — this is the spec. Apply it literally.
+0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rules.
+0c. The PR you are working: #${PR_NUMBER}. Read it: `gh pr view ${PR_NUMBER} --comments`. Note the tier label (`ralphie:tier-1-safe` or `ralphie:tier-2-adapt`) — Phase 2 only processes those two.
+
+1. **Checkout the PR branch.** From `main`: `git checkout main && git pull`. Then: `gh pr checkout ${PR_NUMBER}`. Capture the branch name (`git branch --show-current`) for later reference; you'll need it if you fall through to Path B.
+
+2. **Install.** From the repo root: `pnpm install --frozen-lockfile`. If it fails because the lockfile drifted, run `pnpm install` (no frozen) and treat any unexpected lockfile diff beyond what Dependabot already wrote as a signal to investigate before continuing.
+
+3. **Verify.** From `happyhq/`:
+   - `pnpm format`
+   - `pnpm lint`
+   - `pnpm check-types`
+   - `pnpm --filter=happyhq test`
+   - `npx tsx scripts/smoke-test.ts` (start the dev server first if the script needs it; see @CLAUDE.md "Using HappyHQ's API")
+
+4. **Branch on the result:**
+
+   **Path A — clean (Tier 1, or Tier 2 where nothing actually broke):**
+   - Merge: `gh pr merge ${PR_NUMBER} --squash --delete-branch`.
+   - Comment: `gh pr comment ${PR_NUMBER} --body "Ralphie merged this. Verification: lint/types/test/smoke clean."`
+   - Label: `gh pr edit ${PR_NUMBER} --add-label "ralphie:merged"`. (Post-merge labels are fine — they're just for searchability.)
+   - Return to main: `git checkout main && git pull`.
+   - Exit.
+
+   **Path B — Tier 2 with breaking changes (verification step 3 failed):**
+   - **Plan from the changelog first.** Read the upstream release notes / migration guide for the version delta. Identify which breaking change(s) caused the failures. Quote the relevant entries in the work plan. If the failure mode isn't predicted by the changelog, **stop**: apply `ralphie:skip-verification-failed` to the original PR with the failure output included, return to main, exit.
+   - Return to main: `git checkout main`. Note Dependabot's branch name from step 1 — you'll need to read files from it.
+   - Create a fresh branch: `git checkout -b chore/upgrade-<package>-v<major>` (use the package name and target major, e.g., `chore/upgrade-stripe-v22`).
+   - Apply the version bump from the Dependabot branch to your fresh branch:
+     ```
+     git checkout <dependabot-branch-name> -- happyhq/package.json pnpm-lock.yaml
+     pnpm install
+     ```
+     (Adjust paths if the Dependabot PR also touched the root `package.json` or other workspace `package.json` files.)
+   - Apply the smallest set of fixups required to pass verification. Cite the changelog item that justifies each fixup in commit messages — the diff and the changelog should map 1:1.
+   - Re-run verification (step 3). If it fails, fix and re-run. If it fails twice, apply `ralphie:skip-verification-failed` to the original PR with the failing output. Push nothing. Return to main. Exit.
+   - **Size gate.** `git diff --stat main...HEAD -- ':!happyhq/package.json' ':!package.json' ':!pnpm-lock.yaml' ':!*.md' ':!*.mdx'`. If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` to the original PR with a summary of what the fixup would have entailed. Leave the local branch in place (do not push). Return to main. Exit.
+   - Commit: `git add -A && git commit -m "chore: upgrade <package> to v<major>"` (one commit per discrete fixup is also fine; cite the changelog item in each commit body).
+   - Push: `git push -u origin chore/upgrade-<package>-v<major>`.
+   - Open replacement PR: `gh pr create --base main --assignee @me --title "chore: upgrade <package> to v<major>" --body "..."`. PR body MUST include:
+     - `Replaces #${PR_NUMBER}`
+     - One paragraph identifying the breaking changes that required fixups
+     - Quoted excerpts from the upstream changelog with links
+     - One bullet per fixup, mapping diff to changelog item (e.g., `- lib/billing.ts:42 — renamed stripe.charges.create → stripe.payments.create per migration guide`)
+     - Verification summary (lint/types/test/smoke output, all green)
+     - AI-assistance disclosure per @CONTRIBUTING.md (e.g., "Authored by Ralphie, the autonomous dependency-upgrade loop. Reviewed by maintainer before merge.")
+   - Capture the new PR number from the create output.
+   - Close the original Dependabot PR with the rules-shape replacement comment, then label it: `gh pr edit ${PR_NUMBER} --add-label "ralphie:replaced-by-#<new>"` (use the new PR number in the label name). Then close: `gh pr close ${PR_NUMBER}` (the comment + label go on first; closing is the last write).
+   - Return to main: `git checkout main`.
+   - Exit.
+
+5. ${DRY_RUN_NOTE}
+
+6. ${OVERRIDE_NOTE}
+
+7. Exit.
+
+**[1]** ONE PR per session. Do not pick up other PRs, do not chain. The orchestrator handles the next one.
+**[2]** Hard constraints from @dependency-rules.md are non-negotiable: never push to `main`, never push to a Dependabot branch, never modify `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files. If the fixup would require any of these, apply `ralphie:skip-out-of-scope` and exit.
+**[3]** Cite the changelog. Every Tier 2 fixup commit message and the replacement PR body must reference the upstream changelog / migration guide entry that justifies the change. If you can't find a changelog entry for what you're fixing, you've drifted off the rails — stop and skip.
+**[4]** Smallest fixup. Don't refactor adjacent code. Don't update unrelated callers. Surface drift via PR-body comments, not by widening the diff.
+**[5]** Stop when surprised. If a test failure isn't predicted by the changelog, or you can't trace a diff line to a documented change, apply `ralphie:skip-verification-failed` and let the human take it.
+**[6]** AI disclosure in the replacement PR body is required by @CONTRIBUTING.md.
+**[7]** Always end on `main` with a clean working tree, even on skip paths.
+**[8]** Replacement PRs are not auto-merged. They go to the human's review queue. The loop's job ends at "complete, well-documented PR open."

--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -1,6 +1,6 @@
 0a. Read @dependency-rules.md — this is the spec. Apply it literally.
 0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rules.
-0c. The PR you are working: #${PR_NUMBER}. Read it: `gh pr view ${PR_NUMBER} --comments`. Note the tier label (`ralphie:tier-1-safe` or `ralphie:tier-2-adapt`) — Phase 2 only processes those two.
+0c. The PR you are working: #${PR_NUMBER}. Read it: `gh pr view ${PR_NUMBER} --comments`. Phase 2 only processes Dependabot PRs that passed triage (no `ralphie:*` label).
 
 1. **Checkout the PR branch.** From `main`: `git checkout main && git pull`. Then: `gh pr checkout ${PR_NUMBER}`. Capture the branch name (`git branch --show-current`) for later reference; you'll need it if you fall through to Path B.
 
@@ -15,14 +15,13 @@
 
 4. **Branch on the result:**
 
-   **Path A — clean (Tier 1, or Tier 2 where nothing actually broke):**
+   **Path A — clean (verification passed):**
    - Merge: `gh pr merge ${PR_NUMBER} --squash --delete-branch`.
    - Comment: `gh pr comment ${PR_NUMBER} --body "Ralphie merged this. Verification: lint/types/test/smoke clean."`
-   - Label: `gh pr edit ${PR_NUMBER} --add-label "ralphie:merged"`. (Post-merge labels are fine — they're just for searchability.)
    - Return to main: `git checkout main && git pull`.
-   - Exit.
+   - Exit. (No label needed — the merged state is the signal.)
 
-   **Path B — Tier 2 with breaking changes (verification step 3 failed):**
+   **Path B — verification failed (breaking-change fixups):**
    - **Plan from the changelog first.** Read the upstream release notes / migration guide for the version delta. Identify which breaking change(s) caused the failures. Quote the relevant entries in the work plan. If the failure mode isn't predicted by the changelog, **stop**: apply `ralphie:skip-verification-failed` to the original PR with the failure output included, return to main, exit.
    - Return to main: `git checkout main`. Note Dependabot's branch name from step 1 — you'll need to read files from it.
    - Create a fresh branch: `git checkout -b chore/upgrade-<package>-v<major>` (use the package name and target major, e.g., `chore/upgrade-stripe-v22`).
@@ -44,8 +43,8 @@
      - One bullet per fixup, mapping diff to changelog item (e.g., `- lib/billing.ts:42 — renamed stripe.charges.create → stripe.payments.create per migration guide`)
      - Verification summary (lint/types/test/smoke output, all green)
      - AI-assistance disclosure per @CONTRIBUTING.md (e.g., "Authored by Ralphie, the autonomous dependency-upgrade loop. Reviewed by maintainer before merge.")
-   - Capture the new PR number from the create output.
-   - Close the original Dependabot PR with the rules-shape replacement comment, then label it: `gh pr edit ${PR_NUMBER} --add-label "ralphie:replaced-by-#<new>"` (use the new PR number in the label name). Then close: `gh pr close ${PR_NUMBER}` (the comment + label go on first; closing is the last write).
+   - Capture the new PR number from the create output. Create the dynamic label if it doesn't exist: `gh label create "ralphie:replaced-by-#<new>" --color "5319E7" --description "Ralphie closed this in favor of replacement PR #<new>"` (ignore "already exists" errors).
+   - Close the original Dependabot PR with the rules-shape replacement comment, label it `ralphie:replaced-by-#<new>`, then close: `gh pr edit ${PR_NUMBER} --add-label "ralphie:replaced-by-#<new>"`, `gh pr comment ${PR_NUMBER} --body "..."`, `gh pr close ${PR_NUMBER}` (label + comment go on first; closing is the last write).
    - Return to main: `git checkout main`.
    - Exit.
 
@@ -57,7 +56,7 @@
 
 **[1]** ONE PR per session. Do not pick up other PRs, do not chain. The orchestrator handles the next one.
 **[2]** Hard constraints from @dependency-rules.md are non-negotiable: never push to `main`, never push to a Dependabot branch, never modify `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files. If the fixup would require any of these, apply `ralphie:skip-out-of-scope` and exit.
-**[3]** Cite the changelog. Every Tier 2 fixup commit message and the replacement PR body must reference the upstream changelog / migration guide entry that justifies the change. If you can't find a changelog entry for what you're fixing, you've drifted off the rails — stop and skip.
+**[3]** Cite the changelog. Every fixup commit message and the replacement PR body must reference the upstream changelog / migration guide entry that justifies the change. If you can't find a changelog entry for what you're fixing, you've drifted off the rails — stop and skip with `ralphie:skip-verification-failed`.
 **[4]** Smallest fixup. Don't refactor adjacent code. Don't update unrelated callers. Surface drift via PR-body comments, not by widening the diff.
 **[5]** Stop when surprised. If a test failure isn't predicted by the changelog, or you can't trace a diff line to a documented change, apply `ralphie:skip-verification-failed` and let the human take it.
 **[6]** AI disclosure in the replacement PR body is required by @CONTRIBUTING.md.

--- a/happyhq/.dev/dependency-rules.md
+++ b/happyhq/.dev/dependency-rules.md
@@ -5,39 +5,27 @@ Source of truth for how the deps loop processes open Dependabot PRs. Both `PROMP
 ## Queue contract
 
 - The queue is: open PRs authored by `app/dependabot` with no label starting with `ralphie:`.
-- A `ralphie:*` label is terminal for that phase: triage labels mark the PR as classified; Phase 2 advances tier-labeled PRs to a final state (merged, replaced, or skip).
-- One outcome per session.
+- A `ralphie:*` label is terminal — Ralphie never re-evaluates a labeled PR. The human removes the label to re-queue.
+- One outcome per session (a label, a merge, or a replacement PR).
 
-## Triage tiers (Phase 1)
+## Rules
 
-Apply in order — first match wins. Bail at the earliest stop.
+Apply in order — bail at the earliest stop. The first three are evaluable from the PR text alone (Phase 1 — triage). The last three only show up after attempting an upgrade (Phase 2).
 
-| #   | Condition                                                                                                                                                    | Label applied               | Phase 2 picks up?       |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------- | ----------------------- |
-| 1   | PR diff would touch `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files                                                            | `ralphie:skip-out-of-scope` | No — human only         |
-| 2   | CI on the PR is red and the failure is unrelated to the version bump (infra flake, lint config drift, network timeout, etc.)                                 | `ralphie:skip-ci-red`       | No — human investigates |
-| 3   | Update is a major bump on a framework runtime (`next`, `react`, `react-dom`) — should have been ignored upstream by `dependabot.yml` but slipped through     | `ralphie:tier-3-manual`     | No — human upgrades     |
-| 4   | Update is a major bump on a security-sensitive runtime dep (auth, crypto, billing primitives — e.g., `stripe` ≥2 majors at once, `instantdb`, JWT/OIDC libs) | `ralphie:tier-3-manual`     | No                      |
-| 5   | Update is a pre-1.0 → 1.0 jump on a runtime dep (`dependencies`, not `devDependencies`)                                                                      | `ralphie:tier-3-manual`     | No                      |
-| 6   | Update is a major bump on a runtime dep (single-major, in `dependencies`) where the changelog identifies discrete breaking changes                           | `ralphie:tier-2-adapt`      | Yes — attempts fixups   |
-| 7   | Update is a major bump on a dev/types/tooling dep (`@types/*`, dev-only ESLint plugins, etc.)                                                                | `ralphie:tier-1-safe`       | Yes — verify and merge  |
-| 8   | Update is from an official-publisher GitHub Action (`actions/*`, `github/*`, `pnpm/*`, `docker/*`) with no input renames in the changelog                    | `ralphie:tier-1-safe`       | Yes                     |
-| 9   | Update is a minor/patch group PR with green CI                                                                                                               | `ralphie:tier-1-safe`       | Yes                     |
-| 10  | Anything else                                                                                                                                                | `ralphie:tier-2-adapt`      | Yes — best-effort       |
+| #   | Condition                                                                                                                                                                                                                      | Label applied                      | What unblocks it                                     |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------- |
+| 1   | PR diff would touch `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files                                                                                                                              | `ralphie:skip-out-of-scope`        | Maintainer scopes the change; remove label           |
+| 2   | CI on the PR is red and the failure is unrelated to the version bump (infra flake, lint config drift, network timeout, etc.)                                                                                                   | `ralphie:skip-ci-red`              | Investigate the CI failure; remove label             |
+| 3   | Update is one of: framework major (`next`, `react`, `react-dom`); security-sensitive runtime major (auth, crypto, billing — e.g., `stripe` ≥2 majors at once, `instantdb`, JWT/OIDC libs); pre-1.0 → 1.0 jump on a runtime dep | `ralphie:skip-manual-upgrade`      | Maintainer upgrades and reviews; remove label        |
+| 4   | (Phase 2) Fixups would exceed 10 files or 300 lines net added (`*.md`/`*.mdx` and lockfile/package.json excluded from the count)                                                                                               | `ralphie:skip-too-big`             | Scope it down or do it manually                      |
+| 5   | (Phase 2) `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` / `npx tsx scripts/smoke-test.ts` failed twice                                                                                       | `ralphie:skip-verification-failed` | Read Ralphie's comment; fix locally                  |
+| 6   | (Phase 2) Replacement PR shipped (Tier 2 / breaking-change fixups path)                                                                                                                                                        | `ralphie:replaced-by-#<new>`       | Terminal — the linked replacement PR closes the loop |
 
-When the rules are ambiguous about a PR's tier, lean toward the higher tier (more human review). False tier-3 is cheaper than false tier-1.
-
-## Phase 2 outcomes
-
-| Condition                                                                                                                                                        | Final state                                       |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| Install + verify (`lint`, `check-types`, `test`) + smoke clean → merge Dependabot PR as-is                                                                       | PR merged; `ralphie:merged`                       |
-| Tier 2: verification fails. Breaking changes cited from changelog, fixups applied from a fresh `chore/upgrade-<pkg>-vN` branch off `main`, replacement PR opened | Original closed; `ralphie:replaced-by-#<new>`     |
-| Tier 2: fixups would exceed 10 files / 300 lines net added (`*.md`/`*.mdx` and lockfile/package.json excluded from the count)                                    | `ralphie:skip-too-big` on original PR             |
-| Verification (`pnpm format` / `lint` / `check-types` / `--filter=happyhq test` / `scripts/smoke-test.ts`) failed twice                                           | `ralphie:skip-verification-failed` on original PR |
-| Fixups would touch protected paths (`happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, licensing)                                                        | `ralphie:skip-out-of-scope` on original PR        |
+A PR that passes rules 1–3 is **eligible** — it stays unlabeled and Phase 2 picks it up. Phase 2 either merges Dependabot's PR as-is (Path A — install + verify clean) or, when the bump introduces breaking changes that prevent verification, generates the smallest changelog-cited fixups on a fresh `chore/upgrade-<pkg>-vN` branch off `main` and opens a replacement PR for human review (Path B).
 
 ## Comment shape (skips)
+
+Every skip writes one comment, in this shape:
 
 ```
 Ralphie skipped this for: <rule name>
@@ -45,18 +33,6 @@ Ralphie skipped this for: <rule name>
 What I saw: <1–3 sentences — the specific evidence that triggered the rule>
 
 What would unblock it: <1 sentence — concrete action for the human>
-```
-
-## Comment shape (tier classifications, posted in triage)
-
-```
-Ralphie classified this as: <tier name>
-
-Update: <package> <from> → <to> (<dep type: runtime / dev / types / actions>, <semver category: major / minor / patch / group>)
-
-Changelog highlights: <2–4 bullets from the upstream changelog with links — only if relevant to behavior>
-
-Plan: <one sentence — what Phase 2 will do, or what the human should do for tier-3>
 ```
 
 ## Comment shape (replacement, posted on the original Dependabot PR)
@@ -81,9 +57,9 @@ Replacement: <link to new PR>
 
 ## Principles
 
-These tune _how_ allowed work gets done.
+These are guidance, not gates. The rules above are pass/fail; these tune _how_ allowed work gets done.
 
-**Cite the changelog.** Every Tier 2 fixup PR description must link to the upstream release notes / migration guide and quote the relevant breaking-change item(s). The reviewer should be able to trace each diff line back to a documented change. If the changelog doesn't mention something the fixup is reacting to, that's a signal to stop and skip.
+**Cite the changelog.** Every replacement PR description must link to the upstream release notes / migration guide and quote the relevant breaking-change item(s). The reviewer should be able to trace each diff line back to a documented change. If the changelog doesn't mention something the fixup is reacting to, that's a signal to stop and skip with `ralphie:skip-verification-failed`.
 
 **Smallest fixup that compiles + passes tests + smoke-tests clean.** Don't refactor adjacent code. Don't take on tech-debt cleanup. Don't update unrelated callers. Surface drift via comments in the PR body, not by widening the diff.
 
@@ -95,4 +71,4 @@ These tune _how_ allowed work gets done.
 
 ## Tuning signal
 
-When the loop gets it wrong — labels something `tier-1-safe` that should have been `tier-3-manual`, opens a replacement PR with bad fixups, misses a protected-path edit — that's a rule-tuning signal, not a one-off correction. Edit this file. The next run will pick up the change.
+When the loop gets it wrong — labels something `skip-manual-upgrade` that wasn't, opens a replacement PR with bad fixups, misses a protected-path edit — that's a rule-tuning signal, not a one-off correction. Edit this file. The next run will pick up the change.

--- a/happyhq/.dev/dependency-rules.md
+++ b/happyhq/.dev/dependency-rules.md
@@ -1,0 +1,98 @@
+# Dependency Rules
+
+Source of truth for how the deps loop processes open Dependabot PRs. Both `PROMPT_dependency_triage.md` and `PROMPT_dependency_upgrade.md` load this file. Edit here, not in the prompts.
+
+## Queue contract
+
+- The queue is: open PRs authored by `app/dependabot` with no label starting with `ralphie:`.
+- A `ralphie:*` label is terminal for that phase: triage labels mark the PR as classified; Phase 2 advances tier-labeled PRs to a final state (merged, replaced, or skip).
+- One outcome per session.
+
+## Triage tiers (Phase 1)
+
+Apply in order — first match wins. Bail at the earliest stop.
+
+| #   | Condition                                                                                                                                                    | Label applied               | Phase 2 picks up?       |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------- | ----------------------- |
+| 1   | PR diff would touch `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files                                                            | `ralphie:skip-out-of-scope` | No — human only         |
+| 2   | CI on the PR is red and the failure is unrelated to the version bump (infra flake, lint config drift, network timeout, etc.)                                 | `ralphie:skip-ci-red`       | No — human investigates |
+| 3   | Update is a major bump on a framework runtime (`next`, `react`, `react-dom`) — should have been ignored upstream by `dependabot.yml` but slipped through     | `ralphie:tier-3-manual`     | No — human upgrades     |
+| 4   | Update is a major bump on a security-sensitive runtime dep (auth, crypto, billing primitives — e.g., `stripe` ≥2 majors at once, `instantdb`, JWT/OIDC libs) | `ralphie:tier-3-manual`     | No                      |
+| 5   | Update is a pre-1.0 → 1.0 jump on a runtime dep (`dependencies`, not `devDependencies`)                                                                      | `ralphie:tier-3-manual`     | No                      |
+| 6   | Update is a major bump on a runtime dep (single-major, in `dependencies`) where the changelog identifies discrete breaking changes                           | `ralphie:tier-2-adapt`      | Yes — attempts fixups   |
+| 7   | Update is a major bump on a dev/types/tooling dep (`@types/*`, dev-only ESLint plugins, etc.)                                                                | `ralphie:tier-1-safe`       | Yes — verify and merge  |
+| 8   | Update is from an official-publisher GitHub Action (`actions/*`, `github/*`, `pnpm/*`, `docker/*`) with no input renames in the changelog                    | `ralphie:tier-1-safe`       | Yes                     |
+| 9   | Update is a minor/patch group PR with green CI                                                                                                               | `ralphie:tier-1-safe`       | Yes                     |
+| 10  | Anything else                                                                                                                                                | `ralphie:tier-2-adapt`      | Yes — best-effort       |
+
+When the rules are ambiguous about a PR's tier, lean toward the higher tier (more human review). False tier-3 is cheaper than false tier-1.
+
+## Phase 2 outcomes
+
+| Condition                                                                                                                                                        | Final state                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Install + verify (`lint`, `check-types`, `test`) + smoke clean → merge Dependabot PR as-is                                                                       | PR merged; `ralphie:merged`                       |
+| Tier 2: verification fails. Breaking changes cited from changelog, fixups applied from a fresh `chore/upgrade-<pkg>-vN` branch off `main`, replacement PR opened | Original closed; `ralphie:replaced-by-#<new>`     |
+| Tier 2: fixups would exceed 10 files / 300 lines net added (`*.md`/`*.mdx` and lockfile/package.json excluded from the count)                                    | `ralphie:skip-too-big` on original PR             |
+| Verification (`pnpm format` / `lint` / `check-types` / `--filter=happyhq test` / `scripts/smoke-test.ts`) failed twice                                           | `ralphie:skip-verification-failed` on original PR |
+| Fixups would touch protected paths (`happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, licensing)                                                        | `ralphie:skip-out-of-scope` on original PR        |
+
+## Comment shape (skips)
+
+```
+Ralphie skipped this for: <rule name>
+
+What I saw: <1–3 sentences — the specific evidence that triggered the rule>
+
+What would unblock it: <1 sentence — concrete action for the human>
+```
+
+## Comment shape (tier classifications, posted in triage)
+
+```
+Ralphie classified this as: <tier name>
+
+Update: <package> <from> → <to> (<dep type: runtime / dev / types / actions>, <semver category: major / minor / patch / group>)
+
+Changelog highlights: <2–4 bullets from the upstream changelog with links — only if relevant to behavior>
+
+Plan: <one sentence — what Phase 2 will do, or what the human should do for tier-3>
+```
+
+## Comment shape (replacement, posted on the original Dependabot PR)
+
+```
+Ralphie replaced this with #<new>.
+
+Why: <one sentence — what breaking change(s) the bump required fixups for>
+
+Changelog: <link>
+
+Replacement: <link to new PR>
+```
+
+## Hard constraints (never violate)
+
+- Never push to `main`. Never force-push. Never `--no-verify`.
+- Never modify files under `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files. If the fixup would require any of these, apply `ralphie:skip-out-of-scope` and exit.
+- Never push to a Dependabot branch. Replacement work happens on a fresh `chore/upgrade-<pkg>-v<N>` branch off `main`.
+- Replacement PRs target `main`, use the `chore/` prefix, and include `Replaces #<original>` plus an AI-assistance disclosure (per `CONTRIBUTING.md`).
+- One outcome per session. After labeling, merging, or opening a replacement, exit.
+
+## Principles
+
+These tune _how_ allowed work gets done.
+
+**Cite the changelog.** Every Tier 2 fixup PR description must link to the upstream release notes / migration guide and quote the relevant breaking-change item(s). The reviewer should be able to trace each diff line back to a documented change. If the changelog doesn't mention something the fixup is reacting to, that's a signal to stop and skip.
+
+**Smallest fixup that compiles + passes tests + smoke-tests clean.** Don't refactor adjacent code. Don't take on tech-debt cleanup. Don't update unrelated callers. Surface drift via comments in the PR body, not by widening the diff.
+
+**Stop when surprised.** If a test failure isn't predicted by the changelog, or you can't trace a diff line to a documented change, apply `ralphie:skip-verification-failed` with the failure output included. Don't speculate — the human takes it from there.
+
+**Look around.** Before writing a fixup, search for prior usage of the changed APIs across the repo. Most "we keep fixing this" pain comes from rederiving in isolation when a reference exists.
+
+**The PR is the gate.** Replacement PRs go to `main` for human review — they are not auto-merged. The loop's job is to put a complete, well-documented upgrade in front of the maintainer; the maintainer's job is to click merge.
+
+## Tuning signal
+
+When the loop gets it wrong — labels something `tier-1-safe` that should have been `tier-3-manual`, opens a replacement PR with bad fixups, misses a protected-path edit — that's a rule-tuning signal, not a one-off correction. Edit this file. The next run will pick up the change.

--- a/happyhq/.dev/dependency.sh
+++ b/happyhq/.dev/dependency.sh
@@ -150,7 +150,7 @@ if [ $UPGRADE_ONLY -eq 0 ]; then
     fi
 fi
 
-# ── Phase 2: Upgrade loop (one session per PR; tier-1 first, then tier-2) ──
+# ── Phase 2: Upgrade loop (one session per eligible PR — oldest first) ──
 DEPS_DONE=0
 while [ $DEPS_DONE -lt $MAX_DEPS ]; do
     NEXT=$(gh pr list \
@@ -158,15 +158,7 @@ while [ $DEPS_DONE -lt $MAX_DEPS ]; do
         --state open \
         --limit 100 \
         --json number,labels,createdAt \
-        --jq '
-            [.[] | select(
-                ([.labels[].name | select(. == "ralphie:tier-1-safe" or . == "ralphie:tier-2-adapt")] | length > 0)
-                and
-                ([.labels[].name | select(startswith("ralphie:") and . != "ralphie:tier-1-safe" and . != "ralphie:tier-2-adapt")] | length == 0)
-            )]
-            | sort_by((.labels | map(.name) | if any(. == "ralphie:tier-1-safe") then 0 else 1 end), .createdAt)
-            | .[0].number // empty
-        ' 2>/dev/null)
+        --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)] | sort_by(.createdAt) | .[0].number // empty' 2>/dev/null)
 
     if [ -z "$NEXT" ]; then
         echo -e "\n  ${GREEN}✓${RESET} Queue empty. $DEPS_DONE PR(s) attempted. Exiting."
@@ -182,13 +174,14 @@ while [ $DEPS_DONE -lt $MAX_DEPS ]; do
         exit $SESSION_EXIT
     fi
 
-    # Verify the PR moved to a terminal state (merged/closed) OR got a non-tier ralphie:* label.
-    # Otherwise the next iteration would re-pick it forever.
+    # Verify the PR moved to a terminal state — either closed (merged or replaced)
+    # or labeled with a ralphie:skip-* / ralphie:replaced-by-* label. Otherwise the
+    # next iteration would re-pick it forever.
     PR_INFO=$(gh pr view "$NEXT" --json state,labels 2>/dev/null)
     STATE=$(echo "$PR_INFO" | jq -r '.state')
-    NON_TIER_RALPHIE=$(echo "$PR_INFO" | jq '[.labels[].name | select(startswith("ralphie:") and . != "ralphie:tier-1-safe" and . != "ralphie:tier-2-adapt")] | length')
-    if [ "$STATE" = "OPEN" ] && [ "$NON_TIER_RALPHIE" = "0" ]; then
-        echo -e "  ${RED}PR #$NEXT is still open with only its tier label after the session — aborting loop to avoid re-picking it.${RESET}"
+    HAS_RALPHIE_LABEL=$(echo "$PR_INFO" | jq '[.labels[].name | select(startswith("ralphie:"))] | length')
+    if [ "$STATE" = "OPEN" ] && [ "$HAS_RALPHIE_LABEL" = "0" ]; then
+        echo -e "  ${RED}PR #$NEXT is still open with no ralphie:* label after the session — aborting loop to avoid re-picking it.${RESET}"
         exit 1
     fi
 

--- a/happyhq/.dev/dependency.sh
+++ b/happyhq/.dev/dependency.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+set -o pipefail
+# Usage: ./dependency.sh [options]
+#   ./dependency.sh                          # triage + upgrade loop, default --max-deps 3
+#   ./dependency.sh --max-deps 5             # cap Phase 2 attempts at 5
+#   ./dependency.sh --triage-only            # Phase 1 only
+#   ./dependency.sh --upgrade-only           # skip Phase 1, run upgrade loop on the queue
+#   ./dependency.sh --pr 124                 # skip triage; one upgrade session against PR #124
+#   ./dependency.sh --pr 124 --override      # bypass self-skip rules (size, verification) for that PR
+#   ./dependency.sh --dry-run                # Phase 1 preview only, no writes
+#   ./dependency.sh --pr 124 --dry-run       # preview a single upgrade session, no writes
+
+DIM='\033[2m'
+BOLD='\033[1m'
+GREEN='\033[32m'
+CYAN='\033[36m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+MAX_DEPS=3
+TRIAGE_ONLY=0
+UPGRADE_ONLY=0
+SINGLE_PR=""
+DRY_RUN=""
+OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --max-deps)
+            MAX_DEPS="$2"
+            shift 2
+            ;;
+        --triage-only)
+            TRIAGE_ONLY=1
+            shift
+            ;;
+        --upgrade-only)
+            UPGRADE_ONLY=1
+            shift
+            ;;
+        --pr)
+            SINGLE_PR="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --override)
+            OVERRIDE=1
+            shift
+            ;;
+        -h|--help)
+            sed -n '3,11p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ $TRIAGE_ONLY -eq 1 ] && [ $UPGRADE_ONLY -eq 1 ]; then
+    echo "Error: --triage-only and --upgrade-only are mutually exclusive" >&2
+    exit 1
+fi
+if [ $UPGRADE_ONLY -eq 1 ] && [ -n "$DRY_RUN" ]; then
+    echo "Error: --upgrade-only --dry-run isn't supported (dry-run on upgrades wastes a real session). Use --pr <#> --dry-run to preview a single upgrade." >&2
+    exit 1
+fi
+if [ -n "$OVERRIDE" ] && [ -z "$SINGLE_PR" ]; then
+    echo "Error: --override is only valid with --pr <#>. The Phase 2 auto-loop must always respect skip gates." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+cleanup() {
+    echo -e "\n${DIM}Cleaning up child processes...${RESET}"
+    pkill -P $$ 2>/dev/null
+    pkill -f "node.*vitest" 2>/dev/null
+    pkill -f "next dev" 2>/dev/null
+    exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+if [ -n "$DRY_RUN" ]; then
+    export DRY_RUN_NOTE="**DRY RUN MODE**: For every action that would write to GitHub or the repo (labels, comments, branches, commits, pushes, PRs, merges, closes), print one line prefixed with 'DRY-RUN:' describing what you WOULD do, then SKIP the actual call. Do not invoke any 'gh pr edit', 'gh pr comment', 'gh pr merge', 'gh pr close', 'gh pr create', 'git commit', 'git push', or filesystem write outside of pnpm install / verification scratch. Reads (gh pr view/list/diff/checks, code search, file reads, pnpm install, verification scripts, smoke tests) are fine."
+else
+    export DRY_RUN_NOTE=""
+fi
+
+if [ -n "$OVERRIDE" ]; then
+    export OVERRIDE_NOTE="**OVERRIDE MODE**: The maintainer invoked --override on this single-PR session. Skip the soft self-skip checks: do NOT apply ralphie:skip-too-big or ralphie:skip-verification-failed, and do NOT exit early on those conditions — push and open the replacement PR (or merge) anyway. Hard constraints from rule [2] (no push to main, no push to Dependabot branches, no edits to happyhq/ee/, .github/, CI workflows, dependabot.yml, or licensing files) remain non-negotiable. Note the override in the replacement PR body's AI-disclosure paragraph: 'Maintainer invoked --override; size/verification self-skip gates were bypassed.'"
+else
+    export OVERRIDE_NOTE=""
+fi
+
+run_session() {
+    local prompt_file="$1"
+    local label="$2"
+
+    echo -e "\n  ${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "  ${BOLD}${label}${RESET}"
+    echo -e "  ${DIM}Prompt:${RESET}  $prompt_file"
+    [ -n "$DRY_RUN" ] && echo -e "  ${YELLOW}DRY RUN${RESET}"
+    echo -e "  ${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+
+    if [ ! -f "$prompt_file" ]; then
+        echo -e "  ${RED}Error: $prompt_file not found${RESET}"
+        return 1
+    fi
+
+    envsubst < "$prompt_file" | claude -p \
+        --dangerously-skip-permissions \
+        --output-format=stream-json \
+        --model opus \
+        --verbose 2>&1 | node "$SCRIPT_DIR/format-stream.mjs"
+
+    return ${PIPESTATUS[1]}
+}
+
+# ── Single-PR mode: skip triage, run one upgrade session ──
+if [ -n "$SINGLE_PR" ]; then
+    export PR_NUMBER="$SINGLE_PR"
+    run_session "PROMPT_dependency_upgrade.md" "Upgrade #$SINGLE_PR"
+    exit $?
+fi
+
+# ── Phase 1: Triage (skipped with --upgrade-only) ──
+if [ $UPGRADE_ONLY -eq 0 ]; then
+    run_session "PROMPT_dependency_triage.md" "Phase 1 · Triage"
+    TRIAGE_EXIT=$?
+    if [ $TRIAGE_EXIT -ne 0 ]; then
+        echo -e "  ${RED}Triage exited with status $TRIAGE_EXIT — stopping${RESET}"
+        exit $TRIAGE_EXIT
+    fi
+
+    if [ $TRIAGE_ONLY -eq 1 ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Triage complete (--triage-only). Exiting."
+        exit 0
+    fi
+
+    if [ -n "$DRY_RUN" ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Phase 1 preview complete. Skipping Phase 2 in --dry-run (labels weren't applied, so the upgrade queue would re-pick the same PRs). Use --pr <#> --dry-run to preview an upgrade session."
+        exit 0
+    fi
+fi
+
+# ── Phase 2: Upgrade loop (one session per PR; tier-1 first, then tier-2) ──
+DEPS_DONE=0
+while [ $DEPS_DONE -lt $MAX_DEPS ]; do
+    NEXT=$(gh pr list \
+        --author "app/dependabot" \
+        --state open \
+        --limit 100 \
+        --json number,labels,createdAt \
+        --jq '
+            [.[] | select(
+                ([.labels[].name | select(. == "ralphie:tier-1-safe" or . == "ralphie:tier-2-adapt")] | length > 0)
+                and
+                ([.labels[].name | select(startswith("ralphie:") and . != "ralphie:tier-1-safe" and . != "ralphie:tier-2-adapt")] | length == 0)
+            )]
+            | sort_by((.labels | map(.name) | if any(. == "ralphie:tier-1-safe") then 0 else 1 end), .createdAt)
+            | .[0].number // empty
+        ' 2>/dev/null)
+
+    if [ -z "$NEXT" ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Queue empty. $DEPS_DONE PR(s) attempted. Exiting."
+        exit 0
+    fi
+
+    DEPS_DONE=$((DEPS_DONE + 1))
+    export PR_NUMBER="$NEXT"
+    run_session "PROMPT_dependency_upgrade.md" "Phase 2 · PR $DEPS_DONE of max $MAX_DEPS · #$NEXT"
+    SESSION_EXIT=$?
+    if [ $SESSION_EXIT -ne 0 ]; then
+        echo -e "  ${RED}Upgrade session exited with status $SESSION_EXIT — stopping loop${RESET}"
+        exit $SESSION_EXIT
+    fi
+
+    # Verify the PR moved to a terminal state (merged/closed) OR got a non-tier ralphie:* label.
+    # Otherwise the next iteration would re-pick it forever.
+    PR_INFO=$(gh pr view "$NEXT" --json state,labels 2>/dev/null)
+    STATE=$(echo "$PR_INFO" | jq -r '.state')
+    NON_TIER_RALPHIE=$(echo "$PR_INFO" | jq '[.labels[].name | select(startswith("ralphie:") and . != "ralphie:tier-1-safe" and . != "ralphie:tier-2-adapt")] | length')
+    if [ "$STATE" = "OPEN" ] && [ "$NON_TIER_RALPHIE" = "0" ]; then
+        echo -e "  ${RED}PR #$NEXT is still open with only its tier label after the session — aborting loop to avoid re-picking it.${RESET}"
+        exit 1
+    fi
+
+    # Clean up any orphaned vitest/dev-server processes from the session
+    pkill -f "node.*vitest" 2>/dev/null || true
+    pkill -f "next dev" 2>/dev/null || true
+    sleep 1
+done
+
+echo -e "\n  ${YELLOW}Reached --max-deps=$MAX_DEPS. Stopping.${RESET}"


### PR DESCRIPTION
## Summary
Adds the deps loop — Ralphie's autonomous Dependabot triage + upgrade pipeline. Mirrors the bugs loop's two-phase shape (`bugs.sh` → `dependency.sh`) and its plain-language label scheme.

**Phase 1 (Triage)** evaluates each open Dependabot PR against three rules. PRs that match a rule get a `ralphie:skip-*` label and a comment. PRs that pass stay **unlabeled** — that's the queue for Phase 2.

**Phase 2 (Upgrade)** picks the oldest unlabeled Dependabot PR per session:
- **Path A — clean:** install + verify (lint/types/test/smoke) clean → merge Dependabot PR (closed = signal; no label needed).
- **Path B — verification failed:** quote the upstream changelog, branch off `main`, apply the smallest changelog-cited fixups, open a replacement PR for human review, close the Dependabot PR with `ralphie:replaced-by-#<new>`.

**The PR is the gate.** Replacement PRs are not auto-merged — they go to the maintainer's review queue with the changelog quoted line by line and verification output included. Bounded at 10 files / 300 LoC; falls through to `ralphie:skip-too-big` or `ralphie:skip-verification-failed` otherwise.

## Files added (under `happyhq/.dev/`)
- `dependency-rules.md` — queue contract, 6-rule table, hard constraints, principles, tuning signal
- `PROMPT_dependency_triage.md` — Phase 1 prompt
- `PROMPT_dependency_upgrade.md` — Phase 2 prompt with Path A / Path B split
- `dependency.sh` — orchestrator: `--triage-only` / `--upgrade-only` / `--pr <#>` / `--dry-run` / `--override`

## Labels
Every label says what happened in plain English (matches the bugs loop):
- `ralphie:skip-out-of-scope` — would touch protected paths (ee/, .github/, CI, dependabot.yml, licensing)
- `ralphie:skip-ci-red` — CI red on the PR for non-version reasons
- `ralphie:skip-manual-upgrade` — framework major / security-sensitive / pre-1.0→1.0 jump
- `ralphie:skip-too-big` — Phase 2 fixups would exceed 10 files / 300 LoC (shared with bugs loop)
- `ralphie:skip-verification-failed` — Phase 2 tests/smoke failed twice (shared with bugs loop)
- `ralphie:replaced-by-#<N>` — Dependabot PR closed in favor of a maintainer-reviewable replacement PR (created on the fly)

## Test plan
- [ ] `./dependency.sh --help` renders correctly
- [ ] `./dependency.sh --dry-run` previews Phase 1 against the current open Dependabot PRs without applying labels
- [ ] `./dependency.sh --pr <#> --dry-run` previews a single upgrade session
- [ ] First real triage run applies skip labels and posts comments; eligible PRs stay unlabeled
- [ ] First real upgrade session lands either Path A (merge) or Path B (replacement PR) — not stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)