### PR TITLE
chore(loop): teach bugs/deps loops to run from sibling worktrees

### DIFF
--- a/happyhq/.dev/PROMPT_bugs_fix.md
+++ b/happyhq/.dev/PROMPT_bugs_fix.md
@@ -4,13 +4,13 @@
 
 1. **Reproduce.** Establish the bug locally — write a failing test, or run the steps in the issue and confirm the failure mode. If repro cannot be established from the issue + linked logs + a focused investigation, apply `ralphie:skip-not-reproducible` (rubric rule 7), post the rubric-shaped comment, exit. Use `~/HappyHQ/.logs/$(date +%Y-%m-%d).jsonl` and `npx tsx scripts/read-logs.ts` for runtime logs (see @CLAUDE.md "Debugging Q").
 
-2. **Branch.** From `main`: `git checkout main && git pull && git checkout -b fix/${ISSUE_NUMBER}-<short-slug>`. The slug is 2–4 hyphenated words derived from the issue title.
+2. **Branch.** The wrapper has already snapped `${BASE_BRANCH}` to latest `origin/main`, so just branch off it: `git checkout ${BASE_BRANCH} && git checkout -b fix/${ISSUE_NUMBER}-<short-slug>`. The slug is 2–4 hyphenated words derived from the issue title.
 
 3. **Fix + regression test.** Implement the smallest change that fixes the bug. Add a regression test that fails before the fix and passes after. Tests verify behavior, not implementation (see @CLAUDE.md). Use Sonnet subagents for parallel reads/searches; use Opus for debugging or architectural calls.
 
 4. **Verify.** From the `happyhq/` directory, run `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test`. If any fail, fix and re-run. If they fail twice, apply `ralphie:skip-verification-failed` (rubric rule 8), post the rubric-shaped comment with the failing output included, exit.
 
-5. **Size gate.** After the fix is in, check the diff: `git diff --stat main...HEAD -- ':!*.md' ':!*.mdx'`. If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` (rubric rule 6/9), post the rubric-shaped comment summarizing what the fix would have entailed, leave the branch in place (do not push), exit. Spec/doc updates (`*.md`/`*.mdx`) are excluded from the count — they don't carry the same review burden as code, and bundling them with the fix keeps design and implementation in sync.
+5. **Size gate.** After the fix is in, check the diff: `git diff --stat origin/main...HEAD -- ':!*.md' ':!*.mdx'`. (Use `origin/main`, not the local `main` ref — when running from a worktree the local `main` may be stale.) If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` (rubric rule 6/9), post the rubric-shaped comment summarizing what the fix would have entailed, leave the branch in place (do not push), exit. Spec/doc updates (`*.md`/`*.mdx`) are excluded from the count — they don't carry the same review burden as code, and bundling them with the fix keeps design and implementation in sync.
 
 6. **Commit.** `git add -A && git commit -m "fix: <one-line summary>\n\nCloses #${ISSUE_NUMBER}"`.
 
@@ -22,7 +22,7 @@
 
 8. **Label.** `gh issue edit ${ISSUE_NUMBER} --add-label "ralphie:fixed-in-pr"`. The PR's `Closes #` is the rest of the breadcrumb.
 
-9. **Return to main.** `git checkout main`. Each session leaves the working tree on `main` so the next session (or the maintainer) starts from a clean baseline. Apply this on the skip paths too — if you abort and revert in step 6 of the guardrails, end on `main`.
+9. **Return to base branch.** `git checkout ${BASE_BRANCH}`. Each session leaves the working tree on `${BASE_BRANCH}` so the next session (or the maintainer) starts from a clean baseline. Apply this on the skip paths too — if you abort and revert in step 6 of the guardrails, end on `${BASE_BRANCH}`.
 
 10. ${DRY_RUN_NOTE}
 
