### PR TITLE
chore: deps loop investigates flagged changelog items, doesn't auto-skip

### DIFF
--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -16,14 +16,22 @@
 4. **Branch on the result:**
 
    **Path A — clean (verification passed):**
-   - **Skim the upstream changelog / release notes** for the version delta. Look for any of:
+   - **Skim the upstream changelog / release notes** for the version delta. Note any of:
      - Ownership change (different maintainer or org publishing the release)
      - Secrets / auth / token handling refactor
      - Security advisory referenced in the release
-     - Deprecation we'd hit (grep the repo for callers of any deprecated API)
+     - Deprecation we might hit
      - Breaking API change that the test suite might not cover
-   - **If the changelog flags any of the above:** apply `ralphie:skip-needs-review` to the PR with a comment quoting the concerning item and linking the changelog. Use the rules-shape skip comment format. Return to main, exit.
-   - **If the changelog is clean:** post the rules-shape `ready-to-merge` summary comment on the PR (verification status, 2–4 changelog highlights with link, one-or-two-sentence recommendation), then label: `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"`.
+   - **If nothing in the skim raises a flag**, jump to "Post the comment" below.
+   - **If something is flagged, do NOT immediately skip — investigate the impact for our codebase before deciding.** This is the loop's job, not the human's. For each flag:
+     - Read the linked PR / issue / migration note for the specific change. Understand what concretely changed (file paths, behavior, defaults, env vars, etc.).
+     - Search the repo for any code, workflow, or config that depends on the affected behavior. Use grep, file reads, and Sonnet subagents in parallel for breadth.
+     - Form a concrete impact verdict, with evidence:
+       - **"Doesn't affect our usage"** — cite the specific evidence (e.g., "grep finds no caller of `db.transact()` with a callback signature; the v6 API change to that signature can't bite us"). Proceed to ready-to-merge.
+       - **"Affects our usage and the change is benign / a clear improvement"** — cite the evidence and reason it's safe (e.g., "we use `actions/checkout` with default `persist-credentials: true`; the new `$RUNNER_TEMP` storage location is functionally equivalent and doesn't break any subsequent step in our workflows"). Proceed to ready-to-merge.
+       - **"Affects our usage and impact is unclear after investigation, OR the change introduces real risk we can't size from the available info"** — apply `ralphie:skip-needs-review` with a comment that includes (a) what the change is, (b) what you investigated, (c) what's still unclear and why a human needs to weigh in. Return to main, exit.
+   - **Post the comment** on the PR using the rules-shape `ready-to-merge` format: verification status, 2–4 changelog highlights with link, **investigation summary** (if anything was flagged and cleared), and one-or-two-sentence recommendation.
+   - **Apply the label**: `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"`.
    - Return to main: `git checkout main && git pull`.
    - Exit. **Do not merge. The human reviews the comment and clicks merge.**
 

