### PR TITLE
fix(agents): genericize automated canUseTool deny message

### DIFF
--- a/happyhq/lib/agents/bash-safety.server.ts
+++ b/happyhq/lib/agents/bash-safety.server.ts
@@ -39,6 +39,11 @@ const SAFE_PREFIXES = new Set([
  * canUseTool callback for automated agents (planning, working).
  * Auto-approves safe bash commands; denies everything else immediately.
  * No user is present, so we never block for confirmation.
+ *
+ * Note: Write/Edit travel through `permissionMode: 'acceptEdits'` and never
+ * reach this callback. The deny message is intentionally generic — any
+ * tool-specific suggestion would be wrong for at least one agent (planning
+ * may not Write outside plan.md; working may).
  */
 export async function automatedCanUseTool(
   toolName: string,
@@ -57,7 +62,7 @@ export async function automatedCanUseTool(
 
   return {
     behavior: 'deny',
-    message: `Tool "${toolName}" is not auto-approved for automated agents. Use Write/Edit for file changes, or safe Bash commands (git, ls, cd, mkdir, etc.).`,
+    message: `Tool "${toolName}" is not available to this agent. Proceed with the work you can do using the tools that are available.`,
   }
 }
 


### PR DESCRIPTION
## Summary

The \`automatedCanUseTool\` deny message advised the agent to *\"Use Write/Edit for file changes\"* — a hint that made sense when this code was written, but is wrong for the planning agent now that #143 denies Write outside \`plan.md\`. An agent hitting the canUseTool deny would follow the suggestion to \"use Write,\" then get denied again by the PreToolUse hook, producing self-contradictory advice across two deny paths.

The fix is to drop the tool-specific advice and keep the message neutral. Any concrete suggestion is wrong for at least one of planning vs. working — generic is the only correct shape. A comment explains the reasoning so the next person doesn't reintroduce a specific hint.

Found while inventorying open threads from the #143 investigation.

## Test plan

- [x] \`pnpm check-types\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test lib/agents/bash-safety.server.test.ts\` — 27 passed (existing tests assert behavior, not message text, so no test changes were needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)