### PR TITLE
chore: Path B.2 detects override-floor bumps and lockfile-only PRs

### DIFF
--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -69,16 +69,47 @@ If yes, this session uses **elevated scrutiny**: investigation needs to be thoro
 
    **Path B.2 — lockfile-regeneration replacement (no behavioral change).**
    - Triggered when `LOCKFILE_REGENERATED=true` from step 2 AND verification (step 3) passed locally. This means the fix is "use the regenerated lockfile" — no code changes needed.
-   - Return to `${BASE_BRANCH}`: `git checkout ${BASE_BRANCH}`.
-   - Create a fresh branch: `git checkout -b chore/upgrade-<package>-lockfile-regen` (or a similarly descriptive name based on the group/package being bumped).
-   - Apply both the version bump and the regenerated lockfile from the Dependabot branch's checkout:
+   - **Before regenerating, inspect Dependabot's diff to detect the case shape:**
+
      ```
-     git checkout <dependabot-branch-name> -- happyhq/package.json package.json
-     pnpm install   # regenerates pnpm-lock.yaml fresh
+     git diff origin/main...<dependabot-branch> --name-only
+     git diff origin/main...<dependabot-branch> -- pnpm-lock.yaml | grep -E '^[+-] {2}[a-zA-Z@/-]+: \^?[0-9]' | head -20
      ```
