### PR TITLE
fix: filter next/image-only props in login page test mock

### DIFF
--- a/happyhq/app/(auth)/login/page.test.tsx
+++ b/happyhq/app/(auth)/login/page.test.tsx
@@ -17,12 +17,30 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
 }))
 
-// Mock next/image to a plain img for simpler test output
+// Mock next/image to a plain img for simpler test output.
+// Strip props that next/image accepts but a raw <img> doesn't, so React
+// doesn't warn about boolean values being forwarded to unknown DOM attrs.
 vi.mock('next/image', () => ({
   default: ({
-    priority: _,
+    priority: _priority,
+    unoptimized: _unoptimized,
+    fill: _fill,
+    quality: _quality,
+    placeholder: _placeholder,
+    blurDataURL: _blurDataURL,
+    loader: _loader,
+    onLoadingComplete: _onLoadingComplete,
     ...props
-  }: React.ComponentProps<'img'> & { priority?: boolean }) => {
+  }: React.ComponentProps<'img'> & {
+    priority?: boolean
+    unoptimized?: boolean
+    fill?: boolean
+    quality?: number
+    placeholder?: string
+    blurDataURL?: string
+    loader?: unknown
+    onLoadingComplete?: unknown
+  }) => {
     // eslint-disable-next-line jsx-a11y/alt-text
     return <img {...props} />
   },
@@ -83,6 +101,19 @@ afterEach(() => {
 })
 
 describe('LoginPage', () => {
+  it('does not forward next/image-only props to the DOM', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<LoginPage hasPasswordGate />)
+
+    const domAttrWarnings = errorSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('for a non-boolean attribute'),
+    )
+    expect(domAttrWarnings).toEqual([])
+
+    errorSpy.mockRestore()
+  })
+
   it('renders a password input and sign-in button', () => {
     render(<LoginPage hasPasswordGate />)
 


### PR DESCRIPTION
Closes #150

## Why

Running `pnpm --filter=happyhq test` emitted a React warning on every login page test run:

```
Received `true` for a non-boolean attribute `unoptimized`.
```

Production code is fine — `app/(auth)/login/login-page.tsx` and `app/(auth)/setup/page.tsx` pass `unoptimized` to Next.js's `<Image>`, which accepts it. The warning came from the test mock at `app/(auth)/login/page.test.tsx`, which only stripped `priority` before spreading the rest of the props onto a raw `<img>`. `unoptimized={true}` (and any other next/image-only prop) flowed straight through to the DOM, and React doesn't accept boolean values on unknown attributes.

The mock now strips the full set of next/image-only props (`priority`, `unoptimized`, `fill`, `quality`, `placeholder`, `blurDataURL`, `loader`, `onLoadingComplete`) so none of them leak.

## Regression test

`happyhq/app/(auth)/login/page.test.tsx:104` — spies on `console.error` while rendering `LoginPage` and asserts no React DOM-attribute warnings (`for a non-boolean attribute`) were emitted. Verified failing against the unfixed mock and passing against the fix.

## Verification

- `pnpm --filter=happyhq test` — 1461 tests pass, no `unoptimized` warning in stderr
- `pnpm lint`, `pnpm check-types`, `pnpm format` — clean

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.