### PR TITLE
chore: raise Dependabot PR cap to 15 + group @instantdb/* packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,29 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    # Limit raised from 5: the deps loop processes each PR autonomously,
+    # so the traditional "don't overwhelm the maintainer" cap matters less.
+    # The constraint now is loop session cost + queue management.
+    open-pull-requests-limit: 15
     groups:
+      # Two principles for grouping:
+      # - Packages that release together get a group (one PR keeps versions
+      #   in lockstep). Add new SDK families here as we encounter them.
+      # - Packages whose behavior tests can't catch get their own PR
+      #   (excluded from groups; LLM clients are the canonical case).
       npm-minor-patch:
         update-types:
           - minor
           - patch
-        # Agent / AI SDKs are excluded from the group so they get their own
-        # PRs. Even patch bumps can shift LLM behavior (tool schemas, default
-        # params, retry semantics, prompt caching) in ways the test suite
-        # can't observe — they need individual review.
         exclude-patterns:
           - '@anthropic-ai/claude-agent-sdk'
           - '@anthropic-ai/sdk'
+      instantdb:
+        # @instantdb/core, @instantdb/react, @instantdb/admin release in
+        # lockstep; bumping one without the others causes type-inference
+        # mismatches and runtime drift across auth/sync/realtime.
+        patterns:
+          - '@instantdb/*'
     ignore:
       - dependency-name: next
         update-types:
@@ -41,7 +51,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 15
     groups:
       actions-minor-patch:
         update-types:


### PR DESCRIPTION
## Summary

Two changes from observed loop behavior on #131 and #156.

### 1. Cap raise: 5 → 15 (both ecosystems)

Original 5 was carried over from defaults — premised on \"don't overwhelm the maintainer.\" With the deps loop processing each PR autonomously and producing evidence-cited verdicts, that constraint matters less. The new constraint is loop session cost + queue management, both of which 15 handles fine.

If a weekly tick produces 15 PRs:
- Loop runs \`./dependency.sh --max-deps 15\` once
- Each session ~5–10 min, ~$5–7
- Total: ~2 hours wallclock, ~$80–100
- Maintainer reviews 15 comment summaries and clicks merge / removes label as appropriate

We can revisit if it gets tight.

### 2. Group \`@instantdb/*\` packages

PR #156's elevated-scrutiny session diagnosed exactly the coordination concern that comes from bumping one InstantDB package without the others — type inference regresses to \`unknown\`/\`{}\` because peer-related packages end up at mismatched versions. The agent caught this organically (without needing explicit \"check paired packages\" rules in the prompt).

The fix is preventive: bundle \`@instantdb/core\`, \`@instantdb/react\`, \`@instantdb/admin\` into a single Dependabot group so they always arrive coordinated.

### The generalized principle (worth naming)

Two complementary rules for grouping in \`dependabot.yml\`:

- **Packages that release together get a group.** One PR keeps versions in lockstep.
- **Packages whose behavior tests can't catch get their own PR.** Excluded from groups; LLM clients are the canonical case.

The agent SDK exclusion (#169) encodes the second principle. The InstantDB grouping in this PR encodes the first. Future SDK families that should follow the InstantDB pattern as we encounter them: \`@trpc/*\`, \`@radix-ui/*\`, \`@aws-sdk/*\`, etc.

## Cleanup after merge

#156 and #157 are still open with their respective skip labels. Consider closing them and triggering Dependabot to refresh — the new \`instantdb\` group will produce a single PR bumping all three packages together.

## Test plan
- [ ] Merge this PR
- [ ] Close #156 and #157 (and possibly the missing \`@instantdb/admin\` PR if it's been recreated)
- [ ] Trigger Dependabot refresh from the network/updates page
- [ ] Confirm: a single grouped \`@instantdb/*\` PR appears with all three packages bumped together
- [ ] Confirm: cap of 15 doesn't truncate the queue under typical weekly load

🤖 Generated with [Claude Code](https://claude.com/claude-code)