### PR TITLE
fix: validate upload slug with assertSafePathSegment to close log-injection

### DIFF
--- a/happyhq/lib/actions/ingestion.ts
+++ b/happyhq/lib/actions/ingestion.ts
@@ -237,11 +237,17 @@ export async function setupTaskFromChat(
   const validFiles: { from: string; to: string }[] = []
   const seen = new Set<string>()
   for (const fileRef of files) {
-    const slug = fileRef
+    const rawSlug = fileRef
       .replace(/^\.?\/?\.chats\/[^/]+\/uploads\//, '')
       .replace(/^\.?\/?uploads\//, '')
       .replace(/\/$/, '')
       .split('/')[0]
+    let slug: string
+    try {
+      slug = assertSafePathSegment(rawSlug, 'upload slug')
+    } catch {
+      continue
+    }
     if (seen.has(slug)) continue
     seen.add(slug)
     const from = safePath(path.join(uploadsDir, slug))


### PR DESCRIPTION
## Why

Closes the js/log-injection alert at [\`ingestion.ts:252\`](happyhq/lib/actions/ingestion.ts#L252).

\`setupTaskFromChat\` derived an upload \`slug\` from a user-supplied \`fileRef\` via regex strip, then used it in \`console.warn\` without first running it through the character-class barrier we use everywhere else for path segments. A crafted fileRef could land newlines or control chars in the slug, forging fake log lines on stdout.

## Summary

After the prefix-strip and \`split('/')[0]\`, run the result through \`assertSafePathSegment(rawSlug, 'upload slug')\`. On rejection, skip the entry — we're already in a skip path on the \`existsSync\` false branch, so this fits naturally and matches the same pattern used in other ingestion flows (e.g. \`web-page filename\` validation in \`read.server.ts\`).

No new sanitiser invented; reuse the existing one.

## Test plan

- [x] \`pnpm check-types\` clean
- [x] \`pnpm lint\` — no warnings
- [x] \`pnpm test\` — 1447 pass
- [x] \`pnpm format\` — no diffs
- [ ] Post-merge: re-pull alert count from main; expect log-injection to drop from 1 to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)