### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ Thumbs.db
 
 # Claude Code user-local overrides
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Spec reference images
 happyhq/specs/refs/


### PR DESCRIPTION
Stale lock file Claude Code drops next to the already-ignored `settings.local.json` — keeps showing up in `git status` after every session. One-line addition to `.gitignore`.