### PR TITLE
chore: resolve react-hooks/purity findings and re-enable rule

### DIFF
--- a/happyhq/components/common/ui/sidebar.tsx
+++ b/happyhq/components/common/ui/sidebar.tsx
@@ -657,10 +657,11 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<'div'> & {
   showIcon?: boolean
 }) {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
-  }, [])
+  // Random width between 50 to 90%. useState (not useMemo) so the value can't
+  // shift if React evicts the memo cache and re-runs the factory.
+  const [width] = React.useState(
+    () => `${Math.floor(Math.random() * 40) + 50}%`,
+  )
 
   return (
     <div

--- a/happyhq/components/features/billing/use-billing-data.test.tsx
+++ b/happyhq/components/features/billing/use-billing-data.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { UsageData } from './use-billing-data'
 
@@ -156,5 +156,57 @@ describe('useBillingData', () => {
     render(<TestComponent />)
     expect(result!.remainingMinutes).toBe(0)
     expect(result!.remainingPercent).toBe(0)
+  })
+
+  it('switches to the next billing period when the boundary crosses while mounted', async () => {
+    // Boundary at T+30s. Period A ends at the boundary; Period B starts at it.
+    const start = Date.now()
+    const boundary = start + 30_000
+
+    mockUseCurrentUser.mockReturnValue({
+      user: { id: 'user-1', email: 'test@example.com', createdAt: 0 },
+      isLoading: false,
+      isAuthenticated: true,
+    })
+    mockUseQuery.mockReturnValue({
+      data: {
+        subscriptions: [{ id: 'sub-1', tier: 'starter', status: 'active' }],
+        usage: [
+          {
+            id: 'period-a',
+            periodStart: start - 86_400_000,
+            periodEnd: boundary,
+            usedMinutes: 50,
+            includedMinutes: 60,
+          },
+          {
+            id: 'period-b',
+            periodStart: boundary,
+            periodEnd: start + 86_400_000,
+            usedMinutes: 5,
+            includedMinutes: 60,
+          },
+        ],
+      },
+    })
+
+    const { useBillingData } = await import('./use-billing-data')
+    let result: UsageData | null | undefined
+
+    function TestComponent() {
+      result = useBillingData()
+      return null
+    }
+
+    render(<TestComponent />)
+    // Initial render is inside Period A.
+    expect(result!.usedMinutes).toBe(50)
+
+    // Advance past the boundary and let the 60s tick fire — the hook should
+    // re-derive `now` and switch to Period B.
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+    expect(result!.usedMinutes).toBe(5)
   })
 })

--- a/happyhq/components/features/billing/use-billing-data.ts
+++ b/happyhq/components/features/billing/use-billing-data.ts
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+
 import { getTierLimits } from '@/ee/lib/billing/plans'
 import type { TierName } from '@/ee/lib/billing/types'
 import { useCurrentUser } from '@/lib/accounts/hooks'
