### PR TITLE
chore: collapse triage to Rule 1; Phase 2 does the rest

### DIFF
--- a/happyhq/.dev/PROMPT_dependency_triage.md
+++ b/happyhq/.dev/PROMPT_dependency_triage.md
@@ -3,23 +3,22 @@
 
 1. Get the queue: `gh pr list --author "app/dependabot" --state open --limit 100 --json number,title,headRefName,labels,createdAt --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)] | sort_by(.createdAt)'`. Empty → exit cleanly.
 
-2. For each PR in the queue (oldest first), in parallel where it makes sense (use Sonnet subagents for changelog reads / code searches), evaluate against rules 1–3 (the Phase 1 entries). For each PR:
-   - Read the PR body and labels: `gh pr view <#> --comments`.
-   - Read the diff to confirm protected-path checks: `gh pr diff <#>`.
-   - Check CI status: `gh pr checks <#>`.
-   - For runtime majors (rule 3), read the upstream changelog to confirm whether the bump fits the framework / security-sensitive / pre-1.0 → 1.0 categories.
+2. For each PR in the queue (oldest first), in parallel where it makes sense (use Sonnet subagents for diff reads), evaluate **only Rule 1** (the protected-paths check). Don't classify by major-version category, don't try to predict CI outcomes, don't read changelogs — Phase 2 does all of that. Triage's only job is to keep the loop out of files it shouldn't touch. For each PR:
+   - Read the diff: `gh pr diff <#>`.
+   - Confirm whether it touches `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files.
+   - Apply the GH-Actions exception: PRs from `dependabot/github_actions/*` with diffs limited to `uses:` line changes are eligible (mechanical version pins, not authored CI edits).
 
 3. For each PR, choose ONE outcome:
-   - **Skip** (matches a rule): apply the matching `ralphie:skip-*` label and post the rules-shape skip comment. Use `gh pr edit <#> --add-label "<label>"` and `gh pr comment <#> --body "..."`.
-   - **Eligible** (passes rules 1–3): leave the PR untouched. Unlabeled = queued for Phase 2.
+   - **Skip** (matches Rule 1): apply `ralphie:skip-out-of-scope` and post the rules-shape skip comment. Use `gh pr edit <#> --add-label "ralphie:skip-out-of-scope"` and `gh pr comment <#> --body "..."`.
+   - **Eligible** (passes Rule 1): leave the PR untouched. Unlabeled = queued for Phase 2.
 
 4. ${DRY_RUN_NOTE}
 
 5. When the queue is exhausted, print a one-line summary: `Triaged N PRs: X skipped, Y eligible.` Exit.
 
-**[1]** Apply rules in order — first match wins. Don't evaluate rule 3 if rule 1 already trips.
+**[1]** Triage's job is narrow: protected-paths gating only. Everything else — CI red, framework/security-sensitive/pre-1.0 majors, changelog flags — is Phase 2's responsibility. Don't try to short-circuit by skipping at triage based on metadata; that punts work to the human that the loop should do.
 **[2]** Never write code in this phase. Never branch, commit, push, merge, or open a PR. Triage is read-only on the repo and write-only on GitHub metadata (labels + comments).
 **[3]** A skip comment is for the human; the label is for the next Ralphie. Both are required for a skip.
-**[4]** If the rules are ambiguous about a PR, lean toward eligible — Phase 2 has its own gates (rules 4–5). False eligibility is cheaper than false skip.
-**[5]** Never apply two `ralphie:*` labels to the same PR. First match wins.
+**[4]** If Rule 1 is ambiguous, lean toward eligible — Phase 2 has its own gates and produces evidence-cited verdicts. False eligibility is cheaper than false skip.
+**[5]** Never apply two `ralphie:*` labels to the same PR. First match wins (in practice this means: if you apply skip-out-of-scope, you're done with that PR).
 **[6]** If `gh` returns an empty queue, exit 0 silently. No error, no comment.

--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -1,10 +1,21 @@
 0a. Read @dependency-rules.md — this is the spec. Apply it literally.
 0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rules.
-0c. The PR you are working: #${PR_NUMBER}. Read it: `gh pr view ${PR_NUMBER} --comments`. Phase 2 only processes Dependabot PRs that passed triage (no `ralphie:*` label).
+0c. The PR you are working: #${PR_NUMBER}. Read it: `gh pr view ${PR_NUMBER} --comments`. Phase 2 only processes Dependabot PRs that passed Rule 1 (no `ralphie:*` label).
+0d. **Classify upfront for elevated scrutiny.** Identify whether this PR is one of:
 
-1. **Checkout the PR branch.** The wrapper has already snapped `${BASE_BRANCH}` to latest `origin/main`. From `${BASE_BRANCH}`: `gh pr checkout ${PR_NUMBER}`. Capture the branch name (`git branch --show-current`) for later reference; you'll need it if you fall through to Path B.
+- **Framework major** — `next`, `react`, `react-dom`, or similar coordinate-the-stack packages
+- **Security-sensitive runtime major** — auth, crypto, billing primitives (e.g., `stripe`, `instantdb`, JWT/OIDC libs)
+- **Pre-1.0 → 1.0 jump on a runtime dep** (in `dependencies`, not `devDependencies`)
+- **Multi-major bump** — e.g., `stripe` v20 → v22, skipping v21
 
-2. **Install.** From the repo root: `pnpm install --frozen-lockfile`. If it fails because the lockfile drifted, run `pnpm install` (no frozen) and treat any unexpected lockfile diff beyond what Dependabot already wrote as a signal to investigate before continuing.
+If yes, this session uses **elevated scrutiny**: investigation needs to be thorough, the bar for "doesn't affect us" is higher, and skip outcomes (`skip-needs-review` or `skip-manual-upgrade`) are correct when investigation can't be exhaustive.
+
+1. **Checkout the PR branch.** The wrapper has already snapped `${BASE_BRANCH}` to latest `origin/main`. From `${BASE_BRANCH}`: `gh pr checkout ${PR_NUMBER}`. Capture the branch name (`git branch --show-current`) for later reference; you'll need it if you fall through to Path B. Capture the head SHA too for the replacement-PR description if needed.
+
+2. **Install.** From the repo root: `pnpm install --frozen-lockfile`.
+   - **If install succeeds:** continue to step 3.
+   - **If install fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` / `ERR_PNPM_OUTDATED_LOCKFILE` / similar tooling-state mismatch:** this is a known Dependabot/pnpm interaction quirk (e.g., Dependabot bumped a `pnpm.overrides` value in `package.json` but didn't re-resolve the lockfile's overrides snapshot). Run `pnpm install` (no frozen) to regenerate the lockfile. **Mark this session as `LOCKFILE_REGENERATED=true`** — you'll need the regenerated lockfile for the replacement PR in step 4 Path B. If no-frozen install also fails, that's a real install failure — apply `ralphie:skip-verification-failed` with the install output and exit.
+   - **If install succeeds but the lockfile diff is larger than what Dependabot's PR contained:** stop and investigate before continuing — there may be transitive resolution drift the agent should not paper over.
 
 3. **Verify.** From `happyhq/`:
    - `pnpm format`
@@ -19,52 +30,83 @@
 
 4. **Branch on the result:**
 
-   **Path A — clean (verification passed):**
+   **Path A — verification clean.** Three sub-cases depending on whether the lockfile was regenerated and whether the bump is in an elevated-scrutiny category.
+
+   First, do the changelog skim and investigation regardless of sub-case:
    - **Skim the upstream changelog / release notes** for the version delta. Note any of:
      - Ownership change (different maintainer or org publishing the release)
      - Secrets / auth / token handling refactor
      - Security advisory referenced in the release
      - Deprecation we might hit
      - Breaking API change that the test suite might not cover
-   - **If nothing in the skim raises a flag**, jump to "Post the comment" below.
-   - **If something is flagged, do NOT immediately skip — investigate the impact for our codebase before deciding.** This is the loop's job, not the human's. For each flag:
-     - Read the linked PR / issue / migration note for the specific change. Understand what concretely changed (file paths, behavior, defaults, env vars, etc.).
+   - **For elevated-scrutiny PRs (per step 0d), investigate proactively** even if no specific changelog item flagged. Read the migration guide thoroughly, grep the repo for all call-sites of the affected APIs, look for behavior tests (not just type tests), think about runtime semantics (RSC boundaries, hydration timing, server actions, etc. for framework majors).
+   - **For each flagged item or elevated-scrutiny concern, investigate the impact** for our codebase before deciding:
+     - Read the linked PR / issue / migration note. Understand what concretely changed.
      - Search the repo for any code, workflow, or config that depends on the affected behavior. Use grep, file reads, and Sonnet subagents in parallel for breadth.
      - Form a concrete impact verdict, with evidence:
-       - **"Doesn't affect our usage"** — cite the specific evidence (e.g., "grep finds no caller of `db.transact()` with a callback signature; the v6 API change to that signature can't bite us"). Proceed to ready-to-merge.
-       - **"Affects our usage and the change is benign / a clear improvement"** — cite the evidence and reason it's safe (e.g., "we use `actions/checkout` with default `persist-credentials: true`; the new `$RUNNER_TEMP` storage location is functionally equivalent and doesn't break any subsequent step in our workflows"). Proceed to ready-to-merge.
-       - **"Affects our usage and impact is unclear after investigation, OR the change introduces real risk we can't size from the available info"** — apply `ralphie:skip-needs-review` with a comment that includes (a) what the change is, (b) what you investigated, (c) what's still unclear and why a human needs to weigh in. Return to `${BASE_BRANCH}`, exit.
-   - **Post the comment** on the PR using the rules-shape `ready-to-merge` format. The comment MUST include an `### Investigation` section (use exactly that header, not "Changelog watch-list" or any other variant) with one line for **each** of the five audit items — ownership, auth/secrets, security advisory, deprecations, breaking API — even when the verdict is "none" or "no change". This is an audit trail for future readers; "didn't mention it" and "checked and found nothing" are not the same. For any item where the skim flagged something, add sub-bullets with depth (what was checked, what was found).
-   - **Apply the label**: `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"`.
-   - Return to base branch: `git checkout ${BASE_BRANCH}`.
-   - Exit. **Do not merge. The human reviews the comment and clicks merge.**
+       - **"Doesn't affect our usage"** — cite the specific evidence. Proceed to ready-to-merge.
+       - **"Affects our usage and the change is benign / a clear improvement"** — cite the evidence and reason it's safe. Proceed to ready-to-merge.
+       - **"Affects our usage; impact is unclear after investigation OR introduces real risk we can't size from the available info"** — apply `ralphie:skip-needs-review` with the rules-shape comment (what investigated, what's still unclear). Return to `${BASE_BRANCH}`, exit.
+       - **"Migration would clearly exceed the loop's size cap (multi-day refactor, multi-major stepping required, breaking API touches >10 call-sites)"** — apply `ralphie:skip-manual-upgrade` with cited reason. Return to `${BASE_BRANCH}`, exit.
 
-   **Path B — verification failed (breaking-change fixups):**
-   - **Plan from the changelog first.** Read the upstream release notes / migration guide for the version delta. Identify which breaking change(s) caused the failures. Quote the relevant entries in the work plan. If the failure mode isn't predicted by the changelog, **stop**: apply `ralphie:skip-verification-failed` to the original PR with the failure output included, return to `${BASE_BRANCH}`, exit.
-   - Return to base branch: `git checkout ${BASE_BRANCH}`. Note Dependabot's branch name from step 1 — you'll need to read files from it.
-   - Create a fresh branch: `git checkout -b chore/upgrade-<package>-v<major>` (use the package name and target major, e.g., `chore/upgrade-stripe-v22`).
-   - Apply the version bump from the Dependabot branch to your fresh branch:
+   Then the sub-case decides what to do with the verdict:
+
+   **Path A.1 — verification clean, install was clean (`LOCKFILE_REGENERATED=false`), investigation passed:**
+   - **Post the comment** on the PR using the rules-shape `ready-to-merge` format. The comment MUST include an `### Investigation` section (use exactly that header) with one line for **each** of the five audit items — ownership, auth/secrets, security advisory, deprecations, breaking API — even when the verdict is "none" or "no change". For elevated-scrutiny PRs, the Investigation section should also explicitly note "Elevated scrutiny applied: <category>" and quote the specific evidence cleared.
+   - **Apply the label**: `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"`.
+   - Return to `${BASE_BRANCH}`: `git checkout ${BASE_BRANCH}`.
+   - Exit. **Do not merge. The human reviews and clicks merge.**
+
+   **Path A.2 — verification clean, but lockfile was regenerated (`LOCKFILE_REGENERATED=true`):**
+   - The Dependabot PR's committed lockfile is broken; we cannot just label `ready-to-merge` because CI will keep failing on Dependabot's branch. We need to push the regenerated lockfile via a replacement PR.
+   - Skip ahead to **Path B.2 — lockfile-regeneration replacement** below.
+
+   **Path B — verification failed.** Three sub-cases:
+
+   **Path B.1 — unrelated CI / pre-existing main breakage.**
+   - If the failure reproduces locally on a fresh `${BASE_BRANCH}` checkout (i.e., the same test or lint failure exists on main itself, not introduced by the bump), this is unrelated CI. Apply `ralphie:skip-ci-red` with the failure output and a one-line "verified by re-running the failing check on `${BASE_BRANCH}` clean checkout". Return to `${BASE_BRANCH}`, exit.
+
+   **Path B.2 — lockfile-regeneration replacement (no behavioral change).**
+   - Triggered when `LOCKFILE_REGENERATED=true` from step 2 AND verification (step 3) passed locally. This means the fix is "use the regenerated lockfile" — no code changes needed.
+   - Return to `${BASE_BRANCH}`: `git checkout ${BASE_BRANCH}`.
+   - Create a fresh branch: `git checkout -b chore/upgrade-<package>-lockfile-regen` (or a similarly descriptive name based on the group/package being bumped).
+   - Apply both the version bump and the regenerated lockfile from the Dependabot branch's checkout:
+     ```
+     git checkout <dependabot-branch-name> -- happyhq/package.json package.json
+     pnpm install   # regenerates pnpm-lock.yaml fresh
+     ```
+   - Verify everything is consistent: `git status` should show `happyhq/package.json`, `package.json` (if root was touched), and `pnpm-lock.yaml` modified — nothing else.
+   - **Size gate** still applies: `git diff --stat origin/main...HEAD -- ':!happyhq/package.json' ':!package.json' ':!pnpm-lock.yaml' ':!*.md' ':!*.mdx'`. (Should be 0 changes — the regen path is supposed to be clean.) If somehow >10 files / >300 LoC, apply `ralphie:skip-too-big` with cited reason and exit.
+   - Commit: `git add -A && git commit -m "chore: regenerate lockfile for <package or group> bump"` with a body that quotes the original `pnpm install --frozen-lockfile` error output.
+   - Push: `git push -u origin chore/upgrade-<package>-lockfile-regen`.
+   - Open replacement PR: `gh pr create --base main --assignee @me --title "chore: regenerate lockfile for <package or group> bump" --body "..."`. PR body MUST include:
+     - `Replaces #${PR_NUMBER}`
+     - One-paragraph explanation: Dependabot's PR had a `pnpm install --frozen-lockfile` mismatch (quote the original error). The fix is the regenerated lockfile; there is no behavioral change beyond the version bump itself.
+     - Quote the original Dependabot PR's bumped versions for traceability.
+     - Verification summary (lint/types/test/smoke output, all green).
+     - AI-assistance disclosure per @CONTRIBUTING.md.
+   - Capture the new PR number. Create the dynamic label if needed: `gh label create "ralphie:replaced-by-#<new>" --color "5319E7" --description "Ralphie closed this in favor of replacement PR #<new>"` (ignore "already exists" errors).
+   - Close the original Dependabot PR: `gh pr edit ${PR_NUMBER} --add-label "ralphie:replaced-by-#<new>"`, `gh pr comment ${PR_NUMBER} --body "..."` (rules-shape replacement comment), `gh pr close ${PR_NUMBER}`.
+   - Return to `${BASE_BRANCH}`. Exit.
+
+   **Path B.3 — breaking-change fixups.**
+   - **Plan from the changelog first.** Read the upstream release notes / migration guide for the version delta. Identify which breaking change(s) caused the failures. Quote the relevant entries in the work plan. **If the failure mode isn't predicted by the changelog**, stop: apply `ralphie:skip-verification-failed` with the failure output included, return to `${BASE_BRANCH}`, exit.
+   - Return to `${BASE_BRANCH}`: `git checkout ${BASE_BRANCH}`. Note Dependabot's branch name from step 1.
+   - Create a fresh branch: `git checkout -b chore/upgrade-<package>-v<major>` (e.g., `chore/upgrade-stripe-v22`).
+   - Apply the version bump from the Dependabot branch:
      ```
      git checkout <dependabot-branch-name> -- happyhq/package.json pnpm-lock.yaml
      pnpm install
      ```
      (Adjust paths if the Dependabot PR also touched the root `package.json` or other workspace `package.json` files.)
    - Apply the smallest set of fixups required to pass verification. Cite the changelog item that justifies each fixup in commit messages — the diff and the changelog should map 1:1.
-   - Re-run verification (step 3). If it fails, fix and re-run. If it fails twice, apply `ralphie:skip-verification-failed` to the original PR with the failing output. Push nothing. Return to `${BASE_BRANCH}`. Exit.
-   - **Size gate.** `git diff --stat origin/main...HEAD -- ':!happyhq/package.json' ':!package.json' ':!pnpm-lock.yaml' ':!*.md' ':!*.mdx'`. (Use `origin/main`, not the local `main` ref — when running from a worktree the local `main` may be stale.) If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` to the original PR with a summary of what the fixup would have entailed. Leave the local branch in place (do not push). Return to `${BASE_BRANCH}`. Exit.
+   - Re-run verification (step 3). If it fails, fix and re-run. **If it fails twice**, apply `ralphie:skip-verification-failed` with the failing output. Push nothing. Return to `${BASE_BRANCH}`. Exit.
+   - **Size gate.** `git diff --stat origin/main...HEAD -- ':!happyhq/package.json' ':!package.json' ':!pnpm-lock.yaml' ':!*.md' ':!*.mdx'`. (Use `origin/main`, not the local `main` ref — when running from a worktree the local `main` may be stale.) If >10 files changed or >300 lines net added, apply `ralphie:skip-too-big` with a summary of what the fixup would have entailed. Leave the local branch in place (do not push). Return to `${BASE_BRANCH}`. Exit.
    - Commit: `git add -A && git commit -m "chore: upgrade <package> to v<major>"` (one commit per discrete fixup is also fine; cite the changelog item in each commit body).
    - Push: `git push -u origin chore/upgrade-<package>-v<major>`.
-   - Open replacement PR: `gh pr create --base main --assignee @me --title "chore: upgrade <package> to v<major>" --body "..."`. PR body MUST include:
-     - `Replaces #${PR_NUMBER}`
-     - One paragraph identifying the breaking changes that required fixups
-     - Quoted excerpts from the upstream changelog with links
-     - One bullet per fixup, mapping diff to changelog item (e.g., `- lib/billing.ts:42 — renamed stripe.charges.create → stripe.payments.create per migration guide`)
-     - Verification summary (lint/types/test/smoke output, all green)
-     - AI-assistance disclosure per @CONTRIBUTING.md (e.g., "Authored by Ralphie, the autonomous dependency-upgrade loop. Reviewed by maintainer before merge.")
-   - Capture the new PR number from the create output. Create the dynamic label if it doesn't exist: `gh label create "ralphie:replaced-by-#<new>" --color "5319E7" --description "Ralphie closed this in favor of replacement PR #<new>"` (ignore "already exists" errors).
-   - Close the original Dependabot PR with the rules-shape replacement comment, label it `ralphie:replaced-by-#<new>`, then close: `gh pr edit ${PR_NUMBER} --add-label "ralphie:replaced-by-#<new>"`, `gh pr comment ${PR_NUMBER} --body "..."`, `gh pr close ${PR_NUMBER}` (label + comment go on first; closing is the last write).
-   - Return to base branch: `git checkout ${BASE_BRANCH}`.
-   - Exit.
+   - Open replacement PR per the standard shape (see Path B.2 for label creation; PR body MUST include `Replaces #${PR_NUMBER}`, a paragraph identifying the breaking changes, quoted changelog excerpts with links, one bullet per fixup mapping diff to changelog item, verification summary, AI disclosure).
+   - Close the original Dependabot PR with the rules-shape replacement comment and label.
+   - Return to `${BASE_BRANCH}`. Exit.
 
 5. ${DRY_RUN_NOTE}
 
@@ -74,9 +116,10 @@
 
 **[1]** ONE PR per session. Do not pick up other PRs, do not chain. The orchestrator handles the next one.
 **[2]** Hard constraints from @dependency-rules.md are non-negotiable: never push to `main`, never push to a Dependabot branch, never merge a Dependabot PR (the human is the gate, always), never modify `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files. If the fixup would require any of these, apply `ralphie:skip-out-of-scope` and exit.
-**[3]** Cite the changelog. Every fixup commit message and the replacement PR body must reference the upstream changelog / migration guide entry that justifies the change. If you can't find a changelog entry for what you're fixing, you've drifted off the rails — stop and skip with `ralphie:skip-verification-failed`.
+**[3]** Cite the changelog for breaking-change fixups (Path B.3). Lockfile-regeneration replacements (Path B.2) don't need changelog citation — they document the pnpm error output and the version bumps inherited from Dependabot.
 **[4]** Smallest fixup. Don't refactor adjacent code. Don't update unrelated callers. Surface drift via PR-body comments, not by widening the diff.
-**[5]** Stop when surprised. If a test failure isn't predicted by the changelog, or you can't trace a diff line to a documented change, apply `ralphie:skip-verification-failed` and let the human take it.
+**[5]** Stop when surprised. If a Path B.3 test failure isn't predicted by the changelog, or you can't trace a diff line to a documented change, apply `ralphie:skip-verification-failed` and let the human take it.
 **[6]** AI disclosure in the replacement PR body is required by @CONTRIBUTING.md.
 **[7]** Always end on `${BASE_BRANCH}` with a clean working tree, even on skip paths.
-**[8]** Nothing the loop touches gets auto-merged. Path A ends at `ralphie:ready-to-merge` (label + summary comment); Path B ends at "replacement PR open." In both cases the merge button is the maintainer's.
+**[8]** Nothing the loop touches gets auto-merged. Path A ends at `ralphie:ready-to-merge` (label + summary comment); Paths B.2 and B.3 end at "replacement PR open." In all cases the merge button is the maintainer's.
+**[9]** For elevated-scrutiny categories (framework majors, security-sensitive, pre-1.0 → 1.0, multi-major), the burden of proof for `ready-to-merge` is higher. When in doubt between `ready-to-merge` and a skip, choose the skip — but the skip comment must surface what was already investigated, not just say "your turn."

--- a/happyhq/.dev/dependency-rules.md
+++ b/happyhq/.dev/dependency-rules.md
@@ -10,29 +10,42 @@ Source of truth for how the deps loop processes open Dependabot PRs. Both `PROMP
 
 ## Rules
 
-Apply in order — bail at the earliest stop. The first three are evaluable from the PR text alone (Phase 1 — triage). The last five only show up after attempting an upgrade (Phase 2).
+Apply in order — bail at the earliest stop. Phase 1 (triage) decides only one thing: would the loop touch protected paths? Everything else flows to Phase 2, which does the substantive work — verify, investigate, then decide.
 
-| #   | Condition                                                                                                                                                                                                                                                                                                                            | Label applied                      | What unblocks it                                                                      |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------- |
-| 1   | PR diff would touch `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files — **except** PRs from the `dependabot/github_actions/*` branch family where the diff is limited to `uses:` line changes in workflow files (those are mechanical version pins, not authored CI edits, and are eligible for Phase 2) | `ralphie:skip-out-of-scope`        | Maintainer scopes the change; remove label                                            |
-| 2   | CI on the PR is red and the failure is unrelated to the version bump (infra flake, lint config drift, network timeout, etc.)                                                                                                                                                                                                         | `ralphie:skip-ci-red`              | Investigate the CI failure; remove label                                              |
-| 3   | Update is one of: framework major (`next`, `react`, `react-dom`); security-sensitive runtime major (auth, crypto, billing — e.g., `stripe` ≥2 majors at once, `instantdb`, JWT/OIDC libs); pre-1.0 → 1.0 jump on a runtime dep                                                                                                       | `ralphie:skip-manual-upgrade`      | Maintainer upgrades and reviews; remove label                                         |
-| 4   | (Phase 2) Verification clean (lint/types/test/smoke) **and** changelog skim reveals nothing concerning                                                                                                                                                                                                                               | `ralphie:ready-to-merge`           | Maintainer reads Ralphie's summary comment, clicks merge                              |
-| 5   | (Phase 2) Changelog skim flags an item AND impact investigation reveals genuine concern for our codebase (or impact is unclear after investigation)                                                                                                                                                                                  | `ralphie:skip-needs-review`        | Maintainer reads Ralphie's investigation summary; decides to merge, replace, or close |
-| 6   | (Phase 2) `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` / `npx tsx scripts/smoke-test.ts` failed twice                                                                                                                                                                                             | `ralphie:skip-verification-failed` | Read Ralphie's comment; fix locally                                                   |
-| 7   | (Phase 2) Fixups would exceed 10 files or 300 lines net added (`*.md`/`*.mdx` and lockfile/package.json excluded from the count)                                                                                                                                                                                                     | `ralphie:skip-too-big`             | Scope it down or do it manually                                                       |
-| 8   | (Phase 2) Replacement PR shipped (breaking-change fixups path)                                                                                                                                                                                                                                                                       | `ralphie:replaced-by-#<new>`       | Terminal — the linked replacement PR closes the loop                                  |
+The loop's value is the verification + investigation work. We don't punt PRs to the human based on metadata-only categorizations (e.g., "this is a major bump, your turn"). We attempt them and produce evidence-cited verdicts. Skips at Phase 2 are reserved for cases where investigation reveals genuine concern or the work exceeds the loop's scope.
 
-A PR that passes rules 1–3 is **eligible** — it stays unlabeled and Phase 2 picks it up. Phase 2 takes one of two paths:
+| #   | Phase   | Condition                                                                                                                                                                                                                                                                                                                            | Label applied                      | What unblocks it                                                                      |
+| --- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | Triage  | PR diff would touch `happyhq/ee/`, `.github/`, CI workflows, `dependabot.yml`, or licensing files — **except** PRs from the `dependabot/github_actions/*` branch family where the diff is limited to `uses:` line changes in workflow files (those are mechanical version pins, not authored CI edits, and are eligible for Phase 2) | `ralphie:skip-out-of-scope`        | Maintainer scopes the change; remove label                                            |
+| 2   | Phase 2 | Verification clean (lint/types/test/smoke) **and** changelog investigation finds no genuine concern                                                                                                                                                                                                                                  | `ralphie:ready-to-merge`           | Maintainer reads Ralphie's summary comment, clicks merge                              |
+| 3   | Phase 2 | Investigation reveals genuine concern, or impact is unclear after a real attempt (changelog flag, ownership change, ambiguous deprecation, etc.)                                                                                                                                                                                     | `ralphie:skip-needs-review`        | Maintainer reads Ralphie's investigation summary; decides to merge, replace, or close |
+| 4   | Phase 2 | Upgrade requires multi-step migration that exceeds the loop's scope (framework majors with multi-major stepping, e.g., `stripe` v20 → v22; pre-1.0 → 1.0 jumps that touch a large surface)                                                                                                                                           | `ralphie:skip-manual-upgrade`      | Maintainer steps the upgrade manually; remove label                                   |
+| 5   | Phase 2 | `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` / `npx tsx scripts/smoke-test.ts` failed twice on causes the agent can't trace                                                                                                                                                                       | `ralphie:skip-verification-failed` | Read Ralphie's comment with cited failure output; fix locally                         |
+| 6   | Phase 2 | CI on the PR is red because of issues unrelated to the version bump (infra flake, lint config drift on main, pre-existing test failure that local verification reproduces)                                                                                                                                                           | `ralphie:skip-ci-red`              | Investigate the CI failure; remove label                                              |
+| 7   | Phase 2 | Fixups would exceed 10 files or 300 lines net added (`*.md`/`*.mdx` and lockfile/package.json excluded from the count)                                                                                                                                                                                                               | `ralphie:skip-too-big`             | Scope it down or do it manually                                                       |
+| 8   | Phase 2 | Replacement PR shipped (breaking-change fixups path, OR lockfile-regeneration path)                                                                                                                                                                                                                                                  | `ralphie:replaced-by-#<new>`       | Terminal — the linked replacement PR closes the loop                                  |
 
-- **Path A — verify and signal.** Install + run lint/types/test/smoke. If clean, skim the upstream changelog. If the changelog is also clean, post a verification + changelog summary comment and apply `ralphie:ready-to-merge`. The human reads the comment and decides whether to click merge.
-- **Path B — fixups.** When verification fails because of a breaking change, generate the smallest changelog-cited fixups on a fresh `chore/upgrade-<pkg>-vN` branch off `main` and open a replacement PR for human review.
+A PR that passes Rule 1 is **eligible** — it stays unlabeled and Phase 2 picks it up. Phase 2 takes one of two paths:
+
+- **Path A — verify and signal.** Install + run lint/types/test/smoke. Skim the upstream changelog. Investigate flagged items by reading linked PRs/notes and grepping the repo for affected behavior. Form an evidence-cited verdict. If clean, post the summary comment and apply `ralphie:ready-to-merge`. If concerning, apply `ralphie:skip-needs-review` with what was investigated and what's still unclear. The human reads and decides.
+- **Path B — fixups.** When verification fails, generate the smallest changelog-cited fixups (or, for `pnpm install`-time errors like `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, regenerate the lockfile via no-frozen install) on a fresh `chore/upgrade-<pkg>-vN` branch off `main` and open a replacement PR for human review.
 
 Ralphie never merges. The merge button is the maintainer's. Always.
 
+## Elevated scrutiny in Phase 2
+
+Some bumps are inherently more delicate. The agent's investigation needs a **higher bar** before reaching `ready-to-merge` for any of these categories:
+
+- **Framework majors** — `next`, `react`, `react-dom`. Coordinate-the-whole-stack changes; even when tests pass, the migration may have user-visible behavior shifts (RSC semantics, hydration timing, server actions).
+- **Security-sensitive runtime majors** — auth, crypto, billing primitives. `stripe`, `instantdb`, JWT/OIDC libs, anything in the request-auth or payment path. Same package can have malicious-by-mistake API removals.
+- **Pre-1.0 → 1.0 jumps on runtime deps** — by definition the upstream is signaling "this is the stable shape." Even when v1.0 is API-compatible, bundle structure / ESM / module-resolution changes can affect downstream tooling.
+- **Multi-major bumps** — e.g., `stripe v20 → v22` skips v21. Each major may have its own breaking changes; assess both.
+
+For these categories, "doesn't affect us" requires more evidence than a quick grep. Read migration guides thoroughly, check all call-sites, look for behavior tests (not just type tests). Defaulting toward `skip-needs-review` (or `skip-manual-upgrade` when the migration would clearly exceed the loop's size cap) is correct here when the investigation is anything less than thorough.
+
 ## Comment shape (skips)
 
-Every skip writes one comment, in this shape:
+Most skips use this shape:
 
 ```
 Ralphie skipped this for: <rule name>
@@ -72,18 +85,18 @@ Ralphie verified this — ready to merge.
 <one or two sentences — why this looks safe to merge for our usage>
 ```
 
-## Comment shape (Path A skip — `skip-needs-review`)
+## Comment shape (Path A skip — `skip-needs-review`, `skip-manual-upgrade`, `skip-ci-red`)
 
-Used when investigation reveals genuine concern or unclear impact. Goes beyond the generic skip shape to surface the work already done.
+Used when investigation reveals genuine concern, the migration exceeds loop scope, or CI is red for reasons unrelated to the bump. Surfaces the work already done.
 
 ```
-Ralphie skipped this for: needs-review
+Ralphie skipped this for: <rule name>
 
-What I saw: <1–2 sentences — the changelog item that triggered investigation, with link>
+What I saw: <1–2 sentences — the changelog item, scope assessment, or CI failure that triggered the skip, with link/output>
 
-What I investigated: <2–4 bullets — the specific code/workflows/configs you checked, and what you found>
+What I investigated: <2–4 bullets — the specific code/workflows/configs/logs you checked, and what you found>
 
-What's still unclear: <1–2 sentences — why the human needs to weigh in: ambiguous impact, ownership change risk, deprecation timeline, etc.>
+What's still unclear: <1–2 sentences — why the human needs to weigh in: ambiguous impact, multi-major step required, pre-existing main breakage, etc.>
 
 What would unblock it: <1 sentence — concrete action for the maintainer>
 ```
@@ -93,9 +106,9 @@ What would unblock it: <1 sentence — concrete action for the maintainer>
 ```
 Ralphie replaced this with #<new>.
 
-Why: <one sentence — what breaking change(s) the bump required fixups for>
+Why: <one sentence — what breaking change(s) or lockfile issue the bump required fixups for>
 
-Changelog: <link>
+Changelog: <link, when applicable>
 
 Replacement: <link to new PR>
 ```
@@ -113,7 +126,7 @@ Replacement: <link to new PR>
 
 These are guidance, not gates. The rules above are pass/fail; these tune _how_ allowed work gets done.
 
-**Cite the changelog.** Every replacement PR description must link to the upstream release notes / migration guide and quote the relevant breaking-change item(s). The reviewer should be able to trace each diff line back to a documented change. If the changelog doesn't mention something the fixup is reacting to, that's a signal to stop and skip with `ralphie:skip-verification-failed`.
+**Cite the changelog.** Every replacement PR description must link to the upstream release notes / migration guide and quote the relevant breaking-change item(s) — except for lockfile-regeneration replacements, which document the pnpm error output and the no-frozen-install diff instead. For breaking-change fixups, the reviewer should be able to trace each diff line back to a documented change. If the changelog doesn't mention something the fixup is reacting to, that's a signal to stop and skip with `ralphie:skip-verification-failed`.
 
 **Smallest fixup that compiles + passes tests + smoke-tests clean.** Don't refactor adjacent code. Don't take on tech-debt cleanup. Don't update unrelated callers. Surface drift via comments in the PR body, not by widening the diff.
 
@@ -121,13 +134,13 @@ These are guidance, not gates. The rules above are pass/fail; these tune _how_ a
 
 **Look around.** Before writing a fixup, search for prior usage of the changed APIs across the repo. Most "we keep fixing this" pain comes from rederiving in isolation when a reference exists.
 
-**The human is the gate, always.** Ralphie never merges — not Dependabot's PRs, not replacement PRs. Path A's job is "verify, summarize, label `ready-to-merge`." Path B's job is "open a replacement PR with the breaking-change fixups documented." In both cases the merge button is the maintainer's. The loop's value is the verification work and the documentation, not the merge click.
+**The human is the gate, always.** Ralphie never merges — not Dependabot's PRs, not replacement PRs. Path A's job is "verify, summarize, label `ready-to-merge`." Path B's job is "open a replacement PR with the breaking-change fixups (or regenerated lockfile) documented." In both cases the merge button is the maintainer's. The loop's value is the verification work and the documentation, not the merge click.
 
 **Skim the changelog even when verification is clean, then investigate before deciding.** Green CI doesn't catch supply-chain risk (maintainer compromise, ownership change, hostile release). It doesn't catch behavior changes that won't bite until production load. A 60-second changelog skim catches a lot of that at near-zero cost.
 
-**But the skim is a trigger to investigate, not a trigger to bail.** When the skim flags something — ownership change, secrets/auth handling refactor, security advisory, deprecation, breaking API change — read the linked PR/migration note, search the repo for usage of the affected behavior, and form a concrete impact verdict. The loop's value is the work; punting every flagged change to the human just shifts the same investigation onto them. Skip with `ralphie:skip-needs-review` only when the investigation reveals genuine concern or the impact is unclear after a real attempt — not as a default response to flagged keywords.
+**The skim is a trigger to investigate, not a trigger to bail.** When the skim flags something — ownership change, secrets/auth handling refactor, security advisory, deprecation, breaking API change — read the linked PR/migration note, search the repo for usage of the affected behavior, and form a concrete impact verdict. The loop's value is the work; punting every flagged change to the human just shifts the same investigation onto them. Skip with `ralphie:skip-needs-review` only when the investigation reveals genuine concern or the impact is unclear after a real attempt — not as a default response to flagged keywords.
 
-Concrete shape: changelog mentions a credential-storage refactor → grep workflows for steps that depend on credential storage location → if no consumer, comment the impact assessment and recommend merge; if there's a consumer and the change is benign, same; if there's a consumer and the impact is ambiguous, skip with the specific concern.
+**Lockfile-time errors are regenerable, not failures.** When `pnpm install --frozen-lockfile` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, `ERR_PNPM_OUTDATED_LOCKFILE`, or similar tooling-state mismatches, that's a deterministic re-resolution — not a behavioral change. Run `pnpm install` (no frozen) to regenerate the lockfile, then proceed to verification. If verification with the regenerated lockfile is clean, the agent's "fixup" for Path B is the regenerated lockfile itself; no changelog citation is required because there's no behavioral delta to cite. Open a replacement PR with the regenerated lockfile and a comment quoting the original pnpm error.
 
 ## Tuning signal
 


### PR DESCRIPTION
## Summary

Two structural changes from observed loop drift on PRs #155 (npm-minor-patch group with \`pnpm.overrides\` lockfile mismatch) and #158 (lucide-react pre-1.0→1.0 auto-skip).

### 1. Triage collapses to Rule 1

The previous Rules 2 (CI red unrelated to bump) and 3 (framework / security-sensitive / pre-1.0→1.0 categories) were category-based auto-skips. They punted real work to the human based on metadata alone — same investigation that the human now has to do, just shifted.

This PR drops Rules 2 and 3 from triage. Triage's job is now narrow: **only check protected paths.** Everything that passes Rule 1 flows to Phase 2, which runs the full verification + investigation and produces evidence-cited verdicts.

### 2. Phase 2 absorbs the cases that previously skipped at triage

- **Path A (verify + investigate)** can now land on \`ready-to-merge\`, \`skip-needs-review\`, or \`skip-manual-upgrade\`. The skip outcomes carry investigation evidence — what was checked, what was found, what's still unclear. No more \"go read the release notes\" skips.
- **Path B.1 — \`skip-ci-red\`** when verification fails locally because of a pre-existing main breakage (lint config drift, flaky test, etc.) that reproduces on a clean \`\${BASE_BRANCH}\` checkout.
- **Path B.2 — lockfile-regeneration replacement** for \`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH\` and similar pnpm tooling-state errors. This handles the Dependabot+pnpm-overrides blind spot that broke #155: bump goes through, regenerate the lockfile via no-frozen install, open a replacement PR with the regenerated lockfile. No changelog citation required (no behavioral change). We use a replacement PR rather than pushing to Dependabot's branch because Dependabot force-pushes during rebase — any commit we'd push could be nuked.
- **Path B.3 — breaking-change fixups** unchanged from before (\`chore/upgrade-<pkg>-vN\` branch, changelog-cited fixups, replacement PR).

### 3. Elevated scrutiny for delicate categories

Step 0d adds an upfront classification: framework majors / security-sensitive / pre-1.0→1.0 / multi-major bumps trigger \"elevated scrutiny\" in Phase 2's investigation. Higher bar for \"doesn't affect us,\" defaults toward skip-needs-review or skip-manual-upgrade when investigation can't be exhaustive. The agent investigates the same way as before — just with a higher threshold for the affirmative verdict.

## Net effect

- Every Dependabot PR that doesn't touch protected paths gets real verification and a real comment.
- The pnpm-overrides class of failure (currently stuck on #155 with no recovery path) becomes a loop-handled outcome.
- Pre-1.0→1.0 jumps and other elevated-scrutiny categories get investigated rather than auto-skipped.
- Phase 2 sessions cost ~5–10 min each — accepted tradeoff because the alternative is the human doing the same investigation.

## Cleanup needed after this lands
- \`gh pr edit 158 --remove-label \"ralphie:skip-manual-upgrade\"\` — re-queue lucide-react under the new rules.
- #155 is already eligible (no ralphie:* label); next loop run will pick it up under Path B.2.

## Test plan
- [ ] Merge this PR
- [ ] Re-label #158 per cleanup
- [ ] Run \`./dependency.sh --max-deps 3\` from the deps worktree
- [ ] Confirm: triage labels nothing for #155 or #158 (just protected-path check). Phase 2 picks up #155, hits the lockfile mismatch, falls back to no-frozen install, opens a Path B.2 replacement PR. Phase 2 picks up #158, runs full investigation against lucide-react v1, lands on a real verdict (ready-to-merge or skip-needs-review with cited reasoning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)