### PR TITLE
chore: add 'pattern fit, not pattern match' to bugs rubric

### DIFF
--- a/happyhq/.dev/bugs-rubric.md
+++ b/happyhq/.dev/bugs-rubric.md
@@ -112,6 +112,8 @@ These are guidance, not gates. The rubric above is pass/fail; these tune _how_ t
 
 **Look around before you write.** Before drafting a fix or skip, scan for prior art on the concern: existing consumers/handlers of the same data shape, recent open/closed issues with the same shape, in-flight PRs touching the same surface, specs documenting the affected behavior. Anchor the work to what's already there. Most "we keep fixing this" pain comes from rederiving in isolation when a reference exists that would have constrained the fix.
 
+**Pattern fit, not pattern match.** Think about the most appropriate decision factoring in the user experience and the developer experience. Simple, maintainable, understandable. If prior art fits, follow it. If it doesn't, don't scope-creep to make it fit — do the right thing for the context.
+
 **A fix isn't just the diff.** Leave the surrounding system coherent. If the fix changes documented behavior, update the spec/doc in the same PR. If you notice a pattern that spans multiple recent issues, surface it for the maintainer rather than fixing one instance silently. If you skip, leave a rationale specific enough that a human can act on it without re-investigating.
 
 **Tests defend behavior, not lines.** Apply `testing.md`'s litmus test before adding a regression test: "what bug would this catch?" If the only answer is "someone reverted this exact line" — asserting a hardcoded asset path, a class name, copy text, or that a specific element exists — it's a vanity test that locks in implementation. Skip it. Asset swaps, copy tweaks, and CSS-only fixes are visually verified, not test-locked. A good regression test would still catch the bug under any reasonable reimplementation; a vanity test only catches the literal revert.


### PR DESCRIPTION
## Summary

Adds a new Principle to [happyhq/.dev/bugs-rubric.md](happyhq/.dev/bugs-rubric.md) covering when to mirror prior art and when not to.

## Why

Logged after reviewing the fix on `fix/216-surface-stderr-failures`, where a foreground chat handler (toast + redirect to `/setup` on `auth_error`) was copied verbatim into a background run-loop path. The redirect made sense in chat but yanked the user out of context during a background run. The general lesson — pattern-match the shape, but only follow the behavior when the context fits — wasn't captured anywhere in the rubric.

The new principle sits between "Look around before you write" (which says to scan for prior art) and "A fix isn't just the diff" (which says to leave the system coherent). It tunes the first one: prior art is the starting point, not the answer.

## Test plan

- [x] Read the new bullet in context — it should match the register and length of the surrounding principles.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — interactive session with the maintainer, not a Ralphie autonomous run.