### PR TITLE
fix: persist Claude Code config across Fly machine restarts

### DIFF
--- a/happyhq/Dockerfile
+++ b/happyhq/Dockerfile
@@ -86,9 +86,11 @@ COPY --from=build /build/happyhq/prompts /app/happyhq/prompts
 COPY --from=build /build/happyhq/q /app/happyhq/q
 
 ENV PORT=3000 HOSTNAME=0.0.0.0
+# Point HOME at the mounted volume so ~/.claude.json and ~/.claude/ both
+# persist across machine restarts. See docker-entrypoint.sh for the migration
+# from the previous symlink-based layout.
+ENV HOME=/data/home
 EXPOSE 3000
 
-# Persist Claude Code state (~/.claude) across machine restarts by symlinking
-# to the mounted volume. The volume at /data survives stop/start cycles; the
-# root filesystem does not.
-CMD ["sh", "-c", "mkdir -p /data/.claude && ln -sfn /data/.claude /root/.claude && exec node server.js"]
+COPY --chmod=755 happyhq/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+CMD ["docker-entrypoint.sh"]

--- a/happyhq/docker-entrypoint.sh
+++ b/happyhq/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Runtime entrypoint for the q-* fleet.
+#
+# Persists Claude Code state across Fly machine restarts. The volume at /data
+# survives stop/start cycles; the root filesystem does not. Setting HOME to a
+# directory on the volume means ~/.claude.json (the config file) and ~/.claude/
+# (the state directory) both persist naturally — no symlinks, no risk of an
+# atomic rename replacing a symlink with an ephemeral file.
+set -eu
+
+mkdir -p "$HOME"
+
+# One-time migration from the old layout, where /data/.claude was symlinked
+# into /root/.claude and /root/.claude.json lived on the (ephemeral) root FS
+# and got wiped on every autostop. Safe to leave in place; remove once all
+# q-* machines have rotated through at least one boot on the new layout.
+if [ -d /data/.claude ] && [ ! -e "$HOME/.claude" ]; then
+  cp -a /data/.claude "$HOME/.claude"
+fi
+if [ ! -f "$HOME/.claude.json" ]; then
+  latest=$(ls -t "$HOME/.claude/backups/.claude.json.backup."* 2>/dev/null | head -1 || true)
+  if [ -n "${latest:-}" ]; then
+    cp "$latest" "$HOME/.claude.json"
+  fi
+fi
+
+exec node server.js

--- a/happyhq/lib/agents/config.server.test.ts
+++ b/happyhq/lib/agents/config.server.test.ts
@@ -389,6 +389,26 @@ describe('planningAgentOptions', () => {
     })
   })
 
+  it('preserves process.env when no override is given', async () => {
+    const original = process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY = 'sk-from-process-env'
+    try {
+      const opts = await planningAgentOptions(
+        'my-stream',
+        'my-task',
+        new AbortController(),
+      )
+      expect(opts.env).toMatchObject({
+        ANTHROPIC_API_KEY: 'sk-from-process-env',
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+        ENABLE_TOOL_SEARCH: 'false',
+      })
+    } finally {
+      if (original === undefined) delete process.env.ANTHROPIC_API_KEY
+      else process.env.ANTHROPIC_API_KEY = original
+    }
+  })
+
   describe('PreToolUse Write/Edit gate', () => {
     type PreHookResult = {
       continue?: boolean

--- a/happyhq/lib/agents/config.server.ts
+++ b/happyhq/lib/agents/config.server.ts
@@ -43,8 +43,12 @@ const claudeExecutable = process.env.Q_PASSWORD
 function agentEnv(
   override?: Record<string, string | undefined>,
 ): Record<string, string | undefined> {
+  // The SDK passes this verbatim as the spawned process's env (no merge with
+  // process.env), so when there's no override we have to spread process.env
+  // ourselves — otherwise ANTHROPIC_API_KEY, HOME, PATH, etc. get stripped
+  // and Claude Code reports "Not logged in".
   return {
-    ...(override ?? {}),
+    ...(override ?? process.env),
     CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
     ENABLE_TOOL_SEARCH: 'false',
   }


### PR DESCRIPTION
Two related fixes for "tasks fail silently a few seconds in" on q-* instances using `ANTHROPIC_API_KEY` env-var auth.

## Bug 1 — `agentEnv` strips `process.env`

`lib/agents/config.server.ts::agentEnv()` returned `{ ...override ?? {}, ...harnessFlags }`. The Agent SDK passes that object as the spawned process's env *verbatim* (replaces, not merges). When `getAuthEnv()` returned `undefined` (the env-var auth path), the spawned Claude Code started with only the two harness flags — no `ANTHROPIC_API_KEY`, no `HOME`, no `PATH` — and errored with "Not logged in · Please run /login".

The OAuth and stored-API-key paths happened to work because `getAuthEnv()` explicitly spreads `process.env` into those override objects before returning. Only the env-var path hit the broken fallback.

Introduced in #143 ("isolate planning agent from CLI harness drift"). Fix: swap the fallback from `{}` to `process.env`.

Regression test added in `config.server.test.ts`: with no override and `ANTHROPIC_API_KEY` set in `process.env`, `planningAgentOptions().env` must contain that key alongside the harness flags.

## Bug 2 — `~/.claude.json` not persisted across machine restarts

The original `CMD` only symlinked the `~/.claude` *directory* to the volume; `~/.claude.json` (the sibling file Claude Code uses for identity, project state, settings) lived on the ephemeral root FS and got wiped on every autostop. Once Bug 1 is fixed, Bug 2 still bites every cold start: Claude Code finds no config file and refuses to start, surfacing as "Claude configuration file not found" on stderr — and because that path bypasses the SDK's structured error stream, the run dies silently with no toast.

Fix: move `HOME` onto the volume (`/data/home`). Both `~/.claude.json` and `~/.claude/` live on persistent storage as plain files. New `docker-entrypoint.sh` migrates from the previous layout on first boot.

## Order of importance

Bug 1 is the active blocker — without it, even a perfectly populated `.claude.json` doesn't help because the SDK strips the API key from the spawned process. Bug 2 prevents a future class of "missing file" failures and removes the silent-fail mode after autostops.

## Test plan

- [x] `pnpm test lib/agents/config.server.test.ts` — passes including the new regression test
- [ ] Deploy to a single instance via `infra/scripts/deploy.sh --app q-<name>`
- [ ] SSH-confirm `$HOME=/data/home`, `~/.claude.json` exists on the volume
- [ ] Start a task end-to-end and confirm it runs without "Not logged in"
- [ ] Force an autostop, restart, repeat — confirm config persists and tasks still start
- [ ] Roll out to remaining q-* instances

## Follow-ups (separate)

- Surface stderr-only spawn failures as a visible task error in the UI (separate issue)
- Update `infra/deploy.md` "Volume layout" section to mention `/data/home/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)