### PR TITLE
chore: enforce worktree↔branch pairing + wrapper-set smoke port

### DIFF
--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -11,10 +11,10 @@
    - `pnpm lint`
    - `pnpm check-types`
    - `pnpm --filter=happyhq test`
-   - `npx tsx scripts/smoke-test.ts` — needs a dev server. **You MUST start it on port 3456, not the default 3000.** Port 3000 is reserved for the maintainer's own dev server (and may also be in use by the bugs loop's worktree). Using 3000 risks an EADDRINUSE failure or — worse — running the smoke test against an unrelated server. Recipe:
-     1. Start the server in the background: `(cd ../happyhq && PORT=3456 pnpm dev > /tmp/dev-3456.log 2>&1 &)` — or use the Bash tool's `run_in_background: true` with the same command (preferred — gives you a task ID to stop cleanly).
-     2. Wait for ready: poll `until curl -sf http://localhost:3456/api/auth/status > /dev/null 2>&1; do sleep 2; done` with the Monitor tool, OR manually re-curl every few seconds. Don't blind-`sleep 30`.
-     3. Run the test: `PORT=3456 npx tsx scripts/smoke-test.ts`.
+   - `npx tsx scripts/smoke-test.ts` — needs a dev server. **Use port `${SMOKE_PORT}` (set by the wrapper). Do not pick another port.** Port 3000 is reserved for the maintainer's own dev server and may also be in use by another worktree; an unrelated port risks EADDRINUSE failures or — worse — running the smoke test against an unrelated server. Recipe:
+     1. Start the server in the background: `(cd ../happyhq && PORT=${SMOKE_PORT} pnpm dev > /tmp/dev-${SMOKE_PORT}.log 2>&1 &)` — or use the Bash tool's `run_in_background: true` with the same command (preferred — gives you a task ID to stop cleanly).
+     2. Wait for ready: poll `until curl -sf http://localhost:${SMOKE_PORT}/api/auth/status > /dev/null 2>&1; do sleep 2; done` with the Monitor tool, OR manually re-curl every few seconds. Don't blind-`sleep 30`.
+     3. Run the test: `PORT=${SMOKE_PORT} npx tsx scripts/smoke-test.ts`.
      4. Kill the server: TaskStop on the background task ID, or `pkill -f "next dev"` as a fallback.
 
 4. **Branch on the result:**

--- a/happyhq/.dev/bugs.sh
+++ b/happyhq/.dev/bugs.sh
@@ -79,23 +79,31 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1
 
 # ── Worktree-aware base branch resolution ──
-# Loops run from the primary checkout (on `main`) or from a sibling worktree
-# (on `loop/bugs`). Snap whichever branch we're on to origin/main so the agent
-# starts from a clean, up-to-date base. The prompts use $BASE_BRANCH instead
-# of literal `main` for checkout/return paths so they work in both locations.
-CURRENT_BRANCH=$(git branch --show-current)
-case "$CURRENT_BRANCH" in
-    main|loop/bugs)
-        BASE_BRANCH="$CURRENT_BRANCH"
+# The expected branch is determined by the worktree path, not by whatever
+# branch happens to be checked out — that prevents the silent drift where
+# the bugs worktree gets nudged onto `main` and the wrapper happily proceeds,
+# leaving the maintainer's primary checkout unable to switch back to main.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+case "$REPO_ROOT" in
+    */happyhq-bugs)
+        BASE_BRANCH="loop/bugs"
+        ;;
+    */happyhq)
+        BASE_BRANCH="main"
         ;;
     *)
-        echo -e "  ${RED}Error: bugs.sh must be run from 'main' (primary checkout) or 'loop/bugs' (bugs worktree). Currently on: $CURRENT_BRANCH${RESET}" >&2
+        echo -e "  ${RED}Error: bugs.sh must run from the primary checkout (.../happyhq) or the bugs worktree (.../happyhq-bugs). Current: ${REPO_ROOT}${RESET}" >&2
         exit 1
         ;;
 esac
 export BASE_BRANCH
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]; then
+    echo -e "  ${RED}Error: ${REPO_ROOT} should be on '${BASE_BRANCH}', not '${CURRENT_BRANCH}'.${RESET}" >&2
+    echo -e "  ${DIM}Fix: git -C ${REPO_ROOT} checkout ${BASE_BRANCH}${RESET}" >&2
+    exit 1
+fi
 
 # Guard against losing uncommitted work — the next step is `git reset --hard`.
 if [ -n "$(git status --porcelain)" ]; then

--- a/happyhq/.dev/dependency.sh
+++ b/happyhq/.dev/dependency.sh
@@ -78,24 +78,37 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1
 