--- a/happyhq/.dev/dependency-rules.md
+++ b/happyhq/.dev/dependency-rules.md
@@ -12,16 +12,16 @@ Source of truth for how the deps loop processes open Dependabot PRs. Both `PROMP
 
 Apply in order — bail at the earliest stop. The first three are evaluable from the PR text alone (Phase 1 — triage). The last five only show up after attempting an upgrade (Phase 2).
 
-| #   | Condition                                                                                                                                                                                                                                                                                                                            | Label applied                      | What unblocks it                                                      |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | --------------------------------------------------------------------- |
-| 1   | PR diff would touch `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files — **except** PRs from the `dependabot/github_actions/*` branch family where the diff is limited to `uses:` line changes in workflow files (those are mechanical version pins, not authored CI edits, and are eligible for Phase 2) | `ralphie:skip-out-of-scope`        | Maintainer scopes the change; remove label                            |
-| 2   | CI on the PR is red and the failure is unrelated to the version bump (infra flake, lint config drift, network timeout, etc.)                                                                                                                                                                                                         | `ralphie:skip-ci-red`              | Investigate the CI failure; remove label                              |
-| 3   | Update is one of: framework major (`next`, `react`, `react-dom`); security-sensitive runtime major (auth, crypto, billing — e.g., `stripe` ≥2 majors at once, `instantdb`, JWT/OIDC libs); pre-1.0 → 1.0 jump on a runtime dep                                                                                                       | `ralphie:skip-manual-upgrade`      | Maintainer upgrades and reviews; remove label                         |
-| 4   | (Phase 2) Verification clean (lint/types/test/smoke) **and** changelog skim reveals nothing concerning                                                                                                                                                                                                                               | `ralphie:ready-to-merge`           | Maintainer reads Ralphie's summary comment, clicks merge              |
-| 5   | (Phase 2) Changelog skim flags a concerning item (ownership change, secrets/auth refactor, security advisory, deprecation we'd hit, breaking API change tests didn't catch)                                                                                                                                                          | `ralphie:skip-needs-review`        | Maintainer reviews the changelog; decides to merge, replace, or close |
-| 6   | (Phase 2) `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` / `npx tsx scripts/smoke-test.ts` failed twice                                                                                                                                                                                             | `ralphie:skip-verification-failed` | Read Ralphie's comment; fix locally                                   |
-| 7   | (Phase 2) Fixups would exceed 10 files or 300 lines net added (`*.md`/`*.mdx` and lockfile/package.json excluded from the count)                                                                                                                                                                                                     | `ralphie:skip-too-big`             | Scope it down or do it manually                                       |
-| 8   | (Phase 2) Replacement PR shipped (breaking-change fixups path)                                                                                                                                                                                                                                                                       | `ralphie:replaced-by-#<new>`       | Terminal — the linked replacement PR closes the loop                  |
+| #   | Condition                                                                                                                                                                                                                                                                                                                            | Label applied                      | What unblocks it                                                                      |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | PR diff would touch `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files — **except** PRs from the `dependabot/github_actions/*` branch family where the diff is limited to `uses:` line changes in workflow files (those are mechanical version pins, not authored CI edits, and are eligible for Phase 2) | `ralphie:skip-out-of-scope`        | Maintainer scopes the change; remove label                                            |
+| 2   | CI on the PR is red and the failure is unrelated to the version bump (infra flake, lint config drift, network timeout, etc.)                                                                                                                                                                                                         | `ralphie:skip-ci-red`              | Investigate the CI failure; remove label                                              |
+| 3   | Update is one of: framework major (`next`, `react`, `react-dom`); security-sensitive runtime major (auth, crypto, billing — e.g., `stripe` ≥2 majors at once, `instantdb`, JWT/OIDC libs); pre-1.0 → 1.0 jump on a runtime dep                                                                                                       | `ralphie:skip-manual-upgrade`      | Maintainer upgrades and reviews; remove label                                         |
+| 4   | (Phase 2) Verification clean (lint/types/test/smoke) **and** changelog skim reveals nothing concerning                                                                                                                                                                                                                               | `ralphie:ready-to-merge`           | Maintainer reads Ralphie's summary comment, clicks merge                              |
+| 5   | (Phase 2) Changelog skim flags an item AND impact investigation reveals genuine concern for our codebase (or impact is unclear after investigation)                                                                                                                                                                                  | `ralphie:skip-needs-review`        | Maintainer reads Ralphie's investigation summary; decides to merge, replace, or close |
+| 6   | (Phase 2) `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` / `npx tsx scripts/smoke-test.ts` failed twice                                                                                                                                                                                             | `ralphie:skip-verification-failed` | Read Ralphie's comment; fix locally                                                   |
+| 7   | (Phase 2) Fixups would exceed 10 files or 300 lines net added (`*.md`/`*.mdx` and lockfile/package.json excluded from the count)                                                                                                                                                                                                     | `ralphie:skip-too-big`             | Scope it down or do it manually                                                       |
+| 8   | (Phase 2) Replacement PR shipped (breaking-change fixups path)                                                                                                                                                                                                                                                                       | `ralphie:replaced-by-#<new>`       | Terminal — the linked replacement PR closes the loop                                  |
 
 A PR that passes rules 1–3 is **eligible** — it stays unlabeled and Phase 2 picks it up. Phase 2 takes one of two paths:
 
@@ -58,8 +58,30 @@ Ralphie verified this — ready to merge.
 - <bullet 2>
 - (link to upstream release notes)
 
+### Investigation
+(Include this section only if the changelog skim flagged anything. Otherwise omit.)
+- Flag: <e.g., "credential-persistence refactor at <link>">
+- What I checked: <e.g., "grep'd ci.yml and codeql.yml for any step depending on persisted git creds; none">
+- Verdict: <one sentence — why the flag doesn't bite us>
+
 ### Recommendation
 <one or two sentences — why this looks safe to merge for our usage>
