### PR TITLE
chore: deps loop never merges; Path A signals ready-to-merge

### DIFF
--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -16,10 +16,16 @@
 4. **Branch on the result:**
 
    **Path A — clean (verification passed):**
-   - Merge: `gh pr merge ${PR_NUMBER} --squash --delete-branch`.
-   - Comment: `gh pr comment ${PR_NUMBER} --body "Ralphie merged this. Verification: lint/types/test/smoke clean."`
+   - **Skim the upstream changelog / release notes** for the version delta. Look for any of:
+     - Ownership change (different maintainer or org publishing the release)
+     - Secrets / auth / token handling refactor
+     - Security advisory referenced in the release
+     - Deprecation we'd hit (grep the repo for callers of any deprecated API)
+     - Breaking API change that the test suite might not cover
+   - **If the changelog flags any of the above:** apply `ralphie:skip-needs-review` to the PR with a comment quoting the concerning item and linking the changelog. Use the rules-shape skip comment format. Return to main, exit.
+   - **If the changelog is clean:** post the rules-shape `ready-to-merge` summary comment on the PR (verification status, 2–4 changelog highlights with link, one-or-two-sentence recommendation), then label: `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"`.
    - Return to main: `git checkout main && git pull`.
-   - Exit. (No label needed — the merged state is the signal.)
+   - Exit. **Do not merge. The human reviews the comment and clicks merge.**
 
    **Path B — verification failed (breaking-change fixups):**
    - **Plan from the changelog first.** Read the upstream release notes / migration guide for the version delta. Identify which breaking change(s) caused the failures. Quote the relevant entries in the work plan. If the failure mode isn't predicted by the changelog, **stop**: apply `ralphie:skip-verification-failed` to the original PR with the failure output included, return to main, exit.
@@ -55,10 +61,10 @@
 7. Exit.
 
 **[1]** ONE PR per session. Do not pick up other PRs, do not chain. The orchestrator handles the next one.
-**[2]** Hard constraints from @dependency-rules.md are non-negotiable: never push to `main`, never push to a Dependabot branch, never modify `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files. If the fixup would require any of these, apply `ralphie:skip-out-of-scope` and exit.
+**[2]** Hard constraints from @dependency-rules.md are non-negotiable: never push to `main`, never push to a Dependabot branch, never merge a Dependabot PR (the human is the gate, always), never modify `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files. If the fixup would require any of these, apply `ralphie:skip-out-of-scope` and exit.
 **[3]** Cite the changelog. Every fixup commit message and the replacement PR body must reference the upstream changelog / migration guide entry that justifies the change. If you can't find a changelog entry for what you're fixing, you've drifted off the rails — stop and skip with `ralphie:skip-verification-failed`.
 **[4]** Smallest fixup. Don't refactor adjacent code. Don't update unrelated callers. Surface drift via PR-body comments, not by widening the diff.
 **[5]** Stop when surprised. If a test failure isn't predicted by the changelog, or you can't trace a diff line to a documented change, apply `ralphie:skip-verification-failed` and let the human take it.
 **[6]** AI disclosure in the replacement PR body is required by @CONTRIBUTING.md.
 **[7]** Always end on `main` with a clean working tree, even on skip paths.
-**[8]** Replacement PRs are not auto-merged. They go to the human's review queue. The loop's job ends at "complete, well-documented PR open."
+**[8]** Nothing the loop touches gets auto-merged. Path A ends at `ralphie:ready-to-merge` (label + summary comment); Path B ends at "replacement PR open." In both cases the merge button is the maintainer's.

