### PR TITLE
chore(deps): bump stripe from 20.4.1 to 22.1.0

### DIFF
--- a/happyhq/package.json
+++ b/happyhq/package.json
@@ -71,7 +71,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",
     "sonner": "^2.0.7",
-    "stripe": "^20.4.1",
+    "stripe": "^22.1.0",
     "swr": "^2.4.0",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,8 +220,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       stripe:
-        specifier: ^20.4.1
-        version: 20.4.1(@types/node@25.6.0)
+        specifier: ^22.1.0
+        version: 22.1.0(@types/node@25.6.0)
       swr:
         specifier: ^2.4.0
         version: 2.4.1(react@19.2.5)
@@ -4314,11 +4314,11 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  stripe@20.4.1:
-    resolution: {integrity: sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==}
-    engines: {node: '>=16'}
+  stripe@22.1.0:
+    resolution: {integrity: sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=16'
+      '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -9225,7 +9225,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stripe@20.4.1(@types/node@25.6.0):
+  stripe@22.1.0(@types/node@25.6.0):
     optionalDependencies:
       '@types/node': 25.6.0
 


### PR DESCRIPTION
Replaces #131.

Why: Dependabot's PR was a v20 → v22 multi-major bump, which the deps loop correctly punted as `ralphie:skip-manual-upgrade` per the rule in `happyhq/.dev/dependency-rules.md`. This is the manual upgrade — done in coordination with the matching bump in the sibling `billing` repo (the webhook handler imports the same SDK and must move in lockstep so `Stripe.*` types stay aligned across the producer/consumer boundary).

## Surface review

- **v21 → Decimal field type change** (`format: decimal` fields move from `string` to `Stripe.Decimal`). Not exercised here — `ee/lib/billing/stripe.server.ts` reads no decimal fields. The producer-side calls are `customers.create` and `subscriptions.update({ cancel_at_period_end: true })`.
- **v22** → `types/` directory removal, `Stripe.StripeContext` rename, `Stripe.errors.StripeError` type shape change, callbacks removed from service methods, `host` per-request removed, `RequestOptions` ordering enforced, string API key arg removed, factory-function removal, CommonJS export shape change, `StripeResource` internals removed. Repo grep found zero references to any of these (we use `new Stripe(secretKey)` with the ESM default import).

## Stripe Dashboard

No dashboard changes required. Webhook endpoint API version is pinned independently of the SDK version — wire format is unchanged.

## Verification

- `pnpm check-types` ✓
- `pnpm lint` ✓
- `pnpm --filter=happyhq test` ✓ (1477 tests)
- `npx tsx scripts/smoke-test.ts` ✓ (no run-time errors)

## Coordination

Paired with `happyhqdotcom/billing#1` (matching v20 → v22 bump in the webhook handler).

🤖 Assisted by Claude (Opus 4.7).