+```
+
+## Comment shape (Path A skip — `skip-needs-review`)
+
+Used when investigation reveals genuine concern or unclear impact. Goes beyond the generic skip shape to surface the work already done.
+
+```
+Ralphie skipped this for: needs-review
+
+What I saw: <1–2 sentences — the changelog item that triggered investigation, with link>
+
+What I investigated: <2–4 bullets — the specific code/workflows/configs you checked, and what you found>
+
+What's still unclear: <1–2 sentences — why the human needs to weigh in: ambiguous impact, ownership change risk, deprecation timeline, etc.>
+
+What would unblock it: <1 sentence — concrete action for the maintainer>
 ```
 
 ## Comment shape (replacement, posted on the original Dependabot PR)
@@ -97,7 +119,11 @@ These are guidance, not gates. The rules above are pass/fail; these tune _how_ a
 
 **The human is the gate, always.** Ralphie never merges — not Dependabot's PRs, not replacement PRs. Path A's job is "verify, summarize, label `ready-to-merge`." Path B's job is "open a replacement PR with the breaking-change fixups documented." In both cases the merge button is the maintainer's. The loop's value is the verification work and the documentation, not the merge click.
 
-**Skim the changelog even when verification is clean.** Green CI doesn't catch supply-chain risk (maintainer compromise, ownership change, hostile release). It doesn't catch behavior changes that won't bite until production load. A 60-second changelog skim catches a lot of that at near-zero cost. If the changelog mentions ownership change, secrets/auth handling refactor, security advisory, or breaking API change, apply `ralphie:skip-needs-review` instead of `ready-to-merge` — even if every test passed.
+**Skim the changelog even when verification is clean, then investigate before deciding.** Green CI doesn't catch supply-chain risk (maintainer compromise, ownership change, hostile release). It doesn't catch behavior changes that won't bite until production load. A 60-second changelog skim catches a lot of that at near-zero cost.
+
+**But the skim is a trigger to investigate, not a trigger to bail.** When the skim flags something — ownership change, secrets/auth handling refactor, security advisory, deprecation, breaking API change — read the linked PR/migration note, search the repo for usage of the affected behavior, and form a concrete impact verdict. The loop's value is the work; punting every flagged change to the human just shifts the same investigation onto them. Skip with `ralphie:skip-needs-review` only when the investigation reveals genuine concern or the impact is unclear after a real attempt — not as a default response to flagged keywords.
+
+Concrete shape: changelog mentions a credential-storage refactor → grep workflows for steps that depend on credential storage location → if no consumer, comment the impact assessment and recommend merge; if there's a consumer and the change is benign, same; if there's a consumer and the impact is ambiguous, skip with the specific concern.
 
 ## Tuning signal
 


### PR DESCRIPTION
## Summary

The first real Path A dry-run (PR #121, \`actions/checkout\` v5→v6) landed on \`ralphie:skip-needs-review\` because the changelog mentioned a credential-persistence refactor. That was technically correct per the old Path A rules — and exactly the wrong shape.

The agent did the verification work (5 minutes), then **punted the investigation back to the human** who now has to read the linked PR, grep our workflows, and decide whether the change matters. The loop saved nothing — it just relocated the same investigation.

## What I'd expected (and what should happen)

The changelog skim should be a **trigger to investigate**, not a trigger to bail. When something is flagged, the agent should:

1. Read the linked PR/migration note for the specific change
2. Search the repo for code, workflows, or configs that depend on the affected behavior
3. Form a concrete impact verdict — \"doesn't affect us because X\", \"affects us but is benign because Y\", or \"unclear, human please weigh in\" — and act accordingly

For #121 specifically, the right behavior would have been:
- Flag: credential storage moves from \`.git/config\` → \`\$RUNNER_TEMP/<file>\`
- Investigation: grep \`ci.yml\` and \`codeql.yml\` for any step that reads persisted git credentials. None found — all post-checkout steps are \`pnpm\` commands.
- Verdict: doesn't affect us. **Recommend ready-to-merge with the investigation summary in the comment.**

\`skip-needs-review\` should be reserved for cases where investigation reveals genuine concern or impact is unclear after a real attempt — not a default response to flagged keywords.

## Changes

- **\`PROMPT_dependency_upgrade.md\` Path A**: insert an \"investigate impact\" step between skim and decision. Three explicit verdict shapes: \"doesn't affect us\", \"affects us but benign\", \"unclear — human needed\".
- **\`dependency-rules.md\` Rule 5**: rephrase to \"investigation reveals genuine concern\" — closes the gap that produced the over-eager skip.
- **\`dependency-rules.md\` \"Skim the changelog\" principle**: split into \"the skim is a trigger to investigate, not to bail\". Includes a concrete example of the shape (credential-storage refactor → grep workflows → recommend or skip with evidence).
- **New comment shape** for \`Path A skip-needs-review\`: surfaces what was already investigated and what's still unclear, so the human's review starts where the agent left off.

## Test plan
- [ ] Merge this PR
- [ ] Re-run \`./dependency.sh --pr 121 --dry-run\` (with the existing \`skip-needs-review\` label on #121 first removed manually so the queue evaluates fresh)
- [ ] Confirm the dry-run trace shows: install → verify → changelog skim → **investigation step** (greps, file reads) → verdict → DRY-RUN: \`ready-to-merge\` comment + label
- [ ] The investigation summary in the comment cites specific evidence (file paths, grep results, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)