### PR TITLE
fix(planning): isolate planning agent from CLI harness drift

### DIFF
--- a/happyhq/lib/agents/config.server.test.ts
+++ b/happyhq/lib/agents/config.server.test.ts
@@ -111,17 +111,36 @@ describe('learningAgentOptions', () => {
     expect(opts.allowedTools).toContain('mcp__q__CreateTask')
   })
 
-  it('passes env override to SDK when provided', async () => {
-    const env = { ANTHROPIC_API_KEY: 'sk-test-123' }
-    const opts = await learningAgentOptions('my-stream', 'session-uuid-1', {
-      env,
+  it('disables CLI harness auto-memory and tool-search by default', async () => {
+    const opts = await learningAgentOptions('my-stream', 'session-uuid-1')
+    expect(opts.env).toMatchObject({
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+      ENABLE_TOOL_SEARCH: 'false',
     })
-    expect(opts.env).toBe(env)
   })
 
-  it('omits env from SDK options when not provided', async () => {
-    const opts = await learningAgentOptions('my-stream', 'session-uuid-1')
-    expect(opts.env).toBeUndefined()
+  it('merges env override with the harness flags', async () => {
+    const opts = await learningAgentOptions('my-stream', 'session-uuid-1', {
+      env: { ANTHROPIC_API_KEY: 'sk-test-123' },
+    })
+    expect(opts.env).toMatchObject({
+      ANTHROPIC_API_KEY: 'sk-test-123',
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+      ENABLE_TOOL_SEARCH: 'false',
+    })
+  })
+
+  it('does not let env override re-enable the harness flags', async () => {
+    const opts = await learningAgentOptions('my-stream', 'session-uuid-1', {
+      env: {
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+        ENABLE_TOOL_SEARCH: 'true',
+      },
+    })
+    expect(opts.env).toMatchObject({
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+      ENABLE_TOOL_SEARCH: 'false',
+    })
   })
 
   describe('canUseTool', () => {
@@ -341,24 +360,119 @@ describe('planningAgentOptions', () => {
     expect(opts.mcpServers).toBeUndefined()
   })
 
-  it('passes env override to SDK when provided', async () => {
-    const env = { ANTHROPIC_API_KEY: 'sk-test-123' }
+  it('disables CLI harness auto-memory and tool-search by default', async () => {
     const opts = await planningAgentOptions(
       'my-stream',
       'my-task',
       new AbortController(),
-      { env },
     )
-    expect(opts.env).toBe(env)
+    expect(opts.env).toMatchObject({
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+      ENABLE_TOOL_SEARCH: 'false',
+    })
   })
 
-  it('omits env from SDK options when not provided', async () => {
+  it('merges env override with the harness flags', async () => {
     const opts = await planningAgentOptions(
       'my-stream',
       'my-task',
       new AbortController(),
+      { env: { ANTHROPIC_API_KEY: 'sk-test-123' } },
     )
-    expect(opts.env).toBeUndefined()
+    expect(opts.env).toMatchObject({
+      ANTHROPIC_API_KEY: 'sk-test-123',
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+      ENABLE_TOOL_SEARCH: 'false',
+    })
+  })
+
+  describe('PreToolUse Write/Edit gate', () => {
+    type PreHookResult = {
+      continue?: boolean
+      hookSpecificOutput?: {
+        hookEventName: string
+        permissionDecision?: string
+        permissionDecisionReason?: string
+      }
+    }
+
+    const callPreHook = async (
+      toolName: string,
+      filePath?: string,
+    ): Promise<PreHookResult> => {
+      const opts = await planningAgentOptions(
+        'my-stream',
+        'my-task',
+        new AbortController(),
+      )
+      const hook = opts.hooks!.PreToolUse![0].hooks[0]
+      const result = await hook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: toolName,
+          tool_input: filePath !== undefined ? { file_path: filePath } : {},
+        } as any,
+        undefined,
+        { signal: new AbortController().signal },
+      )
+      return result as PreHookResult
+    }
+
+    it('allows Write to plan.md (relative path)', async () => {
+      const result = await callPreHook('Write', 'tasks/my-task/plan.md')
+      expect(result.hookSpecificOutput).toBeUndefined()
+      expect(result.continue).toBe(true)
+    })
+
+    it('allows Write to plan.md (absolute path)', async () => {
+      const result = await callPreHook(
+        'Write',
+        '/data/happyhq/tasks/my-task/plan.md',
+      )
+      expect(result.hookSpecificOutput).toBeUndefined()
+      expect(result.continue).toBe(true)
+    })
+
+    it('denies Write to outputs/', async () => {
+      const result = await callPreHook(
+        'Write',
+        '/data/happyhq/tasks/my-task/outputs/crm-note.md',
+      )
+      expect(result.hookSpecificOutput).toMatchObject({
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+      })
+      expect(result.hookSpecificOutput!.permissionDecisionReason).toMatch(
+        /plan\.md/,
+      )
+    })
+
+    it('denies Write to a different task', async () => {
+      const result = await callPreHook(
+        'Write',
+        '/data/happyhq/tasks/other-task/plan.md',
+      )
+      expect(result.hookSpecificOutput).toMatchObject({
+        permissionDecision: 'deny',
+      })
+    })
+
+    it('denies Edit always — even on plan.md', async () => {
+      const result = await callPreHook('Edit', 'tasks/my-task/plan.md')
+      expect(result.hookSpecificOutput).toMatchObject({
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+      })
+      expect(result.hookSpecificOutput!.permissionDecisionReason).toMatch(
+        /may not Edit/,
+      )
+    })
+
+    it('passes through non-Write/Edit tools', async () => {
+      const result = await callPreHook('Read', '/anything')
+      expect(result.hookSpecificOutput).toBeUndefined()
+      expect(result.continue).toBe(true)
+    })
   })
 
   it('includes PostToolUse hook that notifies on Write/Edit', async () => {
@@ -484,24 +598,30 @@ describe('workingAgentOptions', () => {
     expect(opts.settingSources).toEqual([])
   })
 
-  it('passes env override to SDK when provided', async () => {
-    const env = { ANTHROPIC_API_KEY: 'sk-test-123' }
+  it('disables CLI harness auto-memory and tool-search by default', async () => {
     const opts = await workingAgentOptions(
       'my-stream',
       'my-task',
       new AbortController(),
-      { env },
     )
-    expect(opts.env).toBe(env)
+    expect(opts.env).toMatchObject({
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+      ENABLE_TOOL_SEARCH: 'false',
+    })
   })
 
-  it('omits env from SDK options when not provided', async () => {
+  it('merges env override with the harness flags', async () => {
     const opts = await workingAgentOptions(
       'my-stream',
       'my-task',
       new AbortController(),
+      { env: { ANTHROPIC_API_KEY: 'sk-test-123' } },
     )
-    expect(opts.env).toBeUndefined()
+    expect(opts.env).toMatchObject({
+      ANTHROPIC_API_KEY: 'sk-test-123',
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+      ENABLE_TOOL_SEARCH: 'false',
+    })
   })
 
   it('includes PostToolUse hook that notifies on Write/Edit', async () => {

--- a/happyhq/lib/agents/config.server.ts
+++ b/happyhq/lib/agents/config.server.ts
@@ -33,6 +33,23 @@ const claudeExecutable = process.env.Q_PASSWORD
   ? '/usr/local/bin/claude'
   : undefined
 
+/**
+ * Env vars that suppress Claude Code CLI harness behaviors we don't want
+ * leaking into our agents: project-memory auto-loading (MEMORY.md) and
+ * deferred tool loading (ToolSearch). Both default ON in CLI 2.1.59+ and
+ * are not covered by `settingSources: []`. Caller env merges first; the
+ * harness flags win to prevent an upstream caller from re-enabling them.
+ */
+function agentEnv(
+  override?: Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  return {
+    ...(override ?? {}),
+    CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+    ENABLE_TOOL_SEARCH: 'false',
+  }
+}
+
 /** Map a ThinkingMode config value to the SDK thinking option shape. */
 /** Map a ThinkingMode config value to the SDK thinking option shape. */
 function thinkingOption(
@@ -201,6 +218,7 @@ export async function learningAgentOptions(
     includePartialMessages: true,
     mcpServers: { [MCP_SERVER_NAME]: qsMcp },
     settingSources: [],
+    env: agentEnv(opts?.env),
     agents: {
       Drafting: {
         description:
@@ -212,7 +230,6 @@ export async function learningAgentOptions(
       },
     },
     ...(claudeExecutable && { pathToClaudeCodeExecutable: claudeExecutable }),
-    ...(opts?.env && { env: opts.env }),
     ...(opts?.abortController && { abortController: opts.abortController }),
     // New session: set sessionId. Resume: set resume to the session ID.
     ...(opts?.resume ? { resume: sessionId } : { sessionId }),
@@ -385,6 +402,7 @@ export async function chatAgentOptions(params: {
     includePartialMessages: true,
     mcpServers: { [MCP_SERVER_NAME]: qsMcp },
     settingSources: [],
+    env: agentEnv(params.env),
     // Drafting subagent only in learning mode (for writing playbooks/specs)
     agents:
       mode === 'learning'
@@ -400,7 +418,6 @@ export async function chatAgentOptions(params: {
           }
         : {},
     ...(claudeExecutable && { pathToClaudeCodeExecutable: claudeExecutable }),
-    ...(params.env && { env: params.env }),
     ...(params.abortController && { abortController: params.abortController }),
     ...(params.resume ? { resume: sessionId } : { sessionId }),
   }
@@ -424,6 +441,10 @@ export async function planningAgentOptions(
   },
 ): Promise<Options> {
   const config = resolveConfig(await readConfig())
+  // Planning's only legitimate Write target. The hook below denies any
+  // Write outside this path and denies Edit entirely. CLI harness behavior
+  // changes (e.g. injected reminders, new auto-tools) cannot bypass this.
+  const planPath = `tasks/${taskName}/plan.md`
   return {
     model: MODEL_IDS[config.models.planning.model],
     thinking: thinkingOption(config.models.planning.thinking),
@@ -446,7 +467,46 @@ export async function planningAgentOptions(
     includePartialMessages: true,
     persistSession: true,
     settingSources: [],
+    env: agentEnv(opts?.env),
     hooks: {
+      PreToolUse: [
+        {
+          hooks: [
+            async (input) => {
+              if (input.hook_event_name !== 'PreToolUse') {
+                return { continue: true }
+              }
+              if (input.tool_name !== 'Write' && input.tool_name !== 'Edit') {
+                return { continue: true }
+              }
+              if (input.tool_name === 'Edit') {
+                return {
+                  hookSpecificOutput: {
+                    hookEventName: 'PreToolUse' as const,
+                    permissionDecision: 'deny' as const,
+                    permissionDecisionReason: `Planning may not Edit files. Write tasks/${taskName}/plan.md instead.`,
+                  },
+                }
+              }
+              const filePath = (input.tool_input as Record<string, unknown>)
+                ?.file_path as string | undefined
+              const isPlanMd =
+                typeof filePath === 'string' &&
+                (filePath === planPath || filePath.endsWith(`/${planPath}`))
+              if (isPlanMd) {
+                return { continue: true }
+              }
+              return {
+                hookSpecificOutput: {
+                  hookEventName: 'PreToolUse' as const,
+                  permissionDecision: 'deny' as const,
+                  permissionDecisionReason: `Planning may only Write tasks/${taskName}/plan.md. Stop and write the plan.`,
+                },
+              }
+            },
+          ],
+        },
+      ],
       PostToolUse: [
         {
           hooks: [
@@ -478,7 +538,6 @@ export async function planningAgentOptions(
       ],
     },
     ...(claudeExecutable && { pathToClaudeCodeExecutable: claudeExecutable }),
-    ...(opts?.env && { env: opts.env }),
     ...(opts?.sessionId && { sessionId: opts.sessionId }),
   }
 }
@@ -524,6 +583,7 @@ export async function workingAgentOptions(
     includePartialMessages: true,
     persistSession: true,
     settingSources: [],
+    env: agentEnv(opts?.env),
     hooks: {
       PostToolUse: [
         {
@@ -556,7 +616,6 @@ export async function workingAgentOptions(
       ],
     },
     ...(claudeExecutable && { pathToClaudeCodeExecutable: claudeExecutable }),
-    ...(opts?.env && { env: opts.env }),
     ...(opts?.sessionId && { sessionId: opts.sessionId }),
   }
 }

--- a/happyhq/prompts/planning.md
+++ b/happyhq/prompts/planning.md
@@ -23,7 +23,7 @@ IMPORTANT: Plan only. Do NOT write anything other than plan.md. NEVER justify se
 
 CONSTRAINTS:
 
-- You run in a sandboxed environment. Available: Read, Write, Edit, Glob, Grep, WebFetch, and safe Bash (git, ls, cat, find, mkdir, echo, etc.). You CANNOT install packages, run pip/npm/apt, use curl/wget, compile code, or execute arbitrary programs. Do not attempt workarounds — they will all be denied.
+- You may Write only to `tasks/{{TASK_NAME}}/plan.md`. Any other Write or Edit will be denied. You CANNOT install packages, run pip/npm/apt, use curl/wget, compile code, or execute arbitrary programs. Do not attempt workarounds — they will all be denied.
 - If a tool call is denied, the denial is permanent. Do not retry or attempt the same action via a different tool. Proceed with the work you can do.
 
 PLAYBOOK:


### PR DESCRIPTION
## Summary

Planning was producing the working phase's output files (CRM note, insights, protocol sheet) on a real user's machine, while leaving status stuck at \`plan_ready\` and never running working. Investigation pinned the cause to the Claude Code CLI harness (auto-loaded \`MEMORY.md\`, \`ToolSearch\`, \`CLAUDE.md\` discovery) added between CLI 2.1.39 and 2.1.92 — features not covered by \`settingSources: []\`. The planning prompt's \"Plan only\" instruction lost against an agent that had \`Write\` available via \`permissionMode: 'acceptEdits'\` and a richer harness preamble.

This PR adds three independent layers, any one of which would have prevented the regression:

- **Env flags** suppress the new harness behaviors. \`CLAUDE_CODE_DISABLE_AUTO_MEMORY=1\` and \`ENABLE_TOOL_SEARCH=false\` applied to all four agent factories via a new \`agentEnv()\` helper. Caller-supplied env merges first; harness flags last so an upstream override can't accidentally re-enable them.
- **PreToolUse hook on planning** denies \`Edit\` always and denies \`Write\` unless \`file_path\` is \`tasks/<task>/plan.md\` (relative or absolute). Returns \`permissionDecision: 'deny'\` with a model-visible reason. The existing prompt's *\"If a tool call is denied, the denial is permanent. Do not retry\"* makes the agent fall back to writing the plan.
- **Prompt cleanup** in \`prompts/planning.md\` replaces the \"Available: Read, Write, Edit, ...\" line with a focused Write-scope constraint. The SDK already tells the model what tools it has via the API \`tools\` parameter; the prompt no longer advertises tools that should be out of reach.

## Test plan

- [x] \`pnpm check-types\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 1454 tests pass (121 files)
- [x] 13 new/updated tests in \`config.server.test.ts\` covering: env defaults on all three agents, env merge semantics, env override cannot re-enable flags, and 6 PreToolUse cases (allow plan.md relative/absolute, deny outputs/, deny other task, deny Edit always, pass-through non-Write/Edit)
- [ ] Manual: run a planning iteration on a fresh task post-merge and confirm only \`plan.md\` is written (transcript should show \`Write tasks/<slug>/plan.md\` and no Writes to \`outputs/\`)

## Follow-ups (separate PRs)

- Pin \`@anthropic-ai/claude-code\` in the Fly Dockerfile + add an agent-regression CI job that runs a canonical task through the pinned CLI and asserts behavioral invariants (planning writes only \`plan.md\`, working iterations produce expected outputs). Catches harness drift before it ships.
- Open a tracking issue for stuck \`plan_ready\` tasks already on disk in user machines (e.g. \`q-twp\` has \`julie-s-for-kezi-h\` and \`olivia-m-for-julie-j\` in this state with prematurely-produced outputs that bypassed the working iteration commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)