@@ -35,7 +35,7 @@
 **[3]** A regression test is required _when there is a behavior contract worth pinning_. Apply the litmus test from @testing.md before writing one: "what bug would this catch?" If the only answer is "someone reverted this exact line" (e.g. asserting an asset path equals `/brand/q.svg`, asserting a specific class name, asserting copy text), the test is a vanity test — don't write it. Asset swaps, copy tweaks, and CSS-only fixes are visually verified, not test-locked. If you cannot articulate a user-visible contract the test defends, the fix is either too trivial to need a test, or you haven't found the right contract yet — re-think before writing one.
 **[4]** Tests verify behavior — what the system guarantees to the user. 50 different implementations should pass the same test. Test conditional rendering driven by state, input/output contracts, error paths, security boundaries. Never `toBeTruthy()`, snapshots, "renders without crashing", asserts on specific src/href/class/copy values, or "mock was called" (unless the call IS the contract).
 **[5]** Capture the **why** in the PR body and (if non-obvious) a code comment. Never narrate **what** in comments — well-named code does that.
-**[6]** If you discover the fix requires a schema migration / new env var / new dep / CI change mid-implementation, stop, revert your changes (`git checkout main && git branch -D fix/${ISSUE_NUMBER}-...`), apply `ralphie:skip-out-of-scope`, exit.
+**[6]** If you discover the fix requires a schema migration / new env var / new dep / CI change mid-implementation, stop, revert your changes (`git checkout ${BASE_BRANCH} && git branch -D fix/${ISSUE_NUMBER}-...`), apply `ralphie:skip-out-of-scope`, exit.
 **[7]** AI disclosure in the PR body is required by @CONTRIBUTING.md. Never omit it.
 **[8]** When applying any `ralphie:skip-*` label, the comment uses the rubric's "Comment shape" format. Always.
 **[9]** Question the shape of the fix before committing to it. If the fix is purely a constraint (cap, limit, truncate, hide), the unbounded behavior has a cause — find it and fix it, even when it lives in nearby code. Scope follows the cause: touch nearby code when it's the cause, leave it when it's just adjacent and looks improvable. If you're adding a new element to an existing UI surface, check it's distinguishable from neighbors of similar shape.

--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -2,7 +2,7 @@
 0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rules.
 0c. The PR you are working: #${PR_NUMBER}. Read it: `gh pr view ${PR_NUMBER} --comments`. Phase 2 only processes Dependabot PRs that passed triage (no `ralphie:*` label).
 
-1. **Checkout the PR branch.** From `main`: `git checkout main && git pull`. Then: `gh pr checkout ${PR_NUMBER}`. Capture the branch name (`git branch --show-current`) for later reference; you'll need it if you fall through to Path B.
+1. **Checkout the PR branch.** The wrapper has already snapped `${BASE_BRANCH}` to latest `origin/main`. From `${BASE_BRANCH}`: `gh pr checkout ${PR_NUMBER}`. Capture the branch name (`git branch --show-current`) for later reference; you'll need it if you fall through to Path B.
 
 2. **Install.** From the repo root: `pnpm install --frozen-lockfile`. If it fails because the lockfile drifted, run `pnpm install` (no frozen) and treat any unexpected lockfile diff beyond what Dependabot already wrote as a signal to investigate before continuing.
 
@@ -29,15 +29,15 @@
      - Form a concrete impact verdict, with evidence:
        - **"Doesn't affect our usage"** — cite the specific evidence (e.g., "grep finds no caller of `db.transact()` with a callback signature; the v6 API change to that signature can't bite us"). Proceed to ready-to-merge.
        - **"Affects our usage and the change is benign / a clear improvement"** — cite the evidence and reason it's safe (e.g., "we use `actions/checkout` with default `persist-credentials: true`; the new `$RUNNER_TEMP` storage location is functionally equivalent and doesn't break any subsequent step in our workflows"). Proceed to ready-to-merge.
-       - **"Affects our usage and impact is unclear after investigation, OR the change introduces real risk we can't size from the available info"** — apply `ralphie:skip-needs-review` with a comment that includes (a) what the change is, (b) what you investigated, (c) what's still unclear and why a human needs to weigh in. Return to main, exit.
+       - **"Affects our usage and impact is unclear after investigation, OR the change introduces real risk we can't size from the available info"** — apply `ralphie:skip-needs-review` with a comment that includes (a) what the change is, (b) what you investigated, (c) what's still unclear and why a human needs to weigh in. Return to `${BASE_BRANCH}`, exit.
    - **Post the comment** on the PR using the rules-shape `ready-to-merge` format: verification status, 2–4 changelog highlights with link, **investigation summary** (if anything was flagged and cleared), and one-or-two-sentence recommendation.
    - **Apply the label**: `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"`.
