### PR TITLE
chore: regenerate lockfile for npm-minor-patch group bump

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,7 +285,7 @@ importers:
         version: 26.1.0
       postcss:
         specifier: ^8.5.10
-        version: 8.5.10
+        version: 8.5.13
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -3658,8 +3658,8 @@ packages:
     resolution: {integrity: sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ==}
     engines: {node: '>=14.0'}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3845,8 +3845,8 @@ packages:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -6152,7 +6152,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
-      postcss: 8.5.10
+      postcss: 8.5.13
       tailwindcss: 4.2.4
 
   '@tailwindcss/typography@0.5.19(tailwindcss@4.2.4)':
@@ -8464,7 +8464,7 @@ snapshots:
 
   mutative@1.3.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   nanoid@5.1.11: {}
 
@@ -8479,7 +8479,7 @@ snapshots:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001788
-      postcss: 8.5.10
+      postcss: 8.5.13
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(react@19.2.5)
@@ -8646,9 +8646,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.10:
+  postcss@8.5.13:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9544,7 +9544,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.13
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
Replaces #175.

## Why

Dependabot's #175 bumped the `overrides` snapshot for `postcss` to `^8.5.13` inside `pnpm-lock.yaml` without updating the matching `pnpm.overrides` entry in the root `package.json` (which is still `^8.5.10`). `pnpm install --frozen-lockfile` therefore fails with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "overrides" configuration doesn't match the value found in the lockfile
```

Regenerated the lockfile from `main` (overrides snapshot now matches the unchanged package.json), then pulled forward `postcss` + `nanoid` via the Dependabot branch's `pnpm-lock.yaml`. No code or package.json changes — the diff is `pnpm-lock.yaml` only.

## What actually bumped

- `postcss` 8.5.10 → 8.5.13 (resolved version; satisfies existing `^8.5.10` override floor)
- `nanoid` 3.3.11 → 3.3.12 (transitive via postcss)

`@types/react` (19.2.2 → 19.2.14) and `@types/react-dom` (19.2.2 → 19.2.3) listed in #175's title are pinned to `19.2.2` by the root `pnpm.overrides`, so the lockfile resolution for them is unchanged. The override is the floor; the workspace `package.json` specifiers were already at `^19.2.14` / `^19.2.3` before this PR.

## postcss 8.5.10 → 8.5.13 changelog

- 8.5.13: Fixed `postcss-scss` commend regression
- 8.5.12: **Fixed reading any file via user-generated CSS** (path-traversal hardening on source maps); added `opts.unsafeMap`
- 8.5.11: Fixed nested brackets parsing performance

The 8.5.12 fix doesn't affect us — postcss is invoked at build time via `@tailwindcss/postcss` (`happyhq/postcss.config.mjs`) on our own CSS, never on user-provided input.

## Verification (local, with regenerated lockfile)

- `pnpm install --frozen-lockfile`: ✓
- `pnpm lint`: ✓
- `pnpm check-types`: ✓
- `pnpm --filter=happyhq test`: ✓ (1477 tests)
- `npx tsx scripts/smoke-test.ts` (PORT=3456): ✓

## AI assistance

Regenerated and prepared by Ralphie (Claude Opus 4.7) under the deps loop. The diff is mechanical (lockfile only); a maintainer should still verify the regeneration against #175's intent before merging.