--- a/happyhq/.dev/dependency-rules.md
+++ b/happyhq/.dev/dependency-rules.md
@@ -6,22 +6,29 @@ Source of truth for how the deps loop processes open Dependabot PRs. Both `PROMP
 
 - The queue is: open PRs authored by `app/dependabot` with no label starting with `ralphie:`.
 - A `ralphie:*` label is terminal — Ralphie never re-evaluates a labeled PR. The human removes the label to re-queue.
-- One outcome per session (a label, a merge, or a replacement PR).
+- One outcome per session (a label or a replacement PR). **Ralphie never merges. The human is the gate.**
 
 ## Rules
 
-Apply in order — bail at the earliest stop. The first three are evaluable from the PR text alone (Phase 1 — triage). The last three only show up after attempting an upgrade (Phase 2).
+Apply in order — bail at the earliest stop. The first three are evaluable from the PR text alone (Phase 1 — triage). The last five only show up after attempting an upgrade (Phase 2).
 
-| #   | Condition                                                                                                                                                                                                                                                                                                                            | Label applied                      | What unblocks it                                     |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------- |
-| 1   | PR diff would touch `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files — **except** PRs from the `dependabot/github_actions/*` branch family where the diff is limited to `uses:` line changes in workflow files (those are mechanical version pins, not authored CI edits, and are eligible for Phase 2) | `ralphie:skip-out-of-scope`        | Maintainer scopes the change; remove label           |
-| 2   | CI on the PR is red and the failure is unrelated to the version bump (infra flake, lint config drift, network timeout, etc.)                                                                                                                                                                                                         | `ralphie:skip-ci-red`              | Investigate the CI failure; remove label             |
-| 3   | Update is one of: framework major (`next`, `react`, `react-dom`); security-sensitive runtime major (auth, crypto, billing — e.g., `stripe` ≥2 majors at once, `instantdb`, JWT/OIDC libs); pre-1.0 → 1.0 jump on a runtime dep                                                                                                       | `ralphie:skip-manual-upgrade`      | Maintainer upgrades and reviews; remove label        |
-| 4   | (Phase 2) Fixups would exceed 10 files or 300 lines net added (`*.md`/`*.mdx` and lockfile/package.json excluded from the count)                                                                                                                                                                                                     | `ralphie:skip-too-big`             | Scope it down or do it manually                      |
-| 5   | (Phase 2) `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` / `npx tsx scripts/smoke-test.ts` failed twice                                                                                                                                                                                             | `ralphie:skip-verification-failed` | Read Ralphie's comment; fix locally                  |
-| 6   | (Phase 2) Replacement PR shipped (Tier 2 / breaking-change fixups path)                                                                                                                                                                                                                                                              | `ralphie:replaced-by-#<new>`       | Terminal — the linked replacement PR closes the loop |
+| #   | Condition                                                                                                                                                                                                                                                                                                                            | Label applied                      | What unblocks it                                                      |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | --------------------------------------------------------------------- |
+| 1   | PR diff would touch `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files — **except** PRs from the `dependabot/github_actions/*` branch family where the diff is limited to `uses:` line changes in workflow files (those are mechanical version pins, not authored CI edits, and are eligible for Phase 2) | `ralphie:skip-out-of-scope`        | Maintainer scopes the change; remove label                            |
+| 2   | CI on the PR is red and the failure is unrelated to the version bump (infra flake, lint config drift, network timeout, etc.)                                                                                                                                                                                                         | `ralphie:skip-ci-red`              | Investigate the CI failure; remove label                              |
+| 3   | Update is one of: framework major (`next`, `react`, `react-dom`); security-sensitive runtime major (auth, crypto, billing — e.g., `stripe` ≥2 majors at once, `instantdb`, JWT/OIDC libs); pre-1.0 → 1.0 jump on a runtime dep                                                                                                       | `ralphie:skip-manual-upgrade`      | Maintainer upgrades and reviews; remove label                         |
+| 4   | (Phase 2) Verification clean (lint/types/test/smoke) **and** changelog skim reveals nothing concerning                                                                                                                                                                                                                               | `ralphie:ready-to-merge`           | Maintainer reads Ralphie's summary comment, clicks merge              |
+| 5   | (Phase 2) Changelog skim flags a concerning item (ownership change, secrets/auth refactor, security advisory, deprecation we'd hit, breaking API change tests didn't catch)                                                                                                                                                          | `ralphie:skip-needs-review`        | Maintainer reviews the changelog; decides to merge, replace, or close |
+| 6   | (Phase 2) `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` / `npx tsx scripts/smoke-test.ts` failed twice                                                                                                                                                                                             | `ralphie:skip-verification-failed` | Read Ralphie's comment; fix locally                                   |
+| 7   | (Phase 2) Fixups would exceed 10 files or 300 lines net added (`*.md`/`*.mdx` and lockfile/package.json excluded from the count)                                                                                                                                                                                                     | `ralphie:skip-too-big`             | Scope it down or do it manually                                       |
+| 8   | (Phase 2) Replacement PR shipped (breaking-change fixups path)                                                                                                                                                                                                                                                                       | `ralphie:replaced-by-#<new>`       | Terminal — the linked replacement PR closes the loop                  |
 
-A PR that passes rules 1–3 is **eligible** — it stays unlabeled and Phase 2 picks it up. Phase 2 either merges Dependabot's PR as-is (Path A — install + verify clean) or, when the bump introduces breaking changes that prevent verification, generates the smallest changelog-cited fixups on a fresh `chore/upgrade-<pkg>-vN` branch off `main` and opens a replacement PR for human review (Path B).
+A PR that passes rules 1–3 is **eligible** — it stays unlabeled and Phase 2 picks it up. Phase 2 takes one of two paths:
+
+- **Path A — verify and signal.** Install + run lint/types/test/smoke. If clean, skim the upstream changelog. If the changelog is also clean, post a verification + changelog summary comment and apply `ralphie:ready-to-merge`. The human reads the comment and decides whether to click merge.
+- **Path B — fixups.** When verification fails because of a breaking change, generate the smallest changelog-cited fixups on a fresh `chore/upgrade-<pkg>-vN` branch off `main` and open a replacement PR for human review.
+
+Ralphie never merges. The merge button is the maintainer's. Always.
 
 ## Comment shape (skips)
 
@@ -33,6 +40,26 @@ Ralphie skipped this for: <rule name>
 What I saw: <1–3 sentences — the specific evidence that triggered the rule>
 
 What would unblock it: <1 sentence — concrete action for the human>
+```
+
+## Comment shape (Path A success — `ready-to-merge`)
+
+```
+Ralphie verified this — ready to merge.
+
+### Verification
+- lint: ✓
+- check-types: ✓
+- test: ✓ (<N> tests)
+- smoke: ✓
+
+### Changelog highlights
+- <bullet 1>
+- <bullet 2>
+- (link to upstream release notes)
+
+### Recommendation
+<one or two sentences — why this looks safe to merge for our usage>
 ```
 
 ## Comment shape (replacement, posted on the original Dependabot PR)
@@ -53,7 +80,8 @@ Replacement: <link to new PR>
 - Never modify files under `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files. If the fixup would require any of these, apply `ralphie:skip-out-of-scope` and exit.
 - Never push to a Dependabot branch. Replacement work happens on a fresh `chore/upgrade-<pkg>-v<N>` branch off `main`.
 - Replacement PRs target `main`, use the `chore/` prefix, and include `Replaces #<original>` plus an AI-assistance disclosure (per `CONTRIBUTING.md`).
-- One outcome per session. After labeling, merging, or opening a replacement, exit.
+- Never merge a Dependabot PR. The loop's job ends at `ralphie:ready-to-merge` (label + summary comment); the human clicks merge.
+- One outcome per session. After labeling or opening a replacement, exit.
 
 ## Principles
 
@@ -67,7 +95,9 @@ These are guidance, not gates. The rules above are pass/fail; these tune _how_ a
 
 **Look around.** Before writing a fixup, search for prior usage of the changed APIs across the repo. Most "we keep fixing this" pain comes from rederiving in isolation when a reference exists.
 
-**The PR is the gate.** Replacement PRs go to `main` for human review — they are not auto-merged. The loop's job is to put a complete, well-documented upgrade in front of the maintainer; the maintainer's job is to click merge.
+**The human is the gate, always.** Ralphie never merges — not Dependabot's PRs, not replacement PRs. Path A's job is "verify, summarize, label `ready-to-merge`." Path B's job is "open a replacement PR with the breaking-change fixups documented." In both cases the merge button is the maintainer's. The loop's value is the verification work and the documentation, not the merge click.
+
+**Skim the changelog even when verification is clean.** Green CI doesn't catch supply-chain risk (maintainer compromise, ownership change, hostile release). It doesn't catch behavior changes that won't bite until production load. A 60-second changelog skim catches a lot of that at near-zero cost. If the changelog mentions ownership change, secrets/auth handling refactor, security advisory, or breaking API change, apply `ralphie:skip-needs-review` instead of `ready-to-merge` — even if every test passed.
 
 ## Tuning signal
 


### PR DESCRIPTION
## Summary

The original Path A in the upgrade prompt did `gh pr merge ... --squash` directly after verification. That was inconsistent with Path B, which always opens a replacement PR for human review — the "human is the gate" principle was applying to Path B but not Path A.

This PR makes the conservatism uniform across both paths:

### Path A is now "verify + signal, never merge"

- Install + run lint/types/test/smoke (same as before)
- **New: skim the upstream changelog/release notes.** Look for ownership changes, secrets/auth refactors, security advisories, deprecations we'd hit, or breaking API changes the test suite might miss
- If the changelog is clean: post a structured comment (verification status + changelog highlights + recommendation) and apply `ralphie:ready-to-merge`
- If the changelog flags anything: apply `ralphie:skip-needs-review` instead, with a comment quoting the concerning item
- **Exit. The maintainer reviews the comment and clicks merge.**

### Why this matters

Green CI doesn't catch supply-chain risk (xz-style maintainer compromise, hostile release, ownership transfer). A 60-second changelog skim does, at near-zero cost. The merge button stays with the human in both paths.

The loop's value is the verification work + the documentation, not the merge click.

### New labels

- `ralphie:ready-to-merge` (green) — Path A success: verified clean, changelog clean, ready for the human's merge button
- `ralphie:skip-needs-review` (yellow) — Path A escape hatch: tests passed but changelog flagged something

### Files changed

- `happyhq/.dev/dependency-rules.md` — outcomes table reorganized; new `ready-to-merge` and `skip-needs-review` rules; new comment shape for Path A success; "human is the gate, always" promoted in principles
- `happyhq/.dev/PROMPT_dependency_upgrade.md` — Path A rewritten; constraint footnote updated

## Test plan
- [ ] Merge this PR
- [ ] Re-run `./dependency.sh --pr 121 --dry-run` (worktree or main; main is now clear)
- [ ] Confirm the dry-run trace shows: install → verify → changelog skim → DRY-RUN: comment + DRY-RUN: add-label `ready-to-merge` → return to main. **No `gh pr merge` should appear in the trace at all.**
- [ ] If clean, run `./dependency.sh --pr 121` for real. Confirm a `ready-to-merge` comment + label land on the PR but the PR stays open.
- [ ] You manually review the comment and click merge if happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)