### PR TITLE
chore: add tech-debt triage + fix loop

### DIFF
--- a/happyhq/.dev/PROMPT_tech_debt_fix.md
+++ b/happyhq/.dev/PROMPT_tech_debt_fix.md
@@ -1,0 +1,65 @@
+0a. Read @tech-debt-rubric.md — this is the spec. Apply Phase 2 literally; the engineering-judgment framing in "What this rubric is not" is load-bearing.
+0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
+0c. The issue you are working: #${ISSUE_NUMBER}. Read it: `gh issue view ${ISSUE_NUMBER} --comments`.
+
+1. **Read for intent.** What's the underlying concern in this issue? Who benefits from the change? Treat the body as a hypothesis from the author about what should change and how, not as a script. The named files, sites, and per-site decisions are the author's best guess — your job is to read them, read the actual code, and decide whether they're still right.
+
+2. **Verify the situation.** Open every named file/symbol/site. For each:
+   - Does it still exist?
+   - Does it still exhibit the issue described?
+   - Has the terminal action (e.g., a `'rule': 'off'` line) already been done?
+   - Has someone else already addressed part of it?
+
+   **Drift handling:**
+   - If the directive is fully obsolete (terminal action done, all sites cleared) → apply `ralphie:skip-stale` (rubric rule 5), post the rubric-shaped comment, exit.
+   - If significantly drifted but salvageable → proceed with what's left, note the drift in the PR body's "Verification" section.
+   - If under-drifted → continue.
+
+3. **Form an opinion.** Walk each proposed change site and ask honest questions:
+   - Is the body's approach still the right shape for _this_ site? Sometimes a site listed as "fix in place" is actually the kind of pattern the body's "refactor" bucket covers, or vice versa.
+   - Is there a smaller fix? A deeper one? Does the issue describe a symptom whose root cause lives one layer up?
+   - Are there sites the body missed that fall under the same rule? (Note them in the PR body but don't widen the diff to cover them — that's a separate issue.)
+
+   **If the body is wrong** (the proposed approach won't produce a good outcome on inspection) → apply `ralphie:skip-needs-rescope` (rubric rule 6), post the rubric-shaped comment with the alternative shape concrete enough that the maintainer can decide whether to update the body, exit. **Do not ship a thoughtless implementation** just because the loop reached this issue.
+
+4. **Branch.** The wrapper has already snapped `${BASE_BRANCH}` to latest `origin/main`. From `${BASE_BRANCH}`: `git checkout -b chore/${ISSUE_NUMBER}-<short-slug>`. The slug is 2–4 hyphenated words derived from the issue title (per [CLAUDE.md](CLAUDE.md) prefixes — `chore/`, not `fix/`).
+
+5. **Implement.** Apply the change with judgment. Where you deviate from the body, document the deviation in the PR body — that's where reviewers will look for the reasoning. If the body lists per-site decisions ("decide one of: fix / disable / refactor"), apply the bucket guidance the body provides, but override the bucket per site when the code says you should.
+
+6. **Verify.** From the `happyhq/` directory: `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test`. If a re-enable step is in scope (an `'off'` line was removed in eslint.config.mjs), `pnpm lint` must pass with the rule active. If any check fails, fix and re-run. If they fail twice, apply `ralphie:skip-verification-failed` (rubric rule 7), post the rubric-shaped comment with the failing output included, exit.
+
+7. **Risk gate.** With the diff in hand, apply the rubric's "Risk gate" decision tree:
+   - Run `git diff --stat origin/main...HEAD -- ':!*.md' ':!*.mdx'` to get the size.
+   - If under threshold (≤10 files AND ≤300 net lines added) → proceed to step 8.
+   - If over threshold AND low-risk per the rubric's criteria → proceed to step 8 with a "Why this is over threshold but low risk" section in the PR body.
+   - If over threshold AND high-risk per the rubric's criteria → take the **Split path** (rubric Path B): create child issues, comment on parent, apply `ralphie:split-into-children`, revert the branch (`git checkout ${BASE_BRANCH} && git branch -D chore/${ISSUE_NUMBER}-<slug>`), exit. Do not push.
+
+8. **Commit.** `git add -A && git commit -m "chore: <one-line summary>"`. Body should include `Closes #${ISSUE_NUMBER}` and a one-paragraph **why** for the change.
+
+9. **Push + PR.** `git push -u origin chore/${ISSUE_NUMBER}-<slug>` then `gh pr create --base main --assignee @me --title "chore: <summary>" --body "..."`. The `--assignee @me` puts the PR in the maintainer's "Assigned to me" queue. PR body MUST include:
+   - `Closes #${ISSUE_NUMBER}`
+   - One-paragraph summary of what changed and why
+   - **Deviations from the issue body** (if any) — what you did differently and why
+   - **"Why this is over threshold but low risk"** section (if rule 8 sub-case applied)
+   - Verification summary (lint/types/test all green; rule active if applicable)
+   - AI-assistance disclosure per [CONTRIBUTING.md](CONTRIBUTING.md) (e.g., "Authored by the tech-debt loop. Reviewed by maintainer before merge.")
+
+10. **Label.** `gh issue edit ${ISSUE_NUMBER} --add-label "ralphie:fixed-in-pr"`. The PR's `Closes #` is the rest of the breadcrumb.
+
+11. **Return to base branch.** `git checkout ${BASE_BRANCH}`. Each session leaves the working tree on `${BASE_BRANCH}` so the next session (or the maintainer) starts from a clean baseline. Apply this on the skip paths too — if you abort and revert in step 6 of the guardrails, end on `${BASE_BRANCH}`.
+
+12. ${DRY_RUN_NOTE}
+
+13. ${OVERRIDE_NOTE}
+
+14. Exit.
+
+**[1]** ONE issue per session. Do not pick up other issues, do not chain. The orchestrator handles the next one.
+**[2]** Hard constraints from @tech-debt-rubric.md are non-negotiable: never push to `main`, never modify `happyhq/ee/`, `.github/`, CI workflows, lockfiles (beyond what the focused fix demands), or licensing files. If the fix would require any of these, apply `ralphie:skip-out-of-scope` and exit.
+**[3]** Engage seriously, don't follow blindly. The issue body is a hypothesis. Read the code, form your own opinion, deviate when warranted, push back via `ralphie:skip-needs-rescope` when the proposed approach is wrong on inspection. The loop's value comes from doing the engineering — if it just types out what the issue says, the maintainer would be better served reading the issue themselves.
+**[4]** Tests defend behavior, not lines. Tech-debt fixes that don't change runtime behavior usually don't need new tests. Tech-debt fixes that DO change behavior need tests that pin the new behavior. Apply the litmus test from `testing.md`: "what bug would this catch?" If the answer is "someone reverted this exact line," skip the test.
+**[5]** Capture the **why** in the PR body and (if non-obvious) a code comment. Never narrate **what** in comments — well-named code does that.
+**[6]** If you discover the fix requires a schema migration / new env var / new dep / CI change mid-implementation, stop, revert your changes (`git checkout ${BASE_BRANCH} && git branch -D chore/${ISSUE_NUMBER}-...`), apply `ralphie:skip-out-of-scope`, exit.
+**[7]** AI disclosure in the PR body is required by @CONTRIBUTING.md. Never omit it.
+**[8]** When applying any `ralphie:skip-*` label, the comment uses the rubric's "Comment shape" format. Always.
+**[9]** When taking the Split path, the children inherit the rubric — they're unlabeled `tech-debt` issues like any other. Don't pre-label them; let the next loop iteration triage them naturally.

--- a/happyhq/.dev/PROMPT_tech_debt_triage.md
+++ b/happyhq/.dev/PROMPT_tech_debt_triage.md
@@ -1,0 +1,22 @@
+0a. Read @tech-debt-rubric.md — this is the spec. Apply Phase 1 literally.
+0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
+
+1. Get the queue: `gh issue list --label tech-debt --state open --limit 100 --json number,title,author,labels,body,createdAt --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)]'`. Empty → exit cleanly.
+
+2. For each issue in the queue (oldest first), in parallel where it makes sense (use Sonnet subagents for reads/searches), evaluate against Phase 1 rules 1–4. Read the issue body and ALL comments (`gh issue view <#> --comments`). For rule 4 (pre-stale), do a focused read of the cited file(s) — just enough to confirm whether the directive's terminal action is already done. **Do not read deeply** at triage time — that's Phase 2's job.
+
+3. For each issue, choose ONE outcome:
+   - **Skip** (matches a rubric rule): apply the matching `ralphie:skip-*` label and post the comment in the rubric's "Comment shape" format. Use `gh issue edit <#> --add-label "<label>"` and `gh issue comment <#> --body "..."`.
+   - **Eligible** (passes rules 1–4): leave the issue untouched. Unlabeled = queued for Phase 2.
+
+4. ${DRY_RUN_NOTE}
+
+5. When the queue is exhausted, print a one-line summary: `Triaged N issues: X skipped, Y eligible.` Exit.
+
+**[1]** Apply the rubric in order. Bail at the earliest stop.
+**[2]** Never write code in this phase. Never branch, commit, push, or open a PR. Triage is read-only on the repo and write-only on GitHub metadata (labels + comments).
+**[3]** A skip comment is for the human, the label is for the next loop run. Both are required for a skip.
+**[4]** If a rule is ambiguous about an issue, lean toward eligible — Phase 2 has its own gates (rules 5–9), including the rescope path that lets the fix session push back when the body is wrong on closer inspection. False eligibility is cheaper than false skip.
+**[5]** Never apply two `ralphie:*` labels to the same issue. First match wins.
+**[6]** If `gh` returns an empty queue, exit 0 silently. No error, no comment.
+**[7]** **Don't classify by sub-shape.** Triage's only job is to filter issues that aren't actionable as written, that touch protected paths, that need maintainer decisions, or that are pre-stale. Don't try to label issues as "ESLint cluster" or "rename cluster" or anything similar — the fix phase reads each issue on its own and forms its own opinion. Sub-classification at triage punts engineering judgment forward and gets stale fast.

--- a/happyhq/.dev/tech-debt-rubric.md
+++ b/happyhq/.dev/tech-debt-rubric.md
@@ -1,0 +1,116 @@
+# Tech-Debt Rubric
+
+Source of truth for how the loop judges open `tech-debt`-labeled issues. Both `PROMPT_tech_debt_triage.md` and `PROMPT_tech_debt_fix.md` load this file. Edit here, not in the prompts.
+
+## Queue contract
+
+- The queue is: GitHub issues that are `state:open`, labeled `tech-debt`, and have no label starting with `ralphie:`.
+- A `ralphie:*` label is terminal — the loop never re-evaluates a labeled issue. The human removes the label to re-queue.
+- One outcome per session (a label, a comment, or a PR + label). No chaining.
+
+## What this rubric is not
+
+A tech-debt issue body is a hypothesis from the author about what should change and how. It is **not** a script to execute. The fix session reads the body for intent, reads the actual code, and forms its own opinion. Sometimes the body is right; sometimes the body is half-right and the fix deviates with documented reasoning; sometimes the body is wrong and the loop pushes back via `ralphie:skip-needs-rescope` instead of shipping a thoughtless implementation. This rubric encodes the gates around that engineering judgment, not a substitute for it.
+
+## Phase 1 — Triage rubric (evaluable from issue text alone)
+
+Apply in order — bail at the earliest stop.
+
+| #   | Condition                                                                                                                                                                          | Label applied                 | What unblocks it                                                                                        |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------- |
+| 1   | Issue body isn't actionable as written: decision request ("delete or wire up?"), open-ended audit ("audit every code path that..."), "let's discuss" framing, or no concrete scope | `ralphie:skip-not-actionable` | Maintainer rewrites the body with concrete scope (specific files/sites, specific change), removes label |
+| 2   | Body proposes a fix that would touch `happyhq/ee/`, `.github/`, CI workflows, lockfiles beyond a focused change, or licensing files                                                | `ralphie:skip-out-of-scope`   | Maintainer scopes manually or decouples the protected-path piece, removes label                         |
+| 3   | Body has unresolved questions for the maintainer ("should we do A or B?", "@user thoughts?")                                                                                       | `ralphie:skip-not-actionable` | Maintainer answers, removes label                                                                       |
+| 4   | Pre-stale: a quick look at the cited file(s) shows the directive is already done (e.g., `'rule': 'off'` line is already removed; named symbol no longer exists)                    | `ralphie:skip-stale`          | Maintainer closes the issue, or rewrites the body around what's still outstanding                       |
+
+Phase 1 is read-only on the repo, write-only on GitHub metadata (labels + comments). No branches, no commits, no PRs.
+
+## Phase 2 — Fix-time rubric (evaluable only after engaging seriously)
+
+| #   | Condition                                                                                                                                                                     | Label applied                      | What unblocks it                                         |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------------------------------------------------------- |
+| 5   | After opening the cited files: sites listed in the body have significantly drifted (more than a couple already gone) and what's left isn't enough to anchor the change        | `ralphie:skip-stale`               | Maintainer refreshes the body or closes                  |
+| 6   | After reading the code: the body's proposed approach is wrong (smaller fix exists, deeper fix needed, the buckets are mis-assigned). Loop comments with the alternative shape | `ralphie:skip-needs-rescope`       | Maintainer reads the comment, updates the body or closes |
+| 7   | `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` failed twice                                                                                  | `ralphie:skip-verification-failed` | Maintainer reads the comment Ralphie left, fixes locally |
+| 8   | Risk gate trips (see "Risk gate" below): diff is over threshold AND high-risk                                                                                                 | `ralphie:split-into-children`      | Children land — when all close, parent closes too        |
+| 9   | Fix shipped (under threshold, OR over threshold but low-risk and noted in PR body)                                                                                            | `ralphie:fixed-in-pr`              | Terminal — the linked PR closes the loop                 |
+
+## Risk gate (replaces a raw size cap)
+
+Size is a proxy for **review risk**, and the proxy is wrong in both directions: a 12-file mechanical rename is lower risk than a 30-line edit in `lib/run/loop.server.ts`. The gate assesses risk explicitly, post-fix, with the actual diff in hand.
+
+**Threshold (the same numbers bugs.sh uses today):** more than 10 files changed OR more than 300 net lines added, excluding `*.md` and `*.mdx`.
+
+**Low risk** (proceed even if over threshold):
+
+- Change is mechanical: rename, codemod-shaped, uniform per-site application of a published rubric (e.g., "fix / per-line-disable / refactor" applied consistently).
+- Touched files have test coverage that exercises the change, OR the change is provably behavior-preserving (compiler-checked rename, lint rule fix that doesn't change runtime semantics).
+- No runtime behavior change, OR the change is the explicit goal and tests pin it.
+- Files cluster outside critical surfaces.
+
+**High risk** (do not ship as one PR):
+
+- Touches critical surfaces: `lib/run/`, `lib/database/`, `lib/fs/`, `lib/actions.ts`, server actions, agent orchestration, auth, billing.
+- Mixes unrelated concerns (refactor + behavior fix; multiple separable issues collapsed into one PR).
+- Behavior change without test coverage that pins it.
+- Per-site decisions diverge meaningfully (some sites "fix", others "refactor", others "disable") AND the diverging decisions warrant separate review.
+
+**Decision tree:**
+
+1. Diff under threshold → proceed (Path A — ship).
+2. Diff over threshold AND low risk → proceed; add a section to the PR body titled "Why this is over threshold but low risk" with a one-paragraph rationale (Path A — ship with note).
+3. Diff over threshold AND high risk → split (Path B below). Do not push the over-size PR.
+
+## Split path (Path B)
+
+When the risk gate trips, the loop creates child issues instead of one giant PR. The split itself is a low-risk action: only GitHub metadata writes, no code.
+
+1. **Identify the split axis** from the parent body. For ESLint rule re-enablement issues, the natural axis is files (one PR per file) or buckets (one PR for the "fix in place" sites, one for the "per-line-disable" sites). For other shapes, the body usually telegraphs the axis. Pick the axis that produces 2–4 children of comparable size.
+2. **For each child group:** `gh issue create --label tech-debt --title "<parent title> — <axis slice>" --body "..."`. Body must include:
+   - `Split from #<parent>.`
+   - One paragraph stating the scope of this child (which files/sites/buckets).
+   - A copy of the parent's per-site decision rubric, narrowed to the child's scope.
+   - The terminal action for the child (e.g., "Once these N sites are fixed, do NOT remove the `'rule': 'off'` line — that's the parent's terminal action, after all children close.").
+3. **Comment on parent** listing the children: "Split into #X, #Y, #Z by <axis>. This parent stays open until all children close, at which point I (or the next loop iteration) can do the terminal action."
+4. **Apply `ralphie:split-into-children` to parent.**
+5. **Revert the working branch:** `git checkout ${BASE_BRANCH} && git branch -D chore/<slug>`. Push nothing.
+6. Exit. Next loop iteration picks up the children naturally — they're unlabeled `tech-debt` issues like any other.
+
+## Comment shape (for skips and rescope)
+
+Every skip — and every rescope — writes one comment, in this shape:
+
+```
+Loop skipped this for: <rubric reason name>
+
+What I saw: <1–3 sentences — the specific evidence in the issue/code that triggered the rule>
+
+What would unblock it: <1 sentence — the concrete action that lets the next loop run pick this up>
+```
+
+For `ralphie:skip-needs-rescope`, the "What I saw" section IS the alternative shape — describe the better approach concretely enough that the maintainer can decide whether to update the body.
+
+For `ralphie:split-into-children`, the comment on the parent doesn't follow this shape — it lists the children instead (see Split path step 3).
+
+Comments are for the human reading the queue. The label is for the next loop run.
+
+## Hard constraints (never violate, regardless of rubric)
+
+- Never push to `main`. Never force-push. Never `--no-verify`.
+- Never modify files under `happyhq/ee/`, `.github/`, CI workflows, lockfiles (beyond what a focused fix demands), or licensing files. If the fix would require any of these, apply `ralphie:skip-out-of-scope` and exit.
+- PRs always target `main`, branch from `${BASE_BRANCH}`, use the `chore/` prefix, and include `Closes #<issue>` plus an AI-assistance disclosure (per `CONTRIBUTING.md`).
+- One outcome per session. After labeling or opening a PR (or splitting into children), exit.
+
+## Principles
+
+These are guidance, not gates. The rubric above is pass/fail; these tune _how_ the allowed work gets done.
+
+**Engage seriously, don't follow blindly.** A good engineer reads the issue, reads the code, and forms an opinion before changing anything. The body is a hypothesis. If the proposed approach is wrong on inspection, push back via `ralphie:skip-needs-rescope`. If it's partially right, deviate with documented reasoning in the PR body. The loop's job is to do the engineering, not type out what the issue says.
+
+**A fix isn't just the diff.** Leave the surrounding system coherent. If the change moves documented behavior, update the spec/doc in the same PR. If you notice the same anti-pattern in nearby files that aren't listed in the issue, mention it in the PR body — but don't widen the diff to cover them (that's a separate issue).
+
+**Tests defend behavior, not lines.** Tech-debt fixes that don't change runtime behavior usually don't need new tests; existing tests passing is the contract. Tech-debt fixes that DO change behavior (because the old behavior was wrong) need tests that pin the new behavior. Apply the litmus test from `testing.md`: "what bug would this catch?" If the answer is "someone reverted this exact line," it's a vanity test — skip it.
+
+## Tuning signal
+
+When the loop gets it wrong — labels something `not-actionable` that wasn't, ships a PR that should have been a rescope, splits when a single PR would have been fine — that's a rubric-tuning signal, not a one-off correction. Edit this file. The next run will pick up the change.

--- a/happyhq/.dev/tech-debt.sh
+++ b/happyhq/.dev/tech-debt.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+set -o pipefail
+# Usage: ./tech-debt.sh [options]
+#   ./tech-debt.sh                          # triage + fix loop, default --max-issues 3
+#   ./tech-debt.sh --max-issues 5           # cap Phase 2 attempts at 5
+#   ./tech-debt.sh --triage-only            # Phase 1 only
+#   ./tech-debt.sh --fix-only               # skip Phase 1, run the fix loop on the queue
+#   ./tech-debt.sh --issue 203              # skip triage; one fix session against #203
+#   ./tech-debt.sh --issue 203 --override   # bypass self-skip rules (rescope, risk-gate, verification) for that issue
+#   ./tech-debt.sh --dry-run                # Phase 1 preview only, no writes
+#   ./tech-debt.sh --issue 203 --dry-run    # preview a single fix session, no writes
+
+DIM='\033[2m'
+BOLD='\033[1m'
+GREEN='\033[32m'
+CYAN='\033[36m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+MAX_ISSUES=3
+TRIAGE_ONLY=0
+FIX_ONLY=0
+SINGLE_ISSUE=""
+DRY_RUN=""
+OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --max-issues)
+            MAX_ISSUES="$2"
+            shift 2
+            ;;
+        --triage-only)
+            TRIAGE_ONLY=1
+            shift
+            ;;
+        --fix-only)
+            FIX_ONLY=1
+            shift
+            ;;
+        --issue)
+            SINGLE_ISSUE="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --override)
+            OVERRIDE=1
+            shift
+            ;;
+        -h|--help)
+            sed -n '3,12p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ $TRIAGE_ONLY -eq 1 ] && [ $FIX_ONLY -eq 1 ]; then
+    echo "Error: --triage-only and --fix-only are mutually exclusive" >&2
+    exit 1
+fi
+if [ $FIX_ONLY -eq 1 ] && [ -n "$DRY_RUN" ]; then
+    echo "Error: --fix-only --dry-run isn't supported (dry-run on fixes wastes a real session). Use --issue <#> --dry-run to preview a single fix." >&2
+    exit 1
+fi
+if [ -n "$OVERRIDE" ] && [ -z "$SINGLE_ISSUE" ]; then
+    echo "Error: --override is only valid with --issue <#>. The Phase 2 auto-loop must always respect skip gates." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+# ── Worktree-aware base branch resolution ──
+# Tech-debt is required to run from the dedicated worktree, never from the
+# primary checkout. The maintainer's `happyhq/` stays free for collaborative
+# work, and the loop never runs on `main`. Setup (one-time):
+#   git worktree add ../happyhq-debt -b loop/debt origin/main
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+case "$REPO_ROOT" in
+    */happyhq-debt)
+        BASE_BRANCH="loop/debt"
+        ;;
+    *)
+        echo -e "  ${RED}Error: tech-debt.sh must run from the tech-debt worktree (.../happyhq-debt). Current: ${REPO_ROOT}${RESET}" >&2
+        echo -e "  ${DIM}Set up the worktree once with: git worktree add ../happyhq-debt -b loop/debt origin/main${RESET}" >&2
+        exit 1
+        ;;
+esac
+export BASE_BRANCH
+
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]; then
+    echo -e "  ${RED}Error: ${REPO_ROOT} should be on '${BASE_BRANCH}', not '${CURRENT_BRANCH}'.${RESET}" >&2
+    echo -e "  ${DIM}Fix: git -C ${REPO_ROOT} checkout ${BASE_BRANCH}${RESET}" >&2
+    exit 1
+fi
+
+# Guard against losing uncommitted work — the next step is `git reset --hard`.
+if [ -n "$(git status --porcelain)" ]; then
+    echo -e "  ${RED}Error: uncommitted changes in ${REPO_ROOT}. Commit, stash, or discard before running the loop — the next step hard-resets to origin/main.${RESET}" >&2
+    git status --short >&2
+    exit 1
+fi
+
+echo -e "  ${DIM}Snapping ${BASE_BRANCH} → origin/main (hard reset), then pnpm install…${RESET}"
+git fetch origin --quiet || { echo -e "  ${RED}git fetch failed${RESET}" >&2; exit 1; }
+git reset --hard origin/main >/dev/null || { echo -e "  ${RED}git reset failed${RESET}" >&2; exit 1; }
+(cd "$REPO_ROOT" && (pnpm install --frozen-lockfile || pnpm install)) || { echo -e "  ${RED}pnpm install failed${RESET}" >&2; exit 1; }
+
+cleanup() {
+    echo -e "\n${DIM}Cleaning up child processes...${RESET}"
+    pkill -P $$ 2>/dev/null
+    pkill -f "node.*vitest" 2>/dev/null
+    exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+if [ -n "$DRY_RUN" ]; then
+    export DRY_RUN_NOTE="**DRY RUN MODE**: For every action that would write to GitHub or the repo (labels, comments, branches, commits, pushes, PRs, child issues), print one line prefixed with 'DRY-RUN:' describing what you WOULD do, then SKIP the actual call. Do not invoke any 'gh issue edit', 'gh issue comment', 'gh issue create', 'gh pr create', 'git commit', 'git push', or filesystem write outside of pnpm install / verification scratch. Reads (gh issue view/list, code search, file reads, pnpm install, verification scripts) are fine."
+else
+    export DRY_RUN_NOTE=""
+fi
+
+if [ -n "$OVERRIDE" ]; then
+    export OVERRIDE_NOTE="**OVERRIDE MODE**: The maintainer invoked --override on this single-issue session. Skip the soft self-skip checks: do NOT apply ralphie:skip-needs-rescope, ralphie:skip-verification-failed, or ralphie:split-into-children, and do NOT exit early on those conditions — push and open the PR anyway. Hard constraints from the rubric (no push to main, no edits to happyhq/ee/, .github/, CI workflows, lockfiles beyond focused fix, or licensing files) remain non-negotiable. Note the override in the PR body's AI-disclosure paragraph: 'Maintainer invoked --override; rescope/risk/verification self-skip gates were bypassed.'"
+else
+    export OVERRIDE_NOTE=""
+fi
+
+run_session() {
+    local prompt_file="$1"
+    local label="$2"
+
+    echo -e "\n  ${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "  ${BOLD}${label}${RESET}"
+    echo -e "  ${DIM}Prompt:${RESET}  $prompt_file"
+    [ -n "$DRY_RUN" ] && echo -e "  ${YELLOW}DRY RUN${RESET}"
+    echo -e "  ${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+
+    if [ ! -f "$prompt_file" ]; then
+        echo -e "  ${RED}Error: $prompt_file not found${RESET}"
+        return 1
+    fi
+
+    envsubst < "$prompt_file" | claude -p \
+        --dangerously-skip-permissions \
+        --output-format=stream-json \
+        --model opus \
+        --verbose 2>&1 | node "$SCRIPT_DIR/format-stream.mjs"
+
+    return ${PIPESTATUS[1]}
+}
+
+# ── Single-issue mode: skip triage, run one fix session ──
+if [ -n "$SINGLE_ISSUE" ]; then
+    export ISSUE_NUMBER="$SINGLE_ISSUE"
+    run_session "PROMPT_tech_debt_fix.md" "Fix #$SINGLE_ISSUE"
+    exit $?
+fi
+
+# ── Phase 1: Triage (skipped with --fix-only) ──
+if [ $FIX_ONLY -eq 0 ]; then
+    run_session "PROMPT_tech_debt_triage.md" "Phase 1 · Triage"
+    TRIAGE_EXIT=$?
+    if [ $TRIAGE_EXIT -ne 0 ]; then
+        echo -e "  ${RED}Triage exited with status $TRIAGE_EXIT — stopping${RESET}"
+        exit $TRIAGE_EXIT
+    fi
+
+    if [ $TRIAGE_ONLY -eq 1 ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Triage complete (--triage-only). Exiting."
+        exit 0
+    fi
+
+    if [ -n "$DRY_RUN" ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Phase 1 preview complete. Skipping Phase 2 in --dry-run (labels weren't applied, so the fix queue would re-pick the same issues). Use --issue <#> --dry-run to preview a fix session."
+        exit 0
+    fi
+fi
+
+# ── Phase 2: Fix loop (one session per eligible issue — oldest first) ──
+ISSUES_DONE=0
+while [ $ISSUES_DONE -lt $MAX_ISSUES ]; do
+    NEXT=$(gh issue list \
+        --label tech-debt \
+        --state open \
+        --limit 100 \
+        --json number,labels,createdAt \
+        --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)] | sort_by(.createdAt) | .[0].number // empty' 2>/dev/null)
+
+    if [ -z "$NEXT" ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Queue empty. $ISSUES_DONE issue(s) attempted. Exiting."
+        exit 0
+    fi
+
+    ISSUES_DONE=$((ISSUES_DONE + 1))
+    export ISSUE_NUMBER="$NEXT"
+    run_session "PROMPT_tech_debt_fix.md" "Phase 2 · Issue $ISSUES_DONE of max $MAX_ISSUES · #$NEXT"
+    SESSION_EXIT=$?
+    if [ $SESSION_EXIT -ne 0 ]; then
+        echo -e "  ${RED}Fix session exited with status $SESSION_EXIT — stopping loop${RESET}"
+        exit $SESSION_EXIT
+    fi
+
+    LABELED=$(gh issue view "$NEXT" --json labels --jq '.labels | map(.name) | any(startswith("ralphie:"))' 2>/dev/null)
+    if [ "$LABELED" != "true" ]; then
+        echo -e "  ${RED}Issue #$NEXT has no ralphie:* label after the session — aborting loop to avoid re-picking it.${RESET}"
+        exit 1
+    fi
+
+    pkill -f "node.*vitest" 2>/dev/null || true
+    sleep 1
+done
+
+echo -e "\n  ${YELLOW}Reached --max-issues=$MAX_ISSUES. Stopping.${RESET}"


### PR DESCRIPTION
## Why

The `tech-debt`-labeled queue is accumulating (#27, #43, #200–#204) and solving these one-by-one is unappealing. Today's `bugs.sh` flow doesn't fit cleanly — its rubric assumes reproducibility and regression-test-as-contract, neither of which map onto tech-debt. This adds a sibling loop modeled on `dependency.sh`, with rules tuned for the kind of work tech-debt actually is: read the body for intent, verify the situation in code, form an opinion, and either ship, push back, or split.

The four eslint rule re-enablement issues (#200–#203) are the immediate population for it. The other three (#204 decision, #27 multi-surface rename, #43 open-ended audit) get filtered at triage with `ralphie:skip-not-actionable` until a human gives them concrete scope.

## What's in here

- `happyhq/.dev/tech-debt-rubric.md` — Phase 1 (triage) + Phase 2 (fix-time) rubrics, with a **risk gate** replacing the bugs flow's raw size cap. Same numeric threshold (>10 files OR >300 net lines), but the decision is risk-based: low-risk + over-threshold ships with a note; high-risk + over-threshold splits into child issues.
- `happyhq/.dev/tech-debt.sh` — wrapper modeled on `dependency.sh`. Required to run from `../happyhq-debt` on `loop/debt`; refuses to run from the primary checkout.
- `happyhq/.dev/PROMPT_tech_debt_triage.md` — Phase 1 prompt. Skip-only; no sub-shape classification.
- `happyhq/.dev/PROMPT_tech_debt_fix.md` — Phase 2 prompt. Reads body for intent, verifies, forms opinion, can push back via `ralphie:skip-needs-rescope` if the body's approach is wrong on inspection.

## New `ralphie:*` labels in this namespace

- `ralphie:skip-not-actionable` — body isn't a directive (decision request, open-ended audit, "let's discuss")
- `ralphie:skip-stale` — sites already cleared or terminal action already done
- `ralphie:skip-needs-rescope` — loop engaged seriously, doesn't think this should be done as written, comment explains the alternative
- `ralphie:split-into-children` — too risky for one PR; loop filed N child issues

## Test plan

- [ ] Worktree set up at `../happyhq-debt` on `loop/debt` (already done locally)
- [ ] After merge: from `../happyhq-debt`, run `./happyhq/.dev/tech-debt.sh --dry-run` against today's queue. Expect 4 eligible (#200/#201/#202/#203), 3 skipped as `not-actionable` (#27, #43, #204).
- [ ] Then `./happyhq/.dev/tech-debt.sh --issue 203 --dry-run` to preview a single fix session against the smallest issue (#203, 3 sites).
- [ ] Then `./happyhq/.dev/tech-debt.sh --issue 203` for the real shakedown — produces a `chore/203-react-hooks-purity` branch + PR; confirm the off line is removed and `pnpm lint` passes with the rule active.
- [ ] Path guard: confirm the wrapper refuses to run from the primary `happyhq/` checkout (already verified locally).

## Follow-up

Risk-gate logic should backport into [bugs-rubric.md](happyhq/.dev/bugs-rubric.md) — same proxy-for-risk problem applies there. Tracked separately so this PR stays focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)