### PR TITLE
feat(run): stop early with no_progress when agent commits nothing

### DIFF
--- a/happyhq/lib/fs/types.ts
+++ b/happyhq/lib/fs/types.ts
@@ -21,7 +21,7 @@ export interface IterationMetrics {
 export interface RunInfo {
   status: 'planning' | 'plan_ready' | 'working' | 'completed' | 'stopped'
   stoppedDuring?: 'planning' | 'working' // which phase was active when stopped
-  stopReason?: 'budget' | 'user' | 'error' | 'iteration_limit'
+  stopReason?: 'budget' | 'user' | 'error' | 'iteration_limit' | 'no_progress'
   iteration: number // 0 on initial write, 1-based during/after iterations
   startedAt: string // ISO 8601 timestamp
   lastIterationAt: string // ISO 8601 timestamp, updated after each iteration

--- a/happyhq/lib/git/sync.server.test.ts
+++ b/happyhq/lib/git/sync.server.test.ts
@@ -17,7 +17,12 @@ vi.mock('node:child_process', () => ({
   execFileSync: mockExecFileSync,
 }))
 
-import { commitGitState, isTaskCompleted, syncGitState } from './sync.server'
+import {
+  commitGitState,
+  getLatestTaskCommit,
+  isTaskCompleted,
+  syncGitState,
+} from './sync.server'
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -162,6 +167,44 @@ describe('isTaskCompleted', () => {
       'tasks/my-task; rm -rf /',
     ])
     expect(opts).toMatchObject({ cwd: MOCK_ROOT, encoding: 'utf8' })
+  })
+})
+
+describe('getLatestTaskCommit', () => {
+  it('returns the SHA from git log', () => {
+    mockExecFileSync.mockReturnValue('abc123def\n')
+
+    expect(getLatestTaskCommit('my-task')).toBe('abc123def')
+  })
+
+  it('returns null when git log returns empty output (no commits)', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    expect(getLatestTaskCommit('my-task')).toBeNull()
+  })
+
+  it('returns null when execFileSync throws', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('not a git repository')
+    })
+
+    expect(getLatestTaskCommit('my-task')).toBeNull()
+  })
+
+  it('passes the task path as a discrete argv element', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    getLatestTaskCommit('my-task; rm -rf /')
+
+    const [file, args] = mockExecFileSync.mock.calls[0]
+    expect(file).toBe('git')
+    expect(args).toEqual([
+      'log',
+      '--format=%H',
+      '-1',
+      '--',
+      'tasks/my-task; rm -rf /',
+    ])
   })
 })
 

--- a/happyhq/lib/git/sync.server.ts
+++ b/happyhq/lib/git/sync.server.ts
@@ -70,6 +70,31 @@ export function isTaskCompleted(taskName: string): boolean {
   }
 }
 
