### PR TITLE
chore: resolve react-hooks/refs findings and re-enable the rule

### DIFF
--- a/happyhq/components/features/chat/chat-page-content.tsx
+++ b/happyhq/components/features/chat/chat-page-content.tsx
@@ -54,8 +54,10 @@ import { WorkingIndicator } from './messages/working-indicator'
 const EMPTY_CHATS: ChatItem[] = []
 
 export function ChatPageContent({
+  sessionId,
   originStreamSlug,
 }: {
+  sessionId: string
   originStreamSlug?: string | null
 }) {
   const messages = useChatMessages()
@@ -163,7 +165,7 @@ export function ChatPageContent({
                 sessionId: c.sessionId,
                 label: c.title ?? 'Untitled chat',
               }))}
-              currentSessionId={sessionIdRef.current}
+              currentSessionId={sessionId}
               label={chatName || 'New Chat'}
               onSelect={(id) => router.push(`/chat/${id}`)}
               onDelete={(id) => {

--- a/happyhq/components/features/chat/chat-page-shell.tsx
+++ b/happyhq/components/features/chat/chat-page-shell.tsx
@@ -47,7 +47,7 @@ export function ChatPageShell({
       initialSessionId={sessionId}
       initialHistory={initialHistory}
     >
-      <ChatPageContent originStreamSlug={streamSlug} />
+      <ChatPageContent sessionId={sessionId} originStreamSlug={streamSlug} />
     </ChatSessionProvider>
   )
 }

--- a/happyhq/components/features/chat/messages/working-indicator.tsx
+++ b/happyhq/components/features/chat/messages/working-indicator.tsx
@@ -69,8 +69,9 @@ export function useWorkingText() {
     usedSounds: Set<string>
   } | null>(null)
 
-  // Lazy-init on first access so the first phrase is ready immediately
-  if (!ref.current) {
+  // Lazy-init on first access so the first phrase is ready immediately.
+  // `== null` is the React Compiler-sanctioned shape for one-time ref init.
+  if (ref.current == null) {
     const usedMutters = new Set<string>()
     ref.current = {
       bucketIndex: 0,

--- a/happyhq/components/features/desktop/providers/desktop-initializer.tsx
+++ b/happyhq/components/features/desktop/providers/desktop-initializer.tsx
@@ -275,7 +275,12 @@ export function DesktopInitializer() {
   // (playbook, specs, samples, chats) and only fetches task content + task list.
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isRunActiveRef = useRef(isRunActive)
-  isRunActiveRef.current = isRunActive
+  // Mirror `isRunActive` into a ref so the debounced setTimeout below sees
+  // the latest value without re-creating the timer when it changes. Effect
+  // commits before the next setTimeout tick, so the ref is fresh when read.
+  useEffect(() => {
+    isRunActiveRef.current = isRunActive
+  }, [isRunActive])
 
   const debouncedRefresh = useCallback(() => {
     if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current)

--- a/happyhq/components/features/desktop/windows/chat/chat-window.tsx
+++ b/happyhq/components/features/desktop/windows/chat/chat-window.tsx
@@ -48,12 +48,14 @@ function fetchSessionMessages(sessionId: string): Promise<ChatMessage[]> {
 function InteractiveChatContent({
   frameProps,
   windowTitle,
+  sessionId,
 }: {
   frameProps: Omit<
     React.ComponentProps<typeof WindowFrame>,
     'title' | 'children'
   >
   windowTitle: string
+  sessionId: string | null
 }) {
   const chatActions = useChatActions()
   const router = useRouter()
@@ -142,7 +144,7 @@ function InteractiveChatContent({
                   : 'General',
               }),
             }))}
-            currentSessionId={sessionIdRef.current}
+            currentSessionId={sessionId}
             label={windowTitle || 'New Chat'}
             onSelect={(id) => chatActions.switchChat(id)}
             onDelete={(id) => {
@@ -206,7 +208,11 @@ export function ChatWindow({ id, canvasRef }: WindowComponentProps) {
         windowId={w.id}
         initialMode={w.meta.initialMode}
       >
-        <InteractiveChatContent frameProps={frameProps} windowTitle={w.title} />
+        <InteractiveChatContent
+          frameProps={frameProps}
+          windowTitle={w.title}
+          sessionId={w.meta.sessionId ?? null}
+        />
       </ChatWindowProvider>
     )
   }

--- a/happyhq/components/features/desktop/windows/samples/samples-window.tsx
+++ b/happyhq/components/features/desktop/windows/samples/samples-window.tsx
@@ -272,7 +272,7 @@ export function SamplesWindow({
   const [isUploading, setIsUploading] = useState(false)
   const [editingKey, setEditingKey] = useState<string | null>(null)
   const [creatingNewType, setCreatingNewType] = useState(false)
-  const pendingTitlesRef = useRef<Record<string, string>>({})
+  const [pendingTitles, setPendingTitles] = useState<Record<string, string>>({})
   const [pendingTypeTitles, setPendingTypeTitles] = useState<
     Record<string, string>
   >({})
@@ -412,7 +412,10 @@ export function SamplesWindow({
           currentTitle={sample.title}
           slug={sample.name}
           onSave={async (newTitle) => {
-            pendingTitlesRef.current[sample.originalPath] = newTitle
+            setPendingTitles((prev) => ({
+              ...prev,
+              [sample.originalPath]: newTitle,
+            }))
             setEditingKey(null)
             try {
               await writeSampleTitle(
@@ -424,7 +427,10 @@ export function SamplesWindow({
               )
               onSampleIngested()
             } catch {
-              delete pendingTitlesRef.current[sample.originalPath]
+              setPendingTitles((prev) => {
+                const { [sample.originalPath]: _, ...rest } = prev
+                return rest
+              })
             }
           }}
           onCancel={() => setEditingKey(null)}
@@ -434,9 +440,7 @@ export function SamplesWindow({
       <FileRow
         name={sample.name}
         filename={sample.originalName}
-        displayTitle={
-          pendingTitlesRef.current[sample.originalPath] ?? sample.title
-        }
+        displayTitle={pendingTitles[sample.originalPath] ?? sample.title}
         onClick={() =>
           openFileWindow({
             name: sample.originalName,

--- a/happyhq/eslint.config.mjs
+++ b/happyhq/eslint.config.mjs
@@ -19,7 +19,6 @@ const eslintConfig = [
       // (via eslint-config-next 16). Disabled to land the toolchain upgrade
       // non-blocking; addressing the findings is its own piece of work.
       'react-hooks/set-state-in-effect': 'off',
-      'react-hooks/refs': 'off',
       'react-hooks/purity': 'off',
       'react-hooks/immutability': 'off',
       'react/use': 'off',


### PR DESCRIPTION
Closes #200

## Summary

`eslint-plugin-react-hooks@7` (pulled by `eslint-config-next@16` in #199) introduced `react-hooks/refs`, a React Compiler safety rule. It was disabled in eslint.config.mjs to keep the toolchain upgrade non-blocking. This PR fixes each of the 7 flagged sites and re-enables the rule.

## Per-site changes

- **`chat-page-content.tsx:166`** — render-time `sessionIdRef.current` read for `currentSessionId={…}`. The page is keyed by `sessionId` so the URL value is stable for the component's lifetime; thread it as a prop from `ChatPageShell` and use the prop in render. Handler reads of the ref (which may need the latest value after async writes) stay as-is.
- **`working-indicator.tsx:73`** — lazy-init pattern. The rule sanctions `if (ref.current == null) { ref.current = … }` as the canonical one-time-init shape, so just renaming the predicate from `!ref.current` to `ref.current == null` satisfies the rule without a per-line disable.
- **`desktop-initializer.tsx:278`** — render-time write `isRunActiveRef.current = isRunActive` to keep the latest value visible to the debounced `setTimeout`. Move into a `useEffect`. Effects commit before the next macrotask, so the timer (which always runs via `setTimeout`) reads a fresh value.
- **`chat-window.tsx:145`** — same shape as site 1 but for the desktop window. `w.meta.sessionId` already tracks the live session ID via the window store (`updateChatMeta` syncs new sessions there). Thread it as a prop into `InteractiveChatContent`.
- **`samples-window.tsx:538/556/564`** — all three are flagged because `renderSample` (passed to `.map(…)` during render) reads `pendingTitlesRef.current`. Convert `pendingTitlesRef` → `pendingTitles` state. This parallels the `pendingTypeTitles` state that already lives next to it in the same component, removes the rule violation at the root, and is the body's "should be state, not a ref" bucket.

After all 7 sites are addressed, remove `'react-hooks/refs': 'off'` from `eslint.config.mjs`.

## Deviations from the issue body

- The body suggested a per-line disable for the lazy-init pattern at `working-indicator.tsx:73`. The rule now sanctions `if (ref.current == null) { … }` directly (the lint output even surfaces this as a hint), so I used that instead — same intent, no eslint-disable comment.
- The body groups the 3 samples-window sites as separate decisions, but they all stem from one ref. Fixing the root (`pendingTitlesRef` → state) clears all three in one stroke; the alternative (per-line disables on the `.map(renderSample)` call sites) would just paper over a "should be state" smell.
- The body mentions converting `sessionIdRef` itself to state. I kept the ref because it's still needed for synchronous handler reads (delete-active-chat check, fetch payloads), and only swapped the render-time read for a stable prop. Smaller diff, same outcome for the rule.

## Verification

- `pnpm lint` ✓ (with `react-hooks/refs` active)
- `pnpm check-types` ✓
- `pnpm --filter=happyhq test` ✓ (1477 passed)
- `pnpm format` ✓

## AI-assisted disclosure

Authored by the tech-debt loop (Claude Code). Reviewed by maintainer before merge.