-   - Verify everything is consistent: `git status` should show `happyhq/package.json`, `package.json` (if root was touched), and `pnpm-lock.yaml` modified — nothing else.
+
+     Three sub-shapes determine how to construct the replacement branch:
+
+     **B.2.a — package.json + lockfile bumps (the typical case):**
+     - Recipe: take both files from Dependabot's branch and re-run install:
+       ```
+       git checkout <dependabot-branch-name> -- happyhq/package.json package.json
+       pnpm install   # regenerates pnpm-lock.yaml fresh
+       ```
+
+     **B.2.b — lockfile-only bumps (transitive deps; Dependabot didn't change package.json):**
+     - Don't `pnpm install` from the current package.json — that re-resolves _current_ state and may reset transitive bumps Dependabot intended. Instead, take Dependabot's lockfile directly:
+       ```
+       git checkout <dependabot-branch-name> -- pnpm-lock.yaml
+       pnpm install --frozen-lockfile   # verifies the lockfile is internally consistent against current package.json
+       ```
+     - If the frozen install fails, fall through to B.2.c — Dependabot's lockfile carries an override-floor change that needs a package.json reconciliation.
+
+     **B.2.c — override-floor bump in lockfile (Dependabot raised `pnpm.overrides` snapshot in lockfile but didn't update `package.json`'s `pnpm.overrides`):**
+     - Detect by: lockfile diff includes a change to the top-of-file `overrides:` section (e.g., `-  postcss: ^8.5.10` / `+  postcss: ^8.5.13`) **and** `git diff origin/main...<dependabot-branch> -- package.json` shows no matching `pnpm.overrides.<pkg>` change.
+     - This is Dependabot's intent leaking through: it wanted to raise a security/policy floor on a transitive dep but its tooling only updated the lockfile snapshot, not the package.json source of truth.
+     - **Do NOT** simply regenerate from current package.json — that silently undoes the floor bump and weakens the security guarantee.
+     - Recipe:
+       1. Read the lockfile-snapshot bump to identify the package and the new floor (e.g., `postcss: ^8.5.13`).
+       2. Update `package.json`'s `pnpm.overrides.<pkg>` to the new floor:
+          ```
+          # Edit package.json: pnpm.overrides.postcss → "^8.5.13"
+          ```
+       3. Regenerate lockfile: `pnpm install`.
+       4. Verify the resulting lockfile's `overrides:` snapshot matches Dependabot's.
+     - Replacement PR body must call out the override floor change explicitly so the maintainer can sanity-check the security/policy intent.
+
+   - Verify everything is consistent: `git status` should show `package.json` and/or `happyhq/package.json` and `pnpm-lock.yaml` modified — nothing else.
    - **Size gate** still applies: `git diff --stat origin/main...HEAD -- ':!happyhq/package.json' ':!package.json' ':!pnpm-lock.yaml' ':!*.md' ':!*.mdx'`. (Should be 0 changes — the regen path is supposed to be clean.) If somehow >10 files / >300 LoC, apply `ralphie:skip-too-big` with cited reason and exit.
-   - Commit: `git add -A && git commit -m "chore: regenerate lockfile for <package or group> bump"` with a body that quotes the original `pnpm install --frozen-lockfile` error output.
+   - Commit: `git add -A && git commit -m "chore: regenerate lockfile for <package or group> bump"` with a body that quotes the original `pnpm install --frozen-lockfile` error output. For B.2.c, the commit body must also state the override floor was raised and quote the lockfile snapshot diff.
    - Push: `git push -u origin chore/upgrade-<package>-lockfile-regen`.
    - Open replacement PR: `gh pr create --base main --assignee @me --title "chore: regenerate lockfile for <package or group> bump" --body "..."`. PR body MUST include:
      - `Replaces #${PR_NUMBER}`

--- a/happyhq/.dev/dependency-rules.md
+++ b/happyhq/.dev/dependency-rules.md
@@ -141,7 +141,15 @@ These are guidance, not gates. The rules above are pass/fail; these tune _how_ a
 
 **The skim is a trigger to investigate, not a trigger to bail.** When the skim flags something — ownership change, secrets/auth handling refactor, security advisory, deprecation, breaking API change — read the linked PR/migration note, search the repo for usage of the affected behavior, and form a concrete impact verdict. The loop's value is the work; punting every flagged change to the human just shifts the same investigation onto them. Skip with `ralphie:skip-needs-review` only when the investigation reveals genuine concern or the impact is unclear after a real attempt — not as a default response to flagged keywords.
 
-**Lockfile-time errors are regenerable, not failures.** When `pnpm install --frozen-lockfile` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, `ERR_PNPM_OUTDATED_LOCKFILE`, or similar tooling-state mismatches, that's a deterministic re-resolution — not a behavioral change. Run `pnpm install` (no frozen) to regenerate the lockfile, then proceed to verification. If verification with the regenerated lockfile is clean, the agent's "fixup" for Path B is the regenerated lockfile itself; no changelog citation is required because there's no behavioral delta to cite. Open a replacement PR with the regenerated lockfile and a comment quoting the original pnpm error.
+**Lockfile-time errors are regenerable, not failures — but preserve Dependabot's intent.** When `pnpm install --frozen-lockfile` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, `ERR_PNPM_OUTDATED_LOCKFILE`, or similar tooling-state mismatches, that's a deterministic re-resolution — not a behavioral change. Run `pnpm install` (no frozen) to regenerate the lockfile, then proceed to verification. If verification is clean, open a replacement PR with the regenerated lockfile.
+
+**But** Dependabot's PR may carry intent that simple regeneration discards. Three sub-shapes require different recipes (see Path B.2 in the upgrade prompt):
+
+- **B.2.a — package.json + lockfile bumps (typical):** take both files from Dependabot's branch, re-run `pnpm install`.
+- **B.2.b — lockfile-only bumps (transitive):** take Dependabot's lockfile directly (`git checkout <dep-branch> -- pnpm-lock.yaml`), verify with `pnpm install --frozen-lockfile`. Don't re-resolve from current package.json — it'll reset the transitive bumps Dependabot intended.
+- **B.2.c — override-floor bump in lockfile (Dependabot raised `pnpm.overrides` snapshot but didn't update `package.json`):** read the lockfile diff to find the new floor, manually update `package.json`'s `pnpm.overrides.<pkg>` to match, then regenerate. Simply regenerating from current package.json silently undoes the floor and weakens security.
+
+The general principle: **the regenerated lockfile is the fix for tooling-state mismatch; package.json edits are the fix for tooling-intent loss.** Both can apply in the same PR.
 
 ## Tuning signal
 


### PR DESCRIPTION
## Summary

The Path B.2 (lockfile-regeneration replacement) recipe assumed Dependabot's PR carried package.json changes that the loop should pull onto its replacement branch. The recent run on PR #175 (npm-minor-patch group, lockfile-only with an override-floor bump) revealed that this assumption is wrong in two ways:

1. **Lockfile-only Dependabot PRs** have no package.json changes to pull. The agent improvised — \`pnpm update\`, \`pnpm dedupe\`, manual nanoid bump — before settling on \"take Dependabot's lockfile directly.\"
2. **Override-floor bumps** are even subtler: Dependabot updated the lockfile's \`overrides:\` snapshot (e.g., \`postcss: ^8.5.10 → ^8.5.13\`) without updating \`package.json\`'s \`pnpm.overrides\`. The agent regenerated from current package.json, **silently rolling back Dependabot's intent.** PR #179 (the replacement) currently has the regressed override.

## Fix

Path B.2 now branches into three sub-shapes:

- **B.2.a** — package.json + lockfile bumps (typical): take both files from Dependabot, re-run \`pnpm install\`. Unchanged from before.
- **B.2.b** — lockfile-only bumps (transitive deps): take Dependabot's lockfile directly with \`git checkout <dep-branch> -- pnpm-lock.yaml\`, verify with \`--frozen-lockfile\`. Don't re-resolve from current package.json — it'll reset the transitive bumps Dependabot intended.
- **B.2.c** — override-floor bump in lockfile: detect by comparing lockfile-snapshot diff to package.json diff. When the lockfile raised an override floor and package.json didn't change, **manually update \`package.json\`'s \`pnpm.overrides.<pkg>\`** to match the new floor before regenerating. The replacement PR body must call this out explicitly so the maintainer can sanity-check the security/policy intent.

## Principle worth naming

> The regenerated lockfile is the fix for tooling-state mismatch; package.json edits are the fix for tooling-intent loss. Both can apply in the same PR.

## Cleanup needed separately

PR #179 still has the regressed postcss override (\`^8.5.10\` instead of \`^8.5.13\`). A follow-up PR will close #179 and replace it with a B.2.c-shaped fix.

## Test plan
- [ ] Merge this PR
- [ ] Open the follow-up PR for postcss override
- [ ] Close #179 with explanation pointing at the new PR
- [ ] Future Dependabot lockfile-only / overrides-bump PRs land via the new B.2.b/B.2.c paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)