-   - Return to main: `git checkout main && git pull`.
+   - Return to base branch: `git checkout ${BASE_BRANCH}`.
    - Exit. **Do not merge. The human reviews the comment and clicks merge.**
 
    **Path B — verification failed (breaking-change fixups):**
-   - **Plan from the changelog first.** Read the upstream release notes / migration guide for the version delta. Identify which breaking change(s) caused the failures. Quote the relevant entries in the work plan. If the failure mode isn't predicted by the changelog, **stop**: apply `ralphie:skip-verification-failed` to the original PR with the failure output included, return to main, exit.
-   - Return to main: `git checkout main`. Note Dependabot's branch name from step 1 — you'll need to read files from it.
+   - **Plan from the changelog first.** Read the upstream release notes / migration guide for the version delta. Identify which breaking change(s) caused the failures. Quote the relevant entries in the work plan. If the failure mode isn't predicted by the changelog, **stop**: apply `ralphie:skip-verification-failed` to the original PR with the failure output included, return to `${BASE_BRANCH}`, exit.
+   - Return to base branch: `git checkout ${BASE_BRANCH}`. Note Dependabot's branch name from step 1 — you'll need to read files from it.
    - Create a fresh branch: `git checkout -b chore/upgrade-<package>-v<major>` (use the package name and target major, e.g., `chore/upgrade-stripe-v22`).
    - Apply the version bump from the Dependabot branch to your fresh branch:
      ```
@@ -46,8 +46,8 @@
      ```
      (Adjust paths if the Dependabot PR also touched the root `package.json` or other workspace `package.json` files.)
    - Apply the smallest set of fixups required to pass verification. Cite the changelog item that justifies each fixup in commit messages — the diff and the changelog should map 1:1.
-   - Re-run verification (step 3). If it fails, fix and re-run. If it fails twice, apply `ralphie:skip-verification-failed` to the original PR with the failing output. Push nothing. Return to main. Exit.
-   - **Size gate.** `git diff --stat main...HEAD -- ':!happyhq/package.json' ':!package.json' ':!pnpm-lock.yaml' ':!*.md' ':!*.mdx'`. If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` to the original PR with a summary of what the fixup would have entailed. Leave the local branch in place (do not push). Return to main. Exit.
+   - Re-run verification (step 3). If it fails, fix and re-run. If it fails twice, apply `ralphie:skip-verification-failed` to the original PR with the failing output. Push nothing. Return to `${BASE_BRANCH}`. Exit.
+   - **Size gate.** `git diff --stat origin/main...HEAD -- ':!happyhq/package.json' ':!package.json' ':!pnpm-lock.yaml' ':!*.md' ':!*.mdx'`. (Use `origin/main`, not the local `main` ref — when running from a worktree the local `main` may be stale.) If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` to the original PR with a summary of what the fixup would have entailed. Leave the local branch in place (do not push). Return to `${BASE_BRANCH}`. Exit.
    - Commit: `git add -A && git commit -m "chore: upgrade <package> to v<major>"` (one commit per discrete fixup is also fine; cite the changelog item in each commit body).
    - Push: `git push -u origin chore/upgrade-<package>-v<major>`.
    - Open replacement PR: `gh pr create --base main --assignee @me --title "chore: upgrade <package> to v<major>" --body "..."`. PR body MUST include:
@@ -59,7 +59,7 @@
      - AI-assistance disclosure per @CONTRIBUTING.md (e.g., "Authored by Ralphie, the autonomous dependency-upgrade loop. Reviewed by maintainer before merge.")
    - Capture the new PR number from the create output. Create the dynamic label if it doesn't exist: `gh label create "ralphie:replaced-by-#<new>" --color "5319E7" --description "Ralphie closed this in favor of replacement PR #<new>"` (ignore "already exists" errors).
    - Close the original Dependabot PR with the rules-shape replacement comment, label it `ralphie:replaced-by-#<new>`, then close: `gh pr edit ${PR_NUMBER} --add-label "ralphie:replaced-by-#<new>"`, `gh pr comment ${PR_NUMBER} --body "..."`, `gh pr close ${PR_NUMBER}` (label + comment go on first; closing is the last write).
