### PR TITLE
chore: deps loop documents all watch-list items + explicit smoke-test recipe

### DIFF
--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -11,7 +11,11 @@
    - `pnpm lint`
    - `pnpm check-types`
    - `pnpm --filter=happyhq test`
-   - `npx tsx scripts/smoke-test.ts` (start the dev server first if the script needs it; see @CLAUDE.md "Using HappyHQ's API")
+   - `npx tsx scripts/smoke-test.ts` — needs a dev server. Use a non-default port (3000 may collide with another worktree). Recipe:
+     1. Start the server in the background: `(cd ../happyhq && PORT=3456 pnpm dev > /tmp/dev-3456.log 2>&1 &)` — or use the Bash tool's `run_in_background: true` with the same command (preferred — gives you a task ID to stop cleanly).
+     2. Wait for ready: poll `until curl -sf http://localhost:3456/api/auth/status > /dev/null 2>&1; do sleep 2; done` with the Monitor tool, OR manually re-curl every few seconds. Don't blind-`sleep 30`.
+     3. Run the test: `PORT=3456 npx tsx scripts/smoke-test.ts`.
+     4. Kill the server: TaskStop on the background task ID, or `pkill -f "next dev"` as a fallback.
 
 4. **Branch on the result:**
 
@@ -30,7 +34,7 @@
        - **"Doesn't affect our usage"** — cite the specific evidence (e.g., "grep finds no caller of `db.transact()` with a callback signature; the v6 API change to that signature can't bite us"). Proceed to ready-to-merge.
        - **"Affects our usage and the change is benign / a clear improvement"** — cite the evidence and reason it's safe (e.g., "we use `actions/checkout` with default `persist-credentials: true`; the new `$RUNNER_TEMP` storage location is functionally equivalent and doesn't break any subsequent step in our workflows"). Proceed to ready-to-merge.
        - **"Affects our usage and impact is unclear after investigation, OR the change introduces real risk we can't size from the available info"** — apply `ralphie:skip-needs-review` with a comment that includes (a) what the change is, (b) what you investigated, (c) what's still unclear and why a human needs to weigh in. Return to main, exit.
-   - **Post the comment** on the PR using the rules-shape `ready-to-merge` format: verification status, 2–4 changelog highlights with link, **investigation summary** (if anything was flagged and cleared), and one-or-two-sentence recommendation.
+   - **Post the comment** on the PR using the rules-shape `ready-to-merge` format. The comment MUST include a `Changelog watch-list` section that documents the verdict for **each** watch item — ownership, auth/secrets, security advisory, deprecations, breaking API — even when the verdict is "none" or "no change". This is an audit trail for future readers; "didn't mention it" and "checked and found nothing" are not the same. For any item where the skim flagged something, include a one-line summary of what was investigated and the impact verdict.
    - **Apply the label**: `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"`.
    - Return to main: `git checkout main && git pull`.
    - Exit. **Do not merge. The human reviews the comment and clicks merge.**

--- a/happyhq/.dev/dependency-rules.md
+++ b/happyhq/.dev/dependency-rules.md
@@ -44,6 +44,8 @@ What would unblock it: <1 sentence — concrete action for the human>
 
 ## Comment shape (Path A success — `ready-to-merge`)
 
+The `Changelog watch-list` section is **required, even when every item is null** — it's an audit trail proving the agent considered each watch item. A "no" is signal too.
+
 ```
 Ralphie verified this — ready to merge.
 
@@ -58,11 +60,12 @@ Ralphie verified this — ready to merge.
 - <bullet 2>
 - (link to upstream release notes)
 
-### Investigation
-(Include this section only if the changelog skim flagged anything. Otherwise omit.)
-- Flag: <e.g., "credential-persistence refactor at <link>">
-- What I checked: <e.g., "grep'd ci.yml and codeql.yml for any step depending on persisted git creds; none">
-- Verdict: <one sentence — why the flag doesn't bite us>
+### Changelog watch-list
+- Ownership: <"same maintainer (@<handle>)" or "ownership change — investigated → <verdict>">
+- Auth/secrets: <"none" or "<change> — investigated → <verdict>">
+- Security advisory: <"none referenced" or "<advisory> — investigated → <verdict>">
+- Deprecations: <"none we'd hit" or "<deprecation> — investigated → <verdict>">
+- Breaking API: <"none" or "<change> — investigated → <verdict>">
 
 ### Recommendation
 <one or two sentences — why this looks safe to merge for our usage>


### PR DESCRIPTION
## Summary

Two follow-ups from the second Path A dry-run on PR #121.

### 1. Watch-list section is now required, even when null

The previous run's ready-to-merge comment only documented the *flagged* item (credential-persistence refactor). A future reader couldn't tell whether the agent verified the other watch items (ownership, security advisory, deprecations, breaking API) or just forgot to look.

The `Changelog watch-list` section is now a required block in the ready-to-merge comment, with one line per item — "none" / "no change" is signal too.

```
### Changelog watch-list
- Ownership: same maintainer (@ericsciple)
- Auth/secrets: credential-persistence refactor (#2286) — investigated → no consumer in our workflows ✓
- Security advisory: none referenced
- Deprecations: none we'd hit
- Breaking API: none
```

### 2. Explicit smoke-test recipe

The smoke step previously said "start the dev server first if the script needs it" with no recipe. The agent reached for the Monitor tool, abandoned it, and fell back to `sleep 30`. Spelled out the recipe:

- Non-default port (3000 collides across worktrees)
- Poll `/api/auth/status` with Monitor's until-loop or manual curl — don't blind-sleep
- Kill via TaskStop or pkill on exit

### Two follow-ups deliberately not addressed

- **Triple `gh pr view --comments` retry at session start.** Output-buffering hiccup; the agent self-corrected. No clean prompt fix without overspecifying.
- **Truncated heredoc in the trace.** Display-layer issue in `format-stream.mjs` — the actual comment body would post correctly in a real run.

## Notes on stacking

This branches from `main`, not from #163 (worktree base-branch resolution). The two PRs touch different sections of `PROMPT_dependency_upgrade.md` and don't conflict — order of merge doesn't matter. If #163 lands first, this rebases cleanly. If this lands first, #163 rebases cleanly.

## Test plan
- [ ] Merge this PR (after or before #163, either order)
- [ ] Re-run `./dependency.sh --pr 121 --dry-run`
- [ ] Confirm the dry-run trace shows the dev-server poll-loop instead of sleep 30
- [ ] Confirm the dry-run's would-post comment includes a populated `Changelog watch-list` section with all 5 items, even where the verdict is "none"

🤖 Generated with [Claude Code](https://claude.com/claude-code)