### PR TITLE
fix(tasks): snapshot picked files before the input is cleared

### DIFF
--- a/happyhq/components/features/tasks/create/use-file-staging.test.ts
+++ b/happyhq/components/features/tasks/create/use-file-staging.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { useFileStaging } from './use-file-staging'
+
+describe('useFileStaging', () => {
+  it('snapshots files synchronously so a caller may clear the FileList immediately after addFiles', () => {
+    // The change handler on a hidden <input type="file"> resets `e.target.value = ''`
+    // right after calling addFiles, so the user can re-pick the same file. Per the
+    // HTML spec, HTMLInputElement.files is [SameObject] — clearing the input mutates
+    // the FileList that addFiles received in place. addFiles must capture the file
+    // refs synchronously, not defer Array.from inside a setState updater that runs
+    // after the FileList has already been emptied.
+    //
+    // We pair this with a sibling setState so the updater can't be eagerly bailed
+    // out — that mirrors the real flow where handleBlur's setExpanded(false) is
+    // already queued when the file picker fires onChange (issue #140).
+    const file = new File(['x'], 'test.pdf', { type: 'application/pdf' })
+    let cleared = false
+    const liveList = new Proxy({} as unknown as FileList, {
+      get(_target, prop) {
+        if (prop === 'length') return cleared ? 0 : 1
+        if (prop === '0') return cleared ? undefined : file
+        if (prop === 'item') {
+          return (i: number) => (cleared ? null : i === 0 ? file : null)
+        }
+        if (prop === Symbol.iterator) {
+          return function* () {
+            if (!cleared) yield file
+          }
+        }
+        return undefined
+      },
+    })
+
+    const { result } = renderHook(() => {
+      const [, setTick] = useState(0)
+      const staging = useFileStaging()
+      return { setTick, staging }
+    })
+
+    act(() => {
+      result.current.setTick(1)
+      result.current.staging.addFiles(liveList)
+      cleared = true
+    })
+
+    expect(result.current.staging.stagedFiles).toHaveLength(1)
+    expect(result.current.staging.stagedFiles[0]?.name).toBe('test.pdf')
+  })
+})

--- a/happyhq/components/features/tasks/create/use-file-staging.ts
+++ b/happyhq/components/features/tasks/create/use-file-staging.ts
@@ -5,7 +5,12 @@ export function useFileStaging() {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const addFiles = useCallback((files: FileList | File[]) => {
-    setStagedFiles((prev) => [...prev, ...Array.from(files)])
+    // Snapshot here, not inside the updater: HTMLInputElement.files is [SameObject],
+    // so resetting `input.value = ''` after this call mutates the same FileList in
+    // place. If the updater is queued (e.g. another setState is already pending),
+    // it would run after the clear and read an empty list.
+    const snapshot = Array.from(files)
+    setStagedFiles((prev) => [...prev, ...snapshot])
   }, [])
 
   const removeFile = useCallback((index: number) => {


### PR DESCRIPTION
Closes #140

## Why

The hidden `<input type="file">` behind the new-task quick-add's **Attachments** button resets `e.target.value = ''` right after calling `addFiles`, so the user can re-pick the same file. Per the HTML spec, `HTMLInputElement.files` is `[SameObject]` — that reset mutates the very FileList `addFiles` just received.

`addFiles` was deferring `Array.from(files)` inside its `setStagedFiles` updater. React tries to evaluate that updater eagerly, which would have saved us — but only when the fiber has no other pending work. In the reported flow the user opens the form (focusing the title input) and then clicks **Attachments** without typing. The blur on the title fires `handleBlur`, which schedules `setExpanded(false)` via a 100 ms timeout. By the time the file picker returns, that `setExpanded` is already queued, eager bail-out is skipped, and the staging updater runs *after* `value = ''` has emptied the FileList. The file vanishes silently — no error, no toast, no attachment on submit.

Fix: snapshot to a stable array at the call site, before the FileList can be cleared. Same pattern the chat composer already uses (`components/features/chat/composer.tsx:107`).

## Regression test

`happyhq/components/features/tasks/create/use-file-staging.test.ts:9` — pairs `addFiles` with a sibling `setState` so the updater can't bail out eagerly, then mutates the FileList between `addFiles` and the act flush. Pre-fix this test reports `expected [] to have a length of 1`; post-fix it passes.

## Test plan

- [x] `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` — all green (1461 tests).

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by the maintainer before merge.