### PR TITLE
chore: tighten Path A — Investigation header + mandatory smoke port

### DIFF
--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -11,7 +11,7 @@
    - `pnpm lint`
    - `pnpm check-types`
    - `pnpm --filter=happyhq test`
-   - `npx tsx scripts/smoke-test.ts` — needs a dev server. Use a non-default port (3000 may collide with another worktree). Recipe:
+   - `npx tsx scripts/smoke-test.ts` — needs a dev server. **You MUST start it on port 3456, not the default 3000.** Port 3000 is reserved for the maintainer's own dev server (and may also be in use by the bugs loop's worktree). Using 3000 risks an EADDRINUSE failure or — worse — running the smoke test against an unrelated server. Recipe:
      1. Start the server in the background: `(cd ../happyhq && PORT=3456 pnpm dev > /tmp/dev-3456.log 2>&1 &)` — or use the Bash tool's `run_in_background: true` with the same command (preferred — gives you a task ID to stop cleanly).
      2. Wait for ready: poll `until curl -sf http://localhost:3456/api/auth/status > /dev/null 2>&1; do sleep 2; done` with the Monitor tool, OR manually re-curl every few seconds. Don't blind-`sleep 30`.
      3. Run the test: `PORT=3456 npx tsx scripts/smoke-test.ts`.
@@ -34,7 +34,7 @@
        - **"Doesn't affect our usage"** — cite the specific evidence (e.g., "grep finds no caller of `db.transact()` with a callback signature; the v6 API change to that signature can't bite us"). Proceed to ready-to-merge.
        - **"Affects our usage and the change is benign / a clear improvement"** — cite the evidence and reason it's safe (e.g., "we use `actions/checkout` with default `persist-credentials: true`; the new `$RUNNER_TEMP` storage location is functionally equivalent and doesn't break any subsequent step in our workflows"). Proceed to ready-to-merge.
        - **"Affects our usage and impact is unclear after investigation, OR the change introduces real risk we can't size from the available info"** — apply `ralphie:skip-needs-review` with a comment that includes (a) what the change is, (b) what you investigated, (c) what's still unclear and why a human needs to weigh in. Return to `${BASE_BRANCH}`, exit.
-   - **Post the comment** on the PR using the rules-shape `ready-to-merge` format. The comment MUST include a `Changelog watch-list` section that documents the verdict for **each** watch item — ownership, auth/secrets, security advisory, deprecations, breaking API — even when the verdict is "none" or "no change". This is an audit trail for future readers; "didn't mention it" and "checked and found nothing" are not the same. For any item where the skim flagged something, include a one-line summary of what was investigated and the impact verdict.
+   - **Post the comment** on the PR using the rules-shape `ready-to-merge` format. The comment MUST include an `### Investigation` section (use exactly that header, not "Changelog watch-list" or any other variant) with one line for **each** of the five audit items — ownership, auth/secrets, security advisory, deprecations, breaking API — even when the verdict is "none" or "no change". This is an audit trail for future readers; "didn't mention it" and "checked and found nothing" are not the same. For any item where the skim flagged something, add sub-bullets with depth (what was checked, what was found).
    - **Apply the label**: `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"`.
    - Return to base branch: `git checkout ${BASE_BRANCH}`.
    - Exit. **Do not merge. The human reviews the comment and clicks merge.**

--- a/happyhq/.dev/dependency-rules.md
+++ b/happyhq/.dev/dependency-rules.md
@@ -44,7 +44,7 @@ What would unblock it: <1 sentence — concrete action for the human>
 
 ## Comment shape (Path A success — `ready-to-merge`)
 
-The `Changelog watch-list` section is **required, even when every item is null** — it's an audit trail proving the agent considered each watch item. A "no" is signal too.
+The `Investigation` section is **required, with a line for each of the five audit items, even when every item is null** — it's an audit trail proving the agent considered each. A "no" is signal too. For flagged items, add sub-bullets with depth (what was checked, what was found).
 
 ```
 Ralphie verified this — ready to merge.
@@ -60,9 +60,10 @@ Ralphie verified this — ready to merge.
 - <bullet 2>
 - (link to upstream release notes)
 
-### Changelog watch-list
+### Investigation
 - Ownership: <"same maintainer (@<handle>)" or "ownership change — investigated → <verdict>">
-- Auth/secrets: <"none" or "<change> — investigated → <verdict>">
+- Auth/secrets: <"none" or "<change> — investigated → <verdict, with link>">
+  - <optional sub-bullet — what was checked / found, when there's depth>
 - Security advisory: <"none referenced" or "<advisory> — investigated → <verdict>">
 - Deprecations: <"none we'd hit" or "<deprecation> — investigated → <verdict>">
 - Breaking API: <"none" or "<change> — investigated → <verdict>">


### PR DESCRIPTION
## Summary

Two minor inconsistencies that surfaced from the first real Path A run on #121.

### 1. Section header: `### Investigation` (not `### Changelog watch-list`)

The agent gravitated to `### Investigation` over the watch-list header introduced in #164. Maintainer preference is the Investigation header anyway — it reads better and matches what the agent naturally produces.

Keep #164's audit-completeness intent: one required line per watch item (ownership / auth/secrets / security advisory / deprecations / breaking API), even when "none." For flagged items, sub-bullets with depth are fine. The header just goes back to Investigation.

Added an explicit "use exactly that header" guard in the prompt so the agent doesn't drift to other variants.

### 2. Smoke port: must be 3456, not 3000

The recipe in #164 said \`PORT=3456\` with rationale, but the agent used the default 3000 anyway. No collision happened this time, but would if the maintainer's dev server or the bugs-loop worktree were running.

Promoted the port choice from "Use a non-default port" to "**You MUST start it on port 3456, not the default 3000**" with explicit risk callout — EADDRINUSE failures, or worse, running the smoke test against an unrelated server.

## Test plan
- [ ] Merge this PR
- [ ] Re-run \`./dependency.sh --pr <next-eligible-PR> --dry-run\` (against any of #119/120/122 once they're available — actions/checkout #121 already merged)
- [ ] Confirm: dev server starts on 3456, smoke runs on 3456, comment uses \`### Investigation\` header with all 5 audit items

🤖 Generated with [Claude Code](https://claude.com/claude-code)