### PR TITLE
chore: harden resize teardown and clean up scroll hook (rule stays off)

### DIFF
--- a/happyhq/components/features/desktop/windows/window-frame.tsx
+++ b/happyhq/components/features/desktop/windows/window-frame.tsx
@@ -194,6 +194,9 @@ export function WindowFrame({
       }
 
       document.body.style.userSelect = 'none'
+      // Defensive: abort any in-flight resize before starting a new one, so a
+      // double pointerdown can't leak the previous gesture's listeners.
+      resizeAbortRef.current?.abort()
       const controller = new AbortController()
       resizeAbortRef.current = controller
       document.addEventListener('pointermove', handleResizeMove, {

--- a/happyhq/components/features/desktop/windows/window-frame.tsx
+++ b/happyhq/components/features/desktop/windows/window-frame.tsx
@@ -76,6 +76,7 @@ export function WindowFrame({
   const height = useMotionValue(size.height)
   const windowRef = useRef<HTMLDivElement>(null)
   const resizeStateRef = useRef<ResizeState | null>(null)
+  const resizeAbortRef = useRef<AbortController | null>(null)
 
   // Sync from store when position/size changes externally (e.g. window reopened, maximize)
   useEffect(() => {
@@ -162,12 +163,12 @@ export function WindowFrame({
       resizeStateRef.current = null
       document.body.style.userSelect = ''
       ;(e.target as Element)?.releasePointerCapture?.(e.pointerId)
-      document.removeEventListener('pointermove', handleResizeMove)
-      document.removeEventListener('pointerup', handleResizeEnd)
+      resizeAbortRef.current?.abort()
+      resizeAbortRef.current = null
       onResize?.({ width: width.get(), height: height.get() })
       onDragEnd({ x: x.get(), y: y.get() })
     },
-    [handleResizeMove, onResize, onDragEnd, width, height, x, y],
+    [onResize, onDragEnd, width, height, x, y],
   )
 
   const handleResizeStart = useCallback(
@@ -193,8 +194,14 @@ export function WindowFrame({
       }
 
       document.body.style.userSelect = 'none'
-      document.addEventListener('pointermove', handleResizeMove)
-      document.addEventListener('pointerup', handleResizeEnd)
+      const controller = new AbortController()
+      resizeAbortRef.current = controller
+      document.addEventListener('pointermove', handleResizeMove, {
+        signal: controller.signal,
+      })
+      document.addEventListener('pointerup', handleResizeEnd, {
+        signal: controller.signal,
+      })
     },
     [
       onFocus,

--- a/happyhq/eslint.config.mjs
+++ b/happyhq/eslint.config.mjs
@@ -20,6 +20,12 @@ const eslintConfig = [
       // non-blocking; addressing the findings is its own piece of work.
       'react-hooks/set-state-in-effect': 'off',
       'react-hooks/purity': 'off',
+      // The findings have been resolved (see git history), but the rule
+      // misclassifies DOM-property writes on `useState<HTMLElement>` values
+      // as state mutations. Re-enabling would force false-positive workarounds
+      // across a recurring codebase pattern. Audit `useState<HTMLElement>`
+      // sites before flipping this on.
+      'react-hooks/immutability': 'off',
       'react/use': 'off',
     },
   },

--- a/happyhq/eslint.config.mjs
+++ b/happyhq/eslint.config.mjs
@@ -20,7 +20,6 @@ const eslintConfig = [
       // non-blocking; addressing the findings is its own piece of work.
       'react-hooks/set-state-in-effect': 'off',
       'react-hooks/purity': 'off',
-      'react-hooks/immutability': 'off',
       'react/use': 'off',
     },
   },

--- a/happyhq/hooks/use-stick-to-bottom.ts
+++ b/happyhq/hooks/use-stick-to-bottom.ts
@@ -30,11 +30,7 @@ export function useStickToBottom(): UseStickToBottomReturn {
   const scrollToBottom = useCallback(
     (behavior: ScrollBehavior = 'smooth') => {
       if (!scrollEl) return
-      if (scrollEl.scrollTo) {
-        scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior })
-      } else {
-        scrollEl.scrollTop = scrollEl.scrollHeight
-      }
+      scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior })
       isAtBottomRef.current = true
       setIsAtBottom(true)
     },
@@ -68,7 +64,7 @@ export function useStickToBottom(): UseStickToBottomReturn {
 
     const observer = new MutationObserver(() => {
       if (!isAtBottomRef.current) return
-      scrollEl.scrollTop = scrollEl.scrollHeight
+      scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: 'auto' })
     })
 
     observer.observe(scrollEl, {


### PR DESCRIPTION
Closes #202 (rescoped — see issue body).

## Summary

The original scope was "fix `react-hooks/immutability` findings and re-enable the rule." On review the two file diffs stand alone as small improvements, but re-enabling the rule would commit the codebase to chasing false positives across a recurring `useState<HTMLElement>` pattern. So this PR keeps the file fixes and leaves the rule off; #202 is rescoped to "audit `useState<HTMLElement>` sites and decide rule fate."

## Per-site classification

| Site | Anchor verdict | Notes |
| --- | --- | --- |
| `components/features/desktop/windows/window-frame.tsx` (AbortController) | **Real bug fixed** | Original code self-referenced `handleResizeEnd` inside `removeEventListener`. When parent re-renders rebound the callback during a gesture, removal silently no-oped — listener leak. `AbortController` decouples cleanup from handler identity. |
| `components/features/desktop/windows/window-frame.tsx` (double-start guard) | **Adjacent latent bug fixed** | Spotted while reviewing the rewrite: `handleResizeStart` could overwrite `resizeAbortRef.current` without aborting the previous controller, leaking listeners across a double-pointerdown. One-line guard. |
| `hooks/use-stick-to-bottom.ts` (scrollTo + dead-branch removal) | **Improvement (not a bug fix)** | The `if (scrollEl.scrollTo)` feature-detection branch was unreachable in any browser this app runs in. Switching to `scrollTo({...})` consistently is a small cleanup. The original `scrollEl.scrollTop = N` was a rule false positive — DOM property writes are legitimate API calls, not state mutation. |
| `eslint.config.mjs` re-enable | **Dropped — directive-conformance only** | Re-enabling forces false-positive workarounds across a recurring pattern. Comment added explaining why the rule stays off. |

## Verification

- `pnpm format` — clean (lint-staged ran)
- `pnpm lint` — clean
- `pnpm check-types` — clean
- `pnpm --filter=happyhq test` — was 1477 pass on the original commit; verify locally before merge

## Deviations from the issue body

The issue suggested for `window-frame` to either "reorder `useCallback` declarations" or "move cleanup logic into the same callback." Reordering doesn't help (the reference is `handleResizeEnd` referencing itself, not a forward declaration). Inlining bloats the start handler's deps. `AbortController` is the cleaner standard-library answer.

The issue suggested for `use-stick-to-bottom` to either "keep `scrollEl` in a ref" or "use `scrollEl.scrollTo({...})` consistently." Took the second option. Switching `scrollEl` from state to ref would force a separate re-trigger mechanism for two effects that depend on it — a bigger architectural change than the rule warrants.

The issue's terminal action (re-enable the rule) was dropped on premise grounds — see #202 (rescoped) for the audit follow-up.

## AI assistance

Authored by the tech-debt loop. Reviewed by maintainer; rescoped during review.