### PR TITLE
chore: let framework majors flow into the deps loop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,25 +27,11 @@ updates:
         # mismatches and runtime drift across auth/sync/realtime.
         patterns:
           - '@instantdb/*'
-    ignore:
-      - dependency-name: next
-        update-types:
-          - version-update:semver-major
-      - dependency-name: react
-        update-types:
-          - version-update:semver-major
-      - dependency-name: react-dom
-        update-types:
-          - version-update:semver-major
-      - dependency-name: eslint
-        update-types:
-          - version-update:semver-major
-      - dependency-name: eslint-config-next
-        update-types:
-          - version-update:semver-major
-      - dependency-name: typescript
-        update-types:
-          - version-update:semver-major
+    # No framework-major ignores. The loop's value is investigation —
+    # let next/react/typescript/eslint majors flow through so Phase 2
+    # can read migration guides, grep call-sites, and produce a cited
+    # skip-needs-review (or skip-manual-upgrade for multi-major steps).
+    # Elevated-scrutiny rules in dependency-rules.md cover the bar.
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Removes the semver-major ignores for `next`, `react`, `react-dom`, `eslint`, `eslint-config-next`, and `typescript` from `.github/dependabot.yml`.
- Rationale: the deps loop's value is **investigation** — reading migration guides, grepping call-sites, producing a cited verdict. Ignoring framework majors at the Dependabot layer means they sit invisibly forever, with no signal and no investigation.
- With the ignores gone, Phase 2 picks them up like any other PR. The existing rules already handle the outcomes:
  - **Rule 3** (`skip-needs-review`) — single-major bumps where investigation reveals concern or unclear impact
  - **Rule 4** (`skip-manual-upgrade`) — multi-major stepping that exceeds the loop's scope
  - **Elevated scrutiny** — already names `next`/`react`/`react-dom` and demands a higher bar before `ready-to-merge`

No prompt or rules changes needed; the elevated-scrutiny defaults already cover the bar for these packages.

## Test plan

- [ ] Wait for the next Dependabot run; confirm any pending framework-major PRs appear
- [ ] Run the deps loop and confirm Phase 2 investigates rather than punting on metadata
- [ ] Confirm the resulting label is one of `ralphie:ready-to-merge`, `ralphie:skip-needs-review`, or `ralphie:skip-manual-upgrade` with cited evidence in the comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)