+# Wrapper-controlled values exported to the agent prompt (replaces literal
+# values that previously drifted in agent traces — e.g. port 3000 vs 3456).
+SMOKE_PORT=3456
+export SMOKE_PORT
+
 # ── Worktree-aware base branch resolution ──
-# Loops run from the primary checkout (on `main`) or from a sibling worktree
-# (on `loop/deps`). Snap whichever branch we're on to origin/main so the agent
-# starts from a clean, up-to-date base. The prompts use $BASE_BRANCH instead
-# of literal `main` for checkout/return paths so they work in both locations.
-CURRENT_BRANCH=$(git branch --show-current)
-case "$CURRENT_BRANCH" in
-    main|loop/deps)
-        BASE_BRANCH="$CURRENT_BRANCH"
+# The expected branch is determined by the worktree path, not by whatever
+# branch happens to be checked out — that prevents the silent drift where
+# the deps worktree gets nudged onto `main` and the wrapper happily proceeds,
+# leaving the maintainer's primary checkout unable to switch back to main.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+case "$REPO_ROOT" in
+    */happyhq-deps)
+        BASE_BRANCH="loop/deps"
+        ;;
+    */happyhq)
+        BASE_BRANCH="main"
         ;;
     *)
-        echo -e "  ${RED}Error: dependency.sh must be run from 'main' (primary checkout) or 'loop/deps' (deps worktree). Currently on: $CURRENT_BRANCH${RESET}" >&2
+        echo -e "  ${RED}Error: dependency.sh must run from the primary checkout (.../happyhq) or the deps worktree (.../happyhq-deps). Current: ${REPO_ROOT}${RESET}" >&2
         exit 1
         ;;
 esac
 export BASE_BRANCH
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]; then
+    echo -e "  ${RED}Error: ${REPO_ROOT} should be on '${BASE_BRANCH}', not '${CURRENT_BRANCH}'.${RESET}" >&2
+    echo -e "  ${DIM}Fix: git -C ${REPO_ROOT} checkout ${BASE_BRANCH}${RESET}" >&2
+    exit 1
+fi
 
 # Guard against losing uncommitted work — the next step is `git reset --hard`.
 if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
## Summary

Two related fixes from the first full-loop run on the deps loop.

### 1. Worktree branch enforcement (the bigger one)

The previous wrapper accepted either branch — \`case CURRENT_BRANCH in main|loop/deps\` — and set \`BASE_BRANCH\` to whatever happened to be checked out. This let the deps worktree silently end up on \`main\` (probably from an earlier \`git -C\` reset or merge), and once there, every subsequent run perpetuated it. Net effect:

- The worktree-isolation design collapsed (deps worktree no longer on \`loop/deps\`)
- Maintainer's primary checkout couldn't switch back to \`main\` (only one worktree can hold a branch at a time)
- Agent sessions returned to \"main\" instead of \"loop/deps\"

**Fix:** make the rule path-determined, not state-determined.

- \`*/happyhq-deps\` → must be on \`loop/deps\`
- \`*/happyhq-bugs\` → must be on \`loop/bugs\`
- \`*/happyhq\` → must be on \`main\`
- Anything else → refuse to run

Wrong state errors out with a one-line fix command. Same logic applied to \`bugs.sh\`.

### 2. Wrapper-set \`SMOKE_PORT\`

The first session of the full-loop run picked port 3030 instead of the prompt's mandated 3456 — even with the \"MUST start on port 3456\" language we tightened in #165. Subsequent sessions complied, but first-session variance is exactly the kind of drift that a wrapper-set value eliminates.

**Fix:** export \`SMOKE_PORT=3456\` from the wrapper; substitute \`\${SMOKE_PORT}\` for the literal in the prompt's smoke recipe. The agent now reads the value from the environment, no chance to drift.

## Cleanup needed before next run

The deps worktree currently sits on \`main\` from earlier drift; after this lands the wrapper will refuse to run there. Move it back first:

\`\`\`
git -C /Users/philo/dev/happyhqdotcom/happyhq-deps checkout loop/deps
\`\`\`

Then the primary can return to \`main\` cleanly:
\`\`\`
git checkout main
\`\`\`

## Test plan
- [ ] Merge this PR
- [ ] Move deps worktree back to \`loop/deps\` per the cleanup steps above
- [ ] Run \`./dependency.sh --max-deps 3\` from the deps worktree
- [ ] Confirm: wrapper rejects if deps worktree is on \`main\`; agent sessions all use port 3456 (none drift to 3030 or 3000); sessions return to \`loop/deps\` (not \`main\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)