-   - Return to main: `git checkout main`.
+   - Return to base branch: `git checkout ${BASE_BRANCH}`.
    - Exit.
 
 5. ${DRY_RUN_NOTE}
@@ -74,5 +74,5 @@
 **[4]** Smallest fixup. Don't refactor adjacent code. Don't update unrelated callers. Surface drift via PR-body comments, not by widening the diff.
 **[5]** Stop when surprised. If a test failure isn't predicted by the changelog, or you can't trace a diff line to a documented change, apply `ralphie:skip-verification-failed` and let the human take it.
 **[6]** AI disclosure in the replacement PR body is required by @CONTRIBUTING.md.
-**[7]** Always end on `main` with a clean working tree, even on skip paths.
+**[7]** Always end on `${BASE_BRANCH}` with a clean working tree, even on skip paths.
 **[8]** Nothing the loop touches gets auto-merged. Path A ends at `ralphie:ready-to-merge` (label + summary comment); Path B ends at "replacement PR open." In both cases the merge button is the maintainer's.

--- a/happyhq/.dev/bugs.sh
+++ b/happyhq/.dev/bugs.sh
@@ -78,6 +78,37 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1
 
+# ── Worktree-aware base branch resolution ──
+# Loops run from the primary checkout (on `main`) or from a sibling worktree
+# (on `loop/bugs`). Snap whichever branch we're on to origin/main so the agent
+# starts from a clean, up-to-date base. The prompts use $BASE_BRANCH instead
+# of literal `main` for checkout/return paths so they work in both locations.
+CURRENT_BRANCH=$(git branch --show-current)
+case "$CURRENT_BRANCH" in
+    main|loop/bugs)
+        BASE_BRANCH="$CURRENT_BRANCH"
+        ;;
+    *)
+        echo -e "  ${RED}Error: bugs.sh must be run from 'main' (primary checkout) or 'loop/bugs' (bugs worktree). Currently on: $CURRENT_BRANCH${RESET}" >&2
+        exit 1
+        ;;
+esac
+export BASE_BRANCH
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Guard against losing uncommitted work — the next step is `git reset --hard`.
+if [ -n "$(git status --porcelain)" ]; then
+    echo -e "  ${RED}Error: uncommitted changes in ${REPO_ROOT}. Commit, stash, or discard before running the loop — the next step hard-resets to origin/main.${RESET}" >&2
+    git status --short >&2
+    exit 1
+fi
+
+echo -e "  ${DIM}Snapping ${BASE_BRANCH} → origin/main (hard reset), then pnpm install…${RESET}"
+git fetch origin --quiet || { echo -e "  ${RED}git fetch failed${RESET}" >&2; exit 1; }
+git reset --hard origin/main >/dev/null || { echo -e "  ${RED}git reset failed${RESET}" >&2; exit 1; }
+(cd "$REPO_ROOT" && (pnpm install --frozen-lockfile || pnpm install)) || { echo -e "  ${RED}pnpm install failed${RESET}" >&2; exit 1; }
+
 cleanup() {
     echo -e "\n${DIM}Cleaning up child processes...${RESET}"
     pkill -P $$ 2>/dev/null

--- a/happyhq/.dev/dependency.sh
+++ b/happyhq/.dev/dependency.sh
@@ -78,6 +78,37 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1
 
+# ── Worktree-aware base branch resolution ──
+# Loops run from the primary checkout (on `main`) or from a sibling worktree
+# (on `loop/deps`). Snap whichever branch we're on to origin/main so the agent
+# starts from a clean, up-to-date base. The prompts use $BASE_BRANCH instead
+# of literal `main` for checkout/return paths so they work in both locations.
+CURRENT_BRANCH=$(git branch --show-current)
+case "$CURRENT_BRANCH" in
+    main|loop/deps)
+        BASE_BRANCH="$CURRENT_BRANCH"
+        ;;
+    *)
+        echo -e "  ${RED}Error: dependency.sh must be run from 'main' (primary checkout) or 'loop/deps' (deps worktree). Currently on: $CURRENT_BRANCH${RESET}" >&2
+        exit 1
+        ;;
+esac
+export BASE_BRANCH
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Guard against losing uncommitted work — the next step is `git reset --hard`.
+if [ -n "$(git status --porcelain)" ]; then
+    echo -e "  ${RED}Error: uncommitted changes in ${REPO_ROOT}. Commit, stash, or discard before running the loop — the next step hard-resets to origin/main.${RESET}" >&2
+    git status --short >&2
+    exit 1
+fi
+
+echo -e "  ${DIM}Snapping ${BASE_BRANCH} → origin/main (hard reset), then pnpm install…${RESET}"
+git fetch origin --quiet || { echo -e "  ${RED}git fetch failed${RESET}" >&2; exit 1; }
+git reset --hard origin/main >/dev/null || { echo -e "  ${RED}git reset failed${RESET}" >&2; exit 1; }
+(cd "$REPO_ROOT" && (pnpm install --frozen-lockfile || pnpm install)) || { echo -e "  ${RED}pnpm install failed${RESET}" >&2; exit 1; }
+
 cleanup() {
     echo -e "\n${DIM}Cleaning up child processes...${RESET}"
     pkill -P $$ 2>/dev/null


### PR DESCRIPTION
## Summary

- Adds a worktree-aware preamble to `bugs.sh` and `dependency.sh`: detect the parking branch (`main` for the primary checkout, `loop/bugs`/`loop/deps` for sibling worktrees), refuse to clobber uncommitted work, hard-reset to `origin/main`, and run `pnpm install` once before the agent starts. `BASE_BRANCH` is exported so the prompts can substitute it for literal `main` in checkout/return paths.
- Replaces `git checkout main && git pull` and "return to main" instructions in `PROMPT_bugs_fix.md` and `PROMPT_dependency_upgrade.md` with `git checkout ${BASE_BRANCH}` — the wrapper has already done the fetch/reset, so the agent never tries to check out main inside a worktree (which fails when main is held by the primary checkout).
- Switches the Path B size-gate diffs from `main...HEAD` to `origin/main...HEAD` in both prompts: inside a worktree the local `main` ref is whatever the primary checkout last pulled, which can be days stale; `origin/main` always reflects the remote. Inline parenthetical explains the why so the next reader doesn't "fix" it back.
- Leaves PR targets (`gh pr create --base main`), `origin/main` upstream refs, and "never push to `main`" guardrails as literal — those are about the upstream branch and don't move.

## Why

The loops previously assumed the primary checkout — every prompt did `git checkout main && git pull`. Inside a worktree git refuses to check out main in two places, so the agent had to improvise around the failure. Best case it landed in the right state by accident; worst case a Path B replacement PR branched off whatever stale parking-branch state the worktree happened to have, and the size-gate diff measured against a stale local `main`. The wrapper now makes "start from latest origin/main" a precondition the agent doesn't have to think about.

## Test plan

- [ ] From the primary checkout on `main`: `./happyhq/.dev/bugs.sh --issue <#> --dry-run` runs the preamble (`Snapping main → origin/main`), branches off main, ends on main.
- [ ] From `/happyhq-bugs` on `loop/bugs`: same script run reports `Snapping loop/bugs → origin/main`, branches off `loop/bugs`, ends on `loop/bugs` — no `git checkout main` failure in the trace.
- [ ] From `/happyhq-deps` on `loop/deps`: `./happyhq/.dev/dependency.sh --pr <#> --dry-run` reports `Snapping loop/deps → origin/main`, ends on `loop/deps` cleanly.
- [ ] From any of the above with uncommitted changes in the tree: script exits with the porcelain guard error and shows `git status --short`, no reset performed.
- [ ] From a feature branch (e.g. `fix/something`): script refuses with the "must be run from main or loop/bugs" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)