+/**
+ * Get the SHA of the most recent commit touching a task's directory, or null
+ * if no commits exist (or git errors). Used by the working loop to detect
+ * iterations where the agent didn't commit any work — a "no progress" signal
+ * that catches stuck runs before they burn through the iteration cap.
+ */
+export function getLatestTaskCommit(taskName: string): string | null {
+  try {
+    const taskDir = `tasks/${taskName}`
+    const sha = execFileSync(
+      'git',
+      ['log', '--format=%H', '-1', '--', taskDir],
+      {
+        cwd: HAPPYHQ_ROOT,
+        encoding: 'utf8',
+        timeout: 5000,
+        stdio: 'pipe',
+      },
+    ).trim()
+    return sha || null
+  } catch {
+    return null
+  }
+}
+
 export function syncGitState(): void {
   try {
     const status = execSync('git status --porcelain', {

--- a/happyhq/lib/run/loop.server.test.ts
+++ b/happyhq/lib/run/loop.server.test.ts
@@ -28,6 +28,7 @@ const {
   mockPlanningAgentOptions,
   mockWorkingAgentOptions,
   mockIsTaskCompleted,
+  mockGetLatestTaskCommit,
   mockWriteTextFile,
   mockClearDirectory,
   mockIsBillingEnabled,
@@ -60,6 +61,10 @@ const {
       }),
     ),
     mockIsTaskCompleted: vi.fn().mockReturnValue(false),
+    // Defaults to a fresh SHA per call so tests that don't care about the
+    // no-progress check keep passing — the loop sees commit advance every
+    // iteration and never trips the staleness counter.
+    mockGetLatestTaskCommit: vi.fn(() => `sha-${Math.random()}`),
     mockWriteTextFile: vi.fn(),
     mockClearDirectory: vi.fn(),
     mockIsBillingEnabled: vi.fn().mockReturnValue(false),
@@ -92,6 +97,7 @@ vi.mock('@/lib/git/sync.server', () => ({
   syncGitState: vi.fn(),
   commitGitState: vi.fn(),
   isTaskCompleted: mockIsTaskCompleted,
+  getLatestTaskCommit: mockGetLatestTaskCommit,
 }))
 
 vi.mock('@/lib/fs/write.server', () => ({
@@ -367,6 +373,45 @@ describe('working mode', () => {
     const writes = getRunInfoWrites()
     const terminal = writes[writes.length - 1]
     expect(terminal.status).toBe('completed')
+  })
+
+  it('stops with no_progress when agent commits nothing for 2 consecutive iterations', async () => {
+    mockQuery.mockImplementation(() => fakeQuery([]))
+    mockIsTaskCompleted.mockReturnValue(false)
+    // Same SHA every call → loop sees no commit advance → staleness trips
+    mockGetLatestTaskCommit.mockReturnValue('stuck-sha')
+
+    await startRun('s1', 't1', 'working')
+    await _waitForLoop()
+
+    const writes = getRunInfoWrites()
+    const terminal = writes[writes.length - 1]
+    expect(terminal).toMatchObject({
+      status: 'stopped',
+      stopReason: 'no_progress',
+      iteration: 2,
+    })
+    expect(terminal.error).toContain('No progress')
+  })
+
+  it('does not trip no_progress when agent commits something every iteration', async () => {
+    mockQuery.mockImplementation(() => fakeQuery([]))
+    mockIsTaskCompleted.mockReturnValue(false)
+    // Distinct SHAs each call → commit "advances" every iteration → never stale
+    let n = 0
+    mockGetLatestTaskCommit.mockImplementation(() => `sha-${n++}`)
+
+    await startRun('s1', 't1', 'working')
+    await _waitForLoop()
+
+    // Should hit iteration_limit (maxIterations=3), not no_progress
+    const writes = getRunInfoWrites()
+    const terminal = writes[writes.length - 1]
+    expect(terminal).toMatchObject({
+      status: 'stopped',
+      stopReason: 'iteration_limit',
+      iteration: 3,
+    })
   })
 
   it('continues iterating when isTaskCompleted returns false', async () => {

--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -29,7 +29,11 @@ import {
 import { updateTaskMdPending } from '@/lib/fs/task-md.server'
 import type { IterationMetrics, PendingType, RunInfo } from '@/lib/fs/types'
 import { clearDirectory, writeTextFile } from '@/lib/fs/write.server'
-import { commitGitState, isTaskCompleted } from '@/lib/git/sync.server'
+import {
+  commitGitState,
+  getLatestTaskCommit,
+  isTaskCompleted,
+} from '@/lib/git/sync.server'
 
 import type { ChatStreamEvent } from '@/lib/chat/types'
 
@@ -679,6 +683,19 @@ async function runWorkingLoop(
       ? existingRun.iteration + 1
       : 1
 
+  // No-progress detection. The working prompt mandates a `git commit` per
+  // iteration. If the latest commit touching tasks/<task>/ doesn't advance for
+  // NO_PROGRESS_LIMIT consecutive iterations, the agent is stuck (e.g. plan
+  // already complete but `[done]` not emitted, or persistently confused).
+  // Stop early with a `no_progress` reason so the user sees a diagnosable
+  // failure instead of burning to maxIterations with `iteration_limit`.
+  //
+  // Threshold of 2 tolerates a single iteration that errored before commit
+  // ("fresh context self-heals"), but catches the actual stuck pattern.
+  const NO_PROGRESS_LIMIT = 2
+  let lastTaskCommit = getLatestTaskCommit(taskName)
+  let staleIterations = 0
+
   for (
     let iteration = startIteration;
     iteration <= maxIterations;
@@ -877,6 +894,43 @@ async function runWorkingLoop(
         duration_ms: Date.now() - iterStartMs,
         error: iterErrMsg,
       })
+
+      // No-progress check applies to errored iterations too — if the agent
+      // crashed before committing two iterations running, that's still stuck.
+      {
+        const currentCommit = getLatestTaskCommit(taskName)
+        if (currentCommit === lastTaskCommit) {
+          staleIterations++
+        } else {
+          staleIterations = 0
+          lastTaskCommit = currentCommit
+        }
+        if (staleIterations >= NO_PROGRESS_LIMIT) {
+          await writeRunInfo(taskName, {
+            status: 'stopped',
+            stoppedDuring: 'working',
+            stopReason: 'no_progress',
+            iteration,
+            startedAt,
+            lastIterationAt: new Date().toISOString(),
+            error: `No progress: agent committed no work for ${NO_PROGRESS_LIMIT} consecutive iterations`,
+            costUsd: totalCost,
+            planningCostUsd,
+            iterations: allIterations,
+            planningSessionId,
+            workingSessionIds,
+          })
+          log('run.stopped', {
+            task: taskName,
+            stream: streamName,
+            mode: 'working',
+            reason: 'no_progress',
+            iteration,
+            cost: totalCost,
+          })
+          return 'stopped'
+        }
+      }
       continue
     } finally {
       cleanup()
@@ -952,7 +1006,10 @@ async function runWorkingLoop(
       duration_ms: iterDurationMs,
     })
 
-    // Check for [done] in the latest commit touching this task
+    // Check for [done] in the latest commit touching this task. [done] wins
+    // over the no-progress check below: if the agent's final commit declares
+    // completion, honor it even if the same commit makes this iteration
+    // technically "stale" relative to the previous one.
     if (isTaskCompleted(taskName)) {
       await writeRunInfo(taskName, {
         status: 'completed',
@@ -975,6 +1032,45 @@ async function runWorkingLoop(
         duration_ms: Date.now() - new Date(startedAt).getTime(),
       })
       return 'completed'
+    }
+
+    // No-progress check: did this iteration advance the head of git log for
+    // tasks/<task>/? Agents that aren't committing any work (plan exhausted,
+    // confused, or stuck in a no-op loop) get caught here before burning
+    // through maxIterations.
+    {
+      const currentCommit = getLatestTaskCommit(taskName)
+      if (currentCommit === lastTaskCommit) {
+        staleIterations++
+      } else {
+        staleIterations = 0
+        lastTaskCommit = currentCommit
+      }
+      if (staleIterations >= NO_PROGRESS_LIMIT) {
+        await writeRunInfo(taskName, {
+          status: 'stopped',
+          stoppedDuring: 'working',
+          stopReason: 'no_progress',
+          iteration,
+          startedAt,
+          lastIterationAt: new Date().toISOString(),
+          error: `No progress: agent committed no work for ${NO_PROGRESS_LIMIT} consecutive iterations`,
+          costUsd: totalCost,
+          planningCostUsd,
+          iterations: allIterations,
+          planningSessionId,
+          workingSessionIds,
+        })
+        log('run.stopped', {
+          task: taskName,
+          stream: streamName,
+          mode: 'working',
+          reason: 'no_progress',
+          iteration,
+          cost: totalCost,
+        })
+        return 'stopped'
+      }
     }
   }
 

--- a/happyhq/specs/working.md
+++ b/happyhq/specs/working.md
@@ -62,6 +62,22 @@ Hardcoded at 20 iterations (`MAX_ITERATIONS` in `lib/constants.ts`). A safety va
 
 This is not expected behavior. Well-scoped plans should complete within the limit. If Q is hitting the limit, the plan is too broad or Q is stuck — either way, human judgment is needed.
 
+## No-Progress Stop
+
+A second safety valve, tighter than the iteration limit. The working prompt mandates a `git commit` per iteration. If the latest commit touching `tasks/{taskName}/` doesn't advance for 2 consecutive iterations, the loop halts and writes `status: 'stopped'` with `stopReason: 'no_progress'` to `.run.json`.
+
+After each iteration (success or error path), the loop reads `git log --format=%H -1 -- tasks/{taskName}` and compares the SHA to the one captured at the start. Same SHA → "stale" counter increments; new SHA → counter resets. When the counter hits 2, the run stops early.
+
+Why a separate signal from `iteration_limit`:
+
+- **Catches stuck runs cheaper.** A confused or already-finished agent that keeps iterating without committing burns ~$0.40/iter for nothing. No-progress catches it after iter 2 instead of iter 20.
+- **More diagnosable.** `iteration_limit` reads as "Q needed more iterations." `no_progress` reads as "Q stalled" — different remediation. The first suggests scope; the second suggests the plan is exhausted or the agent is confused.
+- **Hardened, not heuristic.** The check is binary (commit advanced or not), so it doesn't kill good runs. A working agent commits every iteration per the prompt.
+
+Threshold of 2 (not 1) tolerates a single iteration that errored before commit — fresh-context retry can self-heal one bad iteration. Two in a row indicates a real problem.
+
+**Watch for in the wild:** if `no_progress` fires on legitimate runs, the candidates are (a) the agent intentionally not committing because it had nothing to add — but the working prompt forbids this; (b) commits landing somewhere outside `tasks/{taskName}/` so `git log -- <path>` doesn't see them — possible if the agent edits stream-level files; (c) network/SDK errors before commit twice in a row — rare. If false positives appear, the fix is to widen the path the check looks at, not to weaken the threshold.
+
 ## What Q Produces
 
 - **Working artifacts** in `working/` — Q's breadcrumbs. Extracted facts, draft sections, analysis notes. These show Q's process, not just its output. The detail of what artifacts look like is the prompt's job.
@@ -180,7 +196,7 @@ interface RunInfo {
     | 'stopped'
   stoppedDuring?: 'discovery' | 'planning' | 'working'
   queuedAt?: string // ISO 8601 — set when status is 'queued'
-  stopReason?: 'budget' | 'user' | 'error' | 'iteration_limit'
+  stopReason?: 'budget' | 'user' | 'error' | 'iteration_limit' | 'no_progress'
   startedAt: string // ISO 8601 timestamp
   lastIterationAt: string // ISO 8601 timestamp, updated after each phase/iteration
   error: string | null
@@ -206,17 +222,17 @@ One run at a time per task. Start reads `.run.json` to check — if `status` is 
 
 Eight states. No error state — if the loop crashes, status is `stopped` with the `error` field populated.
 
-| Status        | Entry trigger                                                     | Desktop renders                                                                                                                                                                                                         | User actions                                       |
-| ------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `queued`      | Start Task when concurrency limit reached                         | Task card shows "Queued". Auto-starts when a slot opens.                                                                                                                                                                | Stop button (cancels queue entry).                 |
-| `discovering` | Start Task clicked / Start button clicked / dequeued              | Island shows discovery activity; questions render in island when Q asks. See [Discovery](discovery.md).                                                                                                                 | Stop button (in island).                           |
-| `planning`    | Discovery completes (auto-transition) / restart from plan         | Island shows planning activity (spinner, activity steps).                                                                                                                                                               | Stop button (in island).                           |
-| `plan_ready`  | Planning agent completes successfully                             | Plan auto-opens as window. PlanApproval replaces island.                                                                                                                                                                | Approve (starts working) or open sidebar to teach. |
-| `working`     | Approve clicked / Start button clicked (after planning completes) | Island shows activity steps, task icons show files.                                                                                                                                                                     | Stop button (in island).                           |
-| `completed`   | `[done]` found in git commit message                              | All files listed, outputs viewable.                                                                                                                                                                                     | Start button (restart from scratch).               |
-| `stopped`     | User stop, crash, iteration limit, or billing limit               | Progress shows what completed. Error field shown if present. `stopReason` discriminates the cause: `budget` shows Continue + upgrade prompt (violet); `user`/`error`/`iteration_limit` show Restart + Continue (amber). | Continue (resumes) or Restart (from scratch).      |
+| Status        | Entry trigger                                                     | Desktop renders                                                                                                                                                                                                                       | User actions                                       |
+| ------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `queued`      | Start Task when concurrency limit reached                         | Task card shows "Queued". Auto-starts when a slot opens.                                                                                                                                                                              | Stop button (cancels queue entry).                 |
+| `discovering` | Start Task clicked / Start button clicked / dequeued              | Island shows discovery activity; questions render in island when Q asks. See [Discovery](discovery.md).                                                                                                                               | Stop button (in island).                           |
+| `planning`    | Discovery completes (auto-transition) / restart from plan         | Island shows planning activity (spinner, activity steps).                                                                                                                                                                             | Stop button (in island).                           |
+| `plan_ready`  | Planning agent completes successfully                             | Plan auto-opens as window. PlanApproval replaces island.                                                                                                                                                                              | Approve (starts working) or open sidebar to teach. |
+| `working`     | Approve clicked / Start button clicked (after planning completes) | Island shows activity steps, task icons show files.                                                                                                                                                                                   | Stop button (in island).                           |
+| `completed`   | `[done]` found in git commit message                              | All files listed, outputs viewable.                                                                                                                                                                                                   | Start button (restart from scratch).               |
+| `stopped`     | User stop, crash, iteration limit, no-progress, or billing limit  | Progress shows what completed. Error field shown if present. `stopReason` discriminates the cause: `budget` shows Continue + upgrade prompt (violet); `user`/`error`/`iteration_limit`/`no_progress` show Restart + Continue (amber). | Continue (resumes) or Restart (from scratch).      |
 
-Transitions: `queued → discovering → planning → plan_ready → working → completed` is the happy path. Discovery auto-transitions to planning (server-driven, no user action — see [Discovery](discovery.md)). `queued` transitions to `discovering` or `planning` automatically when a concurrency slot opens (see [Concurrency](concurrency.md)). Any state can transition to `stopped` via user stop, error, or billing limit. `stopReason` captures why: `'budget'` (billing limit), `'user'` (user clicked Stop), `'error'` (crash/auth failure), `'iteration_limit'` (hit max iterations). Budget stops auto-resume on Continue; other stops require explicit `resume: true`. `stoppedDuring` records which phase was active when stopped.
+Transitions: `queued → discovering → planning → plan_ready → working → completed` is the happy path. Discovery auto-transitions to planning (server-driven, no user action — see [Discovery](discovery.md)). `queued` transitions to `discovering` or `planning` automatically when a concurrency slot opens (see [Concurrency](concurrency.md)). Any state can transition to `stopped` via user stop, error, or billing limit. `stopReason` captures why: `'budget'` (billing limit), `'user'` (user clicked Stop), `'error'` (crash/auth failure), `'iteration_limit'` (hit max iterations), `'no_progress'` (agent committed nothing for 2 consecutive iterations — see [No-Progress Stop](#no-progress-stop)). Budget stops auto-resume on Continue; other stops require explicit `resume: true`. `stoppedDuring` records which phase was active when stopped.
 
 ### Minimal In-Memory State
 
@@ -322,6 +338,7 @@ The island's `TaskWorkingContent` renders the most recent step's label and detai
 - [x] Q commits to git as part of each iteration (see [Git Layer](git-layer.md)) _(prompt scope, not loop implementation — `prompts/working.md` line 14 instructs `git add -A && git commit`)_
 - [x] App checks git log for `[done]` after each iteration; loop ends when found
 - [x] Loop halts after 20 iterations if `[done]` not found; writes `status: 'stopped'` with `error: 'Iteration limit reached'` to `.run.json`
+- [x] Loop halts early with `stopReason: 'no_progress'` when the latest commit on `tasks/{taskName}/` doesn't advance for 2 consecutive iterations
 - [x] Loop continues on agent errors — fresh iteration, fresh context
 - [x] User can stop the loop at any time; `abortController.abort()` terminates the current iteration immediately
 - [x] After stopping, user can start a new plan + run for the same task (via "No, start over" in plan approval or restart from sidebar)
@@ -344,6 +361,7 @@ Run loop — working mode (`lib/run/loop.server.test.ts`):
 
 - [x] Iterative loop with `[done]` completion detection in git log (`lib/run/loop.server.test.ts`)
 - [x] MAX_ITERATIONS (20) safety valve halts loop (`lib/run/loop.server.test.ts`)
+- [x] No-progress stop fires when 2 consecutive iterations don't advance the task's git head (`lib/run/loop.server.test.ts`)
 - [x] Error continuation — fresh iteration after failure (`lib/run/loop.server.test.ts`)
 - [x] No `[done]` in git log → loop continues to next iteration (`lib/run/loop.server.test.ts`)
 - [x] Concurrent run prevention (409) (`lib/run/loop.server.test.ts`)


### PR DESCRIPTION
## Summary

- Adds a `no_progress` stop reason to the working loop. After each iteration (success and error paths) the loop reads `git log -1 --format=%H -- tasks/<task>/` and compares the SHA to the one captured at the start. Two consecutive matches → stop with `stopReason: 'no_progress'` and a clear error message. The check lives in [`lib/git/sync.server.ts`](happyhq/lib/git/sync.server.ts) (`getLatestTaskCommit`) and is wired into [`lib/run/loop.server.ts`](happyhq/lib/run/loop.server.ts) alongside the existing `[done]` and `iteration_limit` checks.
- Motivation: the working prompt mandates a `git commit` per iteration. When that doesn't happen twice running, the agent is stuck — plan exhausted but `[done]` not emitted, confused, or treading water. Today the loop just runs to `maxIterations` and burns ~$0.40/iter for nothing. Real reproducer: a recent working run committed on iters 1-2 then ran 18 more iterations with no further commits, hit `iteration_limit`, ~$8 of zombie spend.
- Threshold of 2 (not 1) tolerates a single errored iteration that crashed before commit ("fresh context self-heals"), without papering over genuine stalls. The check is binary — commit advanced or not — so it can't kill good runs.
- Spec ([`specs/working.md`](happyhq/specs/working.md)) gets a "No-Progress Stop" section explaining the mechanism, why it's separate from `iteration_limit` (cheaper to catch, more diagnosable), and false-positive candidates to watch for in the wild — with the remediation being to widen the watched path, not weaken the threshold.
- UI label code in [`components/features/tasks/list/item.tsx`](happyhq/components/features/tasks/list/item.tsx) already falls through to "Stopped" (amber) for any non-budget `stopReason`, so no UI rendering work is needed.

## Test plan

- [x] `pnpm --filter=happyhq test lib/git/sync.server.test.ts lib/run/loop.server.test.ts` — 55 tests green, including new no_progress trip + non-trip cases
- [x] `pnpm --filter=happyhq check-types` — clean
- [x] `pnpm --filter=happyhq lint` — clean
- [x] `pnpm format` — clean
- [ ] Watch a real run after merge: agent that commits each iter should still hit `[done]` cleanly; a stuck run should now stop after 2 iters instead of 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)