### PR TITLE
chore: replace open/search reset effects with key-based remount

### DIFF
--- a/happyhq/components/features/command-menu/pages/url-input-page.tsx
+++ b/happyhq/components/features/command-menu/pages/url-input-page.tsx
@@ -106,8 +106,102 @@ export function UrlInputPage({
   onActionChange,
 }: UrlInputPageProps) {
   const isTopicInput = source === 'research-topic'
+
+  if (isTopicInput) {
+    return (
+      <TopicInputView
+        search={search}
+        onSubmit={onSubmit}
+        onActionChange={onActionChange}
+      />
+    )
+  }
+
+  // Remount on every new search value so previously-fetched unfurl state
+  // can't render against the wrong URL — structural reset replaces an effect.
+  return (
+    <UrlPreviewView
+      key={search}
+      source={source}
+      search={search}
+      onSubmit={onSubmit}
+      onActionChange={onActionChange}
+    />
+  )
+}
+
+interface TopicInputViewProps {
+  search: string
+  onSubmit: (url: string, unfurl: UnfurlResult | null) => void
+  onActionChange?: (action: UrlInputAction) => void
+}
+
+function TopicInputView({
+  search,
+  onSubmit,
+  onActionChange,
+}: TopicInputViewProps) {
+  const config = SOURCE_CONFIGS['research-topic']
   const hasInput = search.trim().length > 0
-  const isValid = isTopicInput ? hasInput : isValidUrl(search)
+
+  useEffect(() => {
+    if (!onActionChange) return
+    if (!hasInput) {
+      onActionChange({ type: 'disabled' })
+    } else {
+      onActionChange({ type: 'submit', onAction: () => onSubmit(search, null) })
+    }
+  }, [hasInput, onActionChange, onSubmit, search])
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center p-6">
+      {hasInput ? (
+        <div className="text-center">
+          <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-blue-100">
+            <Search className="size-6 text-blue-600" />
+          </div>
+          <p className="text-sm font-medium text-zinc-900">
+            Research: {search}
+          </p>
+        </div>
+      ) : (
+        <div className="max-w-sm text-center">
+          <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-blue-100">
+            <Search className="size-6 text-blue-600" />
+          </div>
+          <p className="text-sm font-medium text-zinc-900">{config.title}</p>
+          <p className="mt-2 text-sm text-zinc-500">{config.description}</p>
+          <div className="mt-4 flex flex-wrap justify-center gap-2">
+            {config.examples.map((example) => (
+              <span
+                key={example}
+                className="rounded-full bg-zinc-100 px-2.5 py-1 text-xs text-zinc-600"
+              >
+                {example}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface UrlPreviewViewProps {
+  source: string
+  search: string
+  onSubmit: (url: string, unfurl: UnfurlResult | null) => void
+  onActionChange?: (action: UrlInputAction) => void
+}
+
+function UrlPreviewView({
+  source,
+  search,
+  onSubmit,
+  onActionChange,
+}: UrlPreviewViewProps) {
+  const hasInput = search.trim().length > 0
+  const isValid = isValidUrl(search)
 
   const [unfurlData, setUnfurlData] = useState<UnfurlResult | null>(null)
   const [unfurlError, setUnfurlError] = useState(false)
@@ -117,18 +211,9 @@ export function UrlInputPage({
   const config = SOURCE_CONFIGS[source] || SOURCE_CONFIGS['save-link']
   const Icon = config.icon
 
-  useEffect(() => {
-    // Reset preview state when the search input changes — previously fetched
-    // unfurl data is now stale and would render against the wrong URL.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setUnfurlData(null)
-    setUnfurlError(false)
-    setHasPreviewed(false)
-  }, [search])
-
   // Fetch unfurl data
   const fetchPreview = () => {
-    if (!isTopicInput && isValid && !hasPreviewed) {
+    if (isValid && !hasPreviewed) {
       const url = search.trim()
       setHasPreviewed(true)
 
@@ -154,17 +239,6 @@ export function UrlInputPage({
   useEffect(() => {
     if (!onActionChange) return
 
-    // For topics: just submit when valid
-    if (isTopicInput) {
-      if (!isValid) {
-        onActionChange({ type: 'disabled' })
-      } else {
-        onActionChange({ type: 'submit', onAction: handleSubmit })
-      }
-      return
-    }
-
-    // For URLs: preview → loading → submit flow
     if (!isValid) {
       onActionChange({ type: 'disabled' })
     } else if (!hasPreviewed) {
@@ -174,43 +248,7 @@ export function UrlInputPage({
     } else {
       onActionChange({ type: 'submit', onAction: handleSubmit })
     }
-  }, [isTopicInput, isValid, hasPreviewed, isPending, search])
-
-  // Topic input view
-  if (isTopicInput) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center p-6">
-        {hasInput ? (
-          <div className="text-center">
-            <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-blue-100">
-              <Search className="size-6 text-blue-600" />
-            </div>
-            <p className="text-sm font-medium text-zinc-900">
-              Research: {search}
-            </p>
-          </div>
-        ) : (
-          <div className="max-w-sm text-center">
-            <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-blue-100">
-              <Search className="size-6 text-blue-600" />
-            </div>
-            <p className="text-sm font-medium text-zinc-900">{config.title}</p>
-            <p className="mt-2 text-sm text-zinc-500">{config.description}</p>
-            <div className="mt-4 flex flex-wrap justify-center gap-2">
-              {config.examples.map((example) => (
-                <span
-                  key={example}
-                  className="rounded-full bg-zinc-100 px-2.5 py-1 text-xs text-zinc-600"
-                >
-                  {example}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    )
-  }
+  }, [isValid, hasPreviewed, isPending, search])
 
   // Determine card state
   const isEmpty = !hasInput

--- a/happyhq/components/features/tasks/create/dialog.tsx
+++ b/happyhq/components/features/tasks/create/dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { useSidebarOptional } from '@/components/common/ui/sidebar'
 import { FileRow } from '@/components/features/desktop/windows/shared/file-row'
@@ -25,6 +25,29 @@ export function TaskCreateDialog({
   open: boolean
   onClose: () => void
 }) {
+  // Bump a key each time the dialog opens so the inner shell remounts with
+  // fresh form state — structural reset replaces a setState-in-effect that
+  // had to hedge for both "Headless UI unmounts its children" and "consumer
+  // keeps them mounted during the close transition." The "adjust state during
+  // render" pattern is the canonical alternative to a derived useEffect (see
+  // https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes).
+  const [mountId, setMountId] = useState(0)
+  const [prevOpen, setPrevOpen] = useState(open)
+  if (open !== prevOpen) {
+    setPrevOpen(open)
+    if (open) setMountId((id) => id + 1)
+  }
+
+  return <TaskCreateDialogShell key={mountId} open={open} onClose={onClose} />
+}
+
+function TaskCreateDialogShell({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: () => void
+}) {
   const sidebar = useSidebarOptional()
   const streams = useStreams()
   const { mutate } = useSWRConfig()
@@ -33,30 +56,11 @@ export function TaskCreateDialog({
   const [description, setDescription] = useState('')
   const [selectedStream, setSelectedStream] = useState<string | null>(null)
   const [isCreating, setIsCreating] = useState(false)
-  const {
-    stagedFiles,
-    fileInputRef,
-    addFiles,
-    removeFile,
-    clearFiles,
-    openFilePicker,
-  } = useFileStaging()
+  const { stagedFiles, fileInputRef, addFiles, removeFile, openFilePicker } =
+    useFileStaging()
   const { isDragOver, dragHandlers } = useFileDrop(addFiles)
 
   const canSubmit = title.trim().length > 0
-
-  useEffect(() => {
-    if (open) {
-      // Reset the new-task form each time the dialog (re)opens so the next
-      // user sees a clean slate, regardless of whether the underlying Dialog
-      // unmounts its children between opens.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setTitle('')
-      setDescription('')
-      setSelectedStream(null)
-      clearFiles()
-    }
-  }, [open, clearFiles])
 
   const handleClose = () => {
     if (!isCreating) onClose()


### PR DESCRIPTION
Closes #219

## Summary

The new-task dialog and the URL-input preview both used a `setState`-in-`useEffect` to reset child state when a prop flipped (`open` / `search`). Both carried a per-line `eslint-disable react-hooks/set-state-in-effect` plus a hedge about whether Headless UI keeps its consumers mounted during transitions. Replace each with the structural ["resetting all state when a prop changes"](https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes) pattern from the React docs:

- **`url-input-page.tsx`** — split the URL flow into a `UrlPreviewView` child component owning the unfurl state (`unfurlData` / `unfurlError` / `hasPreviewed` / `isPending`) and key it on `search`. Each new search value remounts → state is fresh by construction. The topic flow has no resettable state and is now its own small `TopicInputView` for symmetry.
- **`tasks/create/dialog.tsx`** — wrap the existing dialog body in a keyed `TaskCreateDialogShell`. The outer `TaskCreateDialog` bumps a mount key when `open` transitions `false → true` using the "adjust state during render" pattern. The key only bumps on open, so the close transition still gets to render the populated form contents — the exact behavior the original `if (open) { ... reset ... }` guard was preserving.

## Per-site classification

| Site | Verdict | Rationale |
| --- | --- | --- |
| `url-input-page.tsx` reset effect on `search` | Improvement | Effectful reset replaced with structural reset; topic vs URL flow now cleanly separated; per-line disable removed. |
| `tasks/create/dialog.tsx` reset effect on `open` | Improvement | Effectful reset replaced with structural reset; close transition preserved by only bumping the key on `false → true`; per-line disable removed. |

Both sites pass the "this change improves the code" anchor — the new shape is what the React docs prescribe for this exact pattern, and the eslint-disable goes away as a side effect of the structural fix rather than as the goal.

## Deviations from the issue body

- The body suggested `key={open ? mountId : 'closed'}` on the form body or `{open && <Form />}` for the dialog. The first requires either a parent change (passing `mountId` down) or a `useEffect`-based bump (defeats the point). The second unmounts the form contents instantly on close, which would render an empty card scaling out during the 100ms exit transition. Chose instead to wrap the dialog in an outer keyed shell that uses "adjust state during render" to bump the key on open transitions only — keeps the parent (`sidebar.tsx`) untouched and preserves the close transition.
- The body suggested `<UnfurlPreview>` as the extracted child. Used `UrlPreviewView` because the extracted scope is not just the preview card but the entire non-topic render (centered message + card), and the topic flow is a sibling `TopicInputView`.

## Adjacent latent issues filed

None filed yet — but `components/features/command-menu/command-menu.tsx:61-68` carries the same shape (`useEffect` + `setUrlInputAction({ type: 'disabled' })` when `page?.type` changes, with the same per-line `eslint-disable`). That's the parent side of the same pattern, and probably worth a follow-up. Not widening this PR to cover it; will let the maintainer decide whether to file or whether the existing rubric in #219 covers it.

## Verification

- `pnpm format` ✅
- `pnpm lint` ✅ (rule `react-hooks/set-state-in-effect` stays active; two per-line disables removed)
- `pnpm check-types` ✅
- `pnpm --filter=happyhq test` ✅ (122 files, 1467 tests passing)

No new tests added: both changes preserve the externally observable behavior the existing reset effects produced (form starts blank on open; preview starts blank on new search). The pattern change is structural, not behavioral, and the litmus test from `testing.md` ("what bug would this catch?") yields "someone reverted this exact line" — a vanity test.

## AI assistance

Authored by the tech-debt loop. Reviewed by maintainer before merge.