@@ -40,7 +42,14 @@ export function useBillingData(): UsageData | null {
   const currentTier: TierName = (activeSubscription?.tier as TierName) ?? 'free'
   const tierLimits = getTierLimits(currentTier)
 
-  const now = Date.now()
+  // Re-evaluate the active period periodically so the meter switches over when
+  // a billing period boundary crosses while the page is open.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [])
+
   const currentUsage = usageRecords.find(
     (u: { periodStart: string | number; periodEnd: string | number }) =>
       Number(u.periodStart) <= now && Number(u.periodEnd) >= now,

--- a/happyhq/components/features/billing/use-billing-data.ts
+++ b/happyhq/components/features/billing/use-billing-data.ts
@@ -7,6 +7,9 @@ import type { TierName } from '@/ee/lib/billing/types'
 import { useCurrentUser } from '@/lib/accounts/hooks'
 import { db } from '@/lib/database/instant'
 
+// Cadence for re-checking the active billing period (see `now` state below).
+const PERIOD_TICK_MS = 60_000
+
 export type UsageData = {
   currentTier: TierName
   usedMinutes: number
@@ -43,10 +46,12 @@ export function useBillingData(): UsageData | null {
   const tierLimits = getTierLimits(currentTier)
 
   // Re-evaluate the active period periodically so the meter switches over when
-  // a billing period boundary crosses while the page is open.
+  // a billing period boundary crosses while the page is open. Cadence is
+  // sub-minute because monthly boundaries don't need higher precision and the
+  // re-render is cheap.
   const [now, setNow] = useState(() => Date.now())
   useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 60_000)
+    const id = setInterval(() => setNow(Date.now()), PERIOD_TICK_MS)
     return () => clearInterval(id)
   }, [])
 

--- a/happyhq/components/features/settings/usage-settings.tsx
+++ b/happyhq/components/features/settings/usage-settings.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+
 import { Link } from '@/components/common/catalyst/link'
 import { getTierLimits } from '@/ee/lib/billing/plans'
 import type { TierName } from '@/ee/lib/billing/types'
@@ -34,8 +36,14 @@ export function UsageSettings() {
   const currentTier: TierName = (activeSubscription?.tier as TierName) ?? 'free'
   const tierLimits = getTierLimits(currentTier)
 
-  // Find the current usage period (the one covering now)
-  const now = Date.now()
+  // Re-evaluate the active period periodically so the meter switches over when
+  // a billing period boundary crosses while the page is open.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [])
+
   const currentUsage = usageRecords.find(
     (u: { periodStart: string | number; periodEnd: string | number }) =>
       Number(u.periodStart) <= now && Number(u.periodEnd) >= now,

--- a/happyhq/components/features/settings/usage-settings.tsx
+++ b/happyhq/components/features/settings/usage-settings.tsx
@@ -9,6 +9,9 @@ import { useCurrentUser } from '@/lib/accounts/hooks'
 import { db } from '@/lib/database/instant'
 import { formatMinutes, formatPrice } from '@/lib/format'
 
+// Cadence for re-checking the active billing period (see `now` state below).
+const PERIOD_TICK_MS = 60_000
+
 /**
  * Usage settings — shows current plan and runtime usage meter.
  * Extracted from BillingSettings so usage has its own page.
@@ -37,10 +40,12 @@ export function UsageSettings() {
   const tierLimits = getTierLimits(currentTier)
 
   // Re-evaluate the active period periodically so the meter switches over when
-  // a billing period boundary crosses while the page is open.
+  // a billing period boundary crosses while the page is open. Cadence is
+  // sub-minute because monthly boundaries don't need higher precision and the
+  // re-render is cheap.
   const [now, setNow] = useState(() => Date.now())
   useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 60_000)
+    const id = setInterval(() => setNow(Date.now()), PERIOD_TICK_MS)
     return () => clearInterval(id)
   }, [])
 

--- a/happyhq/eslint.config.mjs
+++ b/happyhq/eslint.config.mjs
@@ -19,14 +19,12 @@ const eslintConfig = [
       // (via eslint-config-next 16). Disabled to land the toolchain upgrade
       // non-blocking; addressing the findings is its own piece of work.
       'react-hooks/set-state-in-effect': 'off',
-      'react-hooks/purity': 'off',
       // The findings have been resolved (see git history), but the rule
       // misclassifies DOM-property writes on `useState<HTMLElement>` values
       // as state mutations. Re-enabling would force false-positive workarounds
       // across a recurring codebase pattern. Audit `useState<HTMLElement>`
       // sites before flipping this on.
       'react-hooks/immutability': 'off',
-      'react/use': 'off',
     },
   },
 ]


### PR DESCRIPTION
Closes #203

## Summary

Three sites called impure functions during render (`Math.random()` for a sidebar skeleton width; `Date.now()` in two billing-period lookups). Render is supposed to be deterministic so React can re-run it freely; the billing-period case in particular could plausibly misbehave on a clock crossing. Each site is fixed and the rule is re-enabled.

## Per-site classification

| Site | Verdict | Notes |
| --- | --- | --- |
| `components/common/ui/sidebar.tsx` (skeleton width: `useMemo` → `useState` initializer) | **Improvement (low-impact)** | `useMemo`'s cache can be evicted; `useState`'s initializer runs exactly once per mount. Technically more correct under React's contract. For a skeleton bar where flicker is invisible, the practical impact is near zero — but the cost was tiny so fine to do. |
| `components/features/billing/use-billing-data.ts` (`Date.now()` + 60s interval) | **Real bug fixed** | Without the tick, the meter shows the previous billing period until something else triggers a re-render. User holds the page open across midnight UTC on the 1st, sees stale data. |
| `components/features/settings/usage-settings.tsx` (same pattern) | **Real bug fixed** | Same shape as above. |
| `eslint.config.mjs` re-enable `react-hooks/purity` | **Improvement** | Unlike `react-hooks/immutability`, this rule catches real bugs (impure reads during render) and doesn't have a recurring false-positive pattern in this codebase. |
| `eslint.config.mjs` remove `'react/use': 'off'` | **Improvement** | Dead config line — no rule by that name exists. |

## Adjacent latent issues / follow-ups

- **Pre-existing duplication surfaced louder by this PR:** `useBillingData` and `UsageSettings` already had near-identical billing-query + tier-limits + period-find logic. Now they each carry their own `setInterval`. Two timers ticking out of phase doing the same thing. Out of scope for this PR; filed as a follow-up `tech-debt` issue.

## Improvements from review

- Replaced the magic `60_000` with a named `PERIOD_TICK_MS` constant in both files, with a one-line rationale (monthly boundaries don't need sub-minute precision; re-render is cheap).
- Added a fake-timers test (`use-billing-data.test.tsx`) pinning the boundary-crossing contract: render inside Period A, advance time past the boundary + tick the interval, expect Period B's `usedMinutes`. Catches a future "someone refactors the cadence and breaks the period switch" regression.

## Verification

- `pnpm format` — clean (lint-staged ran)
- `pnpm lint` — clean with `react-hooks/purity` active (was 3 errors before)
- `pnpm check-types` — clean
- `pnpm --filter=happyhq test` — all pass, including the new boundary-crossing test

## Deviations from the issue body

None of substance. The body proposed three buckets (compute in initializer, drive via `setInterval`, move into event handlers/effects); the first two applied here as written.

## AI assistance

Authored by the tech-debt loop; reviewed and tightened by maintainer (named constant, boundary test, follow-up issue).