### PR TITLE
fix(deploy): bundle Agent SDK platform binary in standalone build

### DIFF
--- a/happyhq/Dockerfile
+++ b/happyhq/Dockerfile
@@ -56,10 +56,6 @@ FROM node:20-alpine AS runtime
 # git: required by instrumentation.ts (git init) and lib/git/sync.server.ts
 RUN apk add --no-cache git bash
 
-# Claude Code CLI — required for `claude auth login` and `claude auth status`.
-# Pin to the version bundled in claude-agent-sdk to avoid behavior drift.
-RUN npm install -g @anthropic-ai/claude-code@2.1.92
-
 # standalone output mirrors monorepo structure:
 #   .next/standalone/
 #   ├── node_modules/

--- a/happyhq/lib/agents/config.server.ts
+++ b/happyhq/lib/agents/config.server.ts
@@ -28,11 +28,6 @@ import {
 import { buildLearningReminders } from './reminders.server'
 import { createQsMcpServer, MCP_SERVER_NAME, mcpToolName } from './tools.server'
 
-/** In Docker the standalone build strips node_modules; point to the global install. */
-const claudeExecutable = process.env.Q_PASSWORD
-  ? '/usr/local/bin/claude'
-  : undefined
-
 /**
  * Env vars that suppress Claude Code CLI harness behaviors we don't want
  * leaking into our agents: project-memory auto-loading (MEMORY.md) and
@@ -233,7 +228,6 @@ export async function learningAgentOptions(
         maxTurns: 10,
       },
     },
-    ...(claudeExecutable && { pathToClaudeCodeExecutable: claudeExecutable }),
     ...(opts?.abortController && { abortController: opts.abortController }),
     // New session: set sessionId. Resume: set resume to the session ID.
     ...(opts?.resume ? { resume: sessionId } : { sessionId }),
@@ -421,7 +415,6 @@ export async function chatAgentOptions(params: {
             },
           }
         : {},
-    ...(claudeExecutable && { pathToClaudeCodeExecutable: claudeExecutable }),
     ...(params.abortController && { abortController: params.abortController }),
     ...(params.resume ? { resume: sessionId } : { sessionId }),
   }
@@ -541,7 +534,6 @@ export async function planningAgentOptions(
         },
       ],
     },
-    ...(claudeExecutable && { pathToClaudeCodeExecutable: claudeExecutable }),
     ...(opts?.sessionId && { sessionId: opts.sessionId }),
   }
 }
@@ -619,7 +611,6 @@ export async function workingAgentOptions(
         },
       ],
     },
-    ...(claudeExecutable && { pathToClaudeCodeExecutable: claudeExecutable }),
     ...(opts?.sessionId && { sessionId: opts.sessionId }),
   }
 }

--- a/happyhq/next.config.ts
+++ b/happyhq/next.config.ts
@@ -4,6 +4,14 @@ const nextConfig: NextConfig = {
   output: 'standalone',
   reactStrictMode: false,
   serverExternalPackages: ['@hyzyla/pdfium'],
+  // The Agent SDK loads its CLI binary from a platform-specific package whose
+  // name is computed at runtime (`@anthropic-ai/claude-agent-sdk-${platform}-${arch}`).
+  // Next's static tracer can't follow that, so the package gets stripped from
+  // the standalone output. Force-include all platform variants so the deployed
+  // image always has the binary that matches the resolved SDK version.
+  outputFileTracingIncludes: {
+    '*': ['../node_modules/.pnpm/@anthropic-ai+claude-agent-sdk-*/**'],
+  },
   images: {
     remotePatterns: [
       {

--- a/happyhq/next.config.ts
+++ b/happyhq/next.config.ts
@@ -9,6 +9,10 @@ const nextConfig: NextConfig = {
   // Next's static tracer can't follow that, so the package gets stripped from
   // the standalone output. Force-include all platform variants so the deployed
   // image always has the binary that matches the resolved SDK version.
+  //
+  // Known minor over-install: on Alpine builds, pnpm installs both linux-x64
+  // and linux-x64-musl variants because optional-deps can't disambiguate libc.
+  // Tracked: https://github.com/happyhqdotcom/happyhq/issues/226
   outputFileTracingIncludes: {
     '*': ['../node_modules/.pnpm/@anthropic-ai+claude-agent-sdk-*/**'],
   },

--- a/happyhq/package.json
+++ b/happyhq/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
-    "build": "next build && node scripts/check-standalone-sdk-binary.mjs",
+    "build": "next build && node scripts/repair-standalone-symlinks.mjs && node scripts/check-standalone-sdk-binary.mjs",
     "start": "next start",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",

--- a/happyhq/package.json
+++ b/happyhq/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && node scripts/check-standalone-sdk-binary.mjs",
     "start": "next start",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",
@@ -16,7 +16,7 @@
     "db:push": "pnpm dlx instant-cli push schema && pnpm dlx instant-cli push perms"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+    "@anthropic-ai/claude-agent-sdk": "0.2.114",
     "@headlessui/react": "^2.2.9",
     "@hyzyla/pdfium": "^2.1.6",
     "@instantdb/admin": "^0.22.155",

--- a/happyhq/scripts/check-standalone-sdk-binary.mjs
+++ b/happyhq/scripts/check-standalone-sdk-binary.mjs
@@ -43,7 +43,40 @@ for (const pkg of platformPkgs) {
   try {
     statSync(binary)
   } catch {
-    console.error(`Platform package ${pkg} is present but binary missing at ${binary}`)
+    console.error(
+      `Platform package ${pkg} is present but binary missing at ${binary}`,
+    )
+    process.exit(1)
+  }
+}
+
+// Verify the SDK wrapper can actually resolve the platform package via Node's
+// resolver — i.e., the pnpm symlinks survived the standalone copy. The package
+// files being present on disk isn't enough; the SDK does
+// `require('@anthropic-ai/claude-agent-sdk-${platform}-${arch}')` and that
+// fails silently if the symlinks were dropped.
+const wrapperPkgs = entries.filter((d) =>
+  /^@anthropic-ai\+claude-agent-sdk@/.test(d),
+)
+for (const wrapper of wrapperPkgs) {
+  const wrapperAtNs = join(PNPM_DIR, wrapper, 'node_modules', '@anthropic-ai')
+  let entriesUnder
+  try {
+    entriesUnder = readdirSync(wrapperAtNs)
+  } catch {
+    console.error(`SDK wrapper missing @anthropic-ai dir: ${wrapperAtNs}`)
+    process.exit(1)
+  }
+  const platformLinks = entriesUnder.filter((e) =>
+    e.startsWith('claude-agent-sdk-'),
+  )
+  if (platformLinks.length === 0) {
+    console.error(
+      `SDK wrapper ${wrapper} has no platform-binary symlinks under @anthropic-ai/.`,
+    )
+    console.error(
+      `Found: ${entriesUnder.join(', ')}. Run scripts/repair-standalone-symlinks.mjs.`,
+    )
     process.exit(1)
   }
 }

--- a/happyhq/scripts/check-standalone-sdk-binary.mjs
+++ b/happyhq/scripts/check-standalone-sdk-binary.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Verifies the Agent SDK's platform-specific binary package made it into the
+// standalone build output. This catches a regression class where Next's static
+// dependency tracer drops `@anthropic-ai/claude-agent-sdk-${platform}-${arch}`
+// (the package name is computed at runtime so the tracer can't see it). When
+// the package is missing the SDK fails at runtime with "Native CLI binary for
+// <platform> not found", or — worse — silently uses a mismatched CLI elsewhere
+// on PATH and the model behavior diverges from what the SDK expects.
+
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const PNPM_DIR = '.next/standalone/node_modules/.pnpm'
+
+let entries
+try {
+  entries = readdirSync(PNPM_DIR)
+} catch {
+  console.error(`Standalone build not found at ${PNPM_DIR}. Did 'next build' run?`)
+  process.exit(1)
+}
+
+const platformPkgs = entries.filter((d) =>
+  /^@anthropic-ai\+claude-agent-sdk-[a-z0-9-]+@/.test(d),
+)
+
+if (platformPkgs.length === 0) {
+  console.error(
+    `No @anthropic-ai/claude-agent-sdk-<platform> package in ${PNPM_DIR}.`,
+  )
+  console.error(
+    `Check outputFileTracingIncludes in next.config.ts — the Agent SDK's `,
+  )
+  console.error(`platform binary is required and computed at runtime.`)
+  process.exit(1)
+}
+
+for (const pkg of platformPkgs) {
+  const m = pkg.match(/^(@anthropic-ai\+claude-agent-sdk-[a-z0-9-]+)@/)
+  if (!m) continue
+  const inner = m[1].replace('+', '/')
+  const binary = join(PNPM_DIR, pkg, 'node_modules', inner, 'claude')
+  try {
+    statSync(binary)
+  } catch {
+    console.error(`Platform package ${pkg} is present but binary missing at ${binary}`)
+    process.exit(1)
+  }
+}
+
+console.log(`SDK platform binary present in standalone: ${platformPkgs.join(', ')}`)

--- a/happyhq/scripts/repair-standalone-symlinks.mjs
+++ b/happyhq/scripts/repair-standalone-symlinks.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Repair pnpm symlinks the Next.js standalone tracer drops.
+//
+// pnpm sets up the SDK wrapper's `node_modules/@anthropic-ai/` with symlinks
+// to its dependencies (including the platform-specific `claude-agent-sdk-*`
+// package that the SDK loads at runtime). Next's standalone copy follows the
+// files but doesn't preserve those symlinks, leaving the wrapper unable to
+// resolve its own optional dep — even when `outputFileTracingIncludes` has
+// pulled the target package into the standalone's `.pnpm/`.
+//
+// This script walks the standalone's `.pnpm/` directory and rebuilds the
+// missing intra-`.pnpm` symlinks so Node's resolver can follow them again.
+
+import {
+  existsSync,
+  readdirSync,
+  readlinkSync,
+  symlinkSync,
+  unlinkSync,
+} from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+
+const STANDALONE_PNPM = '.next/standalone/node_modules/.pnpm'
+
+if (!existsSync(STANDALONE_PNPM)) {
+  console.error(`Standalone .pnpm dir not found at ${STANDALONE_PNPM}`)
+  process.exit(1)
+}
+
+const pnpmEntries = readdirSync(STANDALONE_PNPM)
+let repaired = 0
+
+// For each platform-specific SDK package present in the standalone, ensure the
+// SDK wrapper package(s) have a symlink pointing at it.
+const platformPkgs = pnpmEntries.filter((d) =>
+  /^@anthropic-ai\+claude-agent-sdk-[a-z0-9-]+@/.test(d),
+)
+const wrapperPkgs = pnpmEntries.filter((d) =>
+  /^@anthropic-ai\+claude-agent-sdk@/.test(d),
+)
+
+if (platformPkgs.length === 0) {
+  console.error(
+    'No platform-specific @anthropic-ai/claude-agent-sdk-* in standalone',
+  )
+  process.exit(1)
+}
+if (wrapperPkgs.length === 0) {
+  console.error('No @anthropic-ai/claude-agent-sdk wrapper in standalone')
+  process.exit(1)
+}
+
+for (const wrapper of wrapperPkgs) {
+  const wrapperAtNs = join(
+    STANDALONE_PNPM,
+    wrapper,
+    'node_modules',
+    '@anthropic-ai',
+  )
+  if (!existsSync(wrapperAtNs)) continue
+
+  for (const platform of platformPkgs) {
+    const m = platform.match(/^(@anthropic-ai\+claude-agent-sdk-[a-z0-9-]+)@/)
+    if (!m) continue
+    const innerName = m[1].replace('+', '/').split('/')[1]
+    const linkName = innerName
+    const linkAt = join(wrapperAtNs, linkName)
+    const target = join(
+      STANDALONE_PNPM,
+      platform,
+      'node_modules',
+      '@anthropic-ai',
+      innerName,
+    )
+
+    if (!existsSync(target)) continue
+    const relTarget = relative(dirname(linkAt), target)
+
+    // Remove any stale entry (file/symlink) before re-linking.
+    try {
+      const existingLink = readlinkSync(linkAt)
+      if (existingLink === relTarget) continue // already correct
+      unlinkSync(linkAt)
+    } catch {
+      // not a symlink or doesn't exist — fine
+      try {
+        unlinkSync(linkAt)
+      } catch {
+        // doesn't exist
+      }
+    }
+
+    symlinkSync(relTarget, linkAt)
+    repaired += 1
+  }
+}
+
+console.log(`Repaired ${repaired} pnpm symlink(s) in standalone`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
   happyhq:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.92
+        specifier: 0.2.114
         version: 0.2.114(zod@4.4.2)
       '@headlessui/react':
         specifier: ^2.2.9


### PR DESCRIPTION
## Why this matters

Planning runs on every q-* instance have been silently broken for at least the past week or two: the agent reads the inputs/specs as expected, then immediately reaches for `Agent` (Explore subagent) + `TodoWrite` instead of writing `plan.md`, and the run ends "successfully" with no plan. Users see "task starts → stops" with no error to act on. Every q-* user using `ANTHROPIC_API_KEY` env-var auth has been hitting this.

## Root cause

Two pieces that drifted apart:

1. **Next.js standalone tracing can't see the SDK's platform binary.** The SDK's runtime resolves `@anthropic-ai/claude-agent-sdk-${platform}-${arch}[-musl]` — a computed package name. Next's static tracer doesn't follow that, so the platform package gets *omitted* from `.next/standalone/`.
2. **The codebase compensated with a workaround.** `lib/agents/config.server.ts` had a constant `claudeExecutable = process.env.Q_PASSWORD ? '/usr/local/bin/claude' : undefined` that, on deployed instances (where `Q_PASSWORD` is set), passed `pathToClaudeCodeExecutable: '/usr/local/bin/claude'` to the SDK. The Dockerfile pre-installed CLI at that path via `npm install -g @anthropic-ai/claude-code@2.1.92`.

That worked when the two pins matched. They drifted: `package.json` declared `^0.2.92`, the lockfile silently bumped to `0.2.114`, the Dockerfile pin stayed at `2.1.92`. SDK wrapper 0.2.114 + CLI 2.1.92 = mismatched tool orchestration, model defaults to its built-in "explore + TodoWrite" agentic pattern instead of obeying the planning prompt.

## Reproduction (proven)

Reproduced locally by mirroring q-twp's exact pinning:
- SDK 0.2.114 in package.json
- Stash `node_modules/.pnpm/@anthropic-ai+claude-agent-sdk-darwin-arm64@0.2.114/` so SDK can't find bundled
- `sudo ln -sf /tmp/c92/.../claude /usr/local/bin/claude` (CLI 2.1.92)
- `Q_PASSWORD=test pnpm dev` (engages the `claudeExecutable` path)
- Triggered planning run via UI

Result: identical session-JSONL pattern to q-twp's broken run — `Read:9, Agent:1, TodoWrite:1, firstWrite: null`. Restoring the bundled binary or unsetting `Q_PASSWORD` makes planning produce `plan.md` cleanly again.

## What this PR changes

Targets the underlying mismatch source, not the symptom:

- **`next.config.ts`** — `outputFileTracingIncludes` glob force-bundles the platform-specific SDK package into the standalone output. Verified by build: `claude` binary now lands in `.next/standalone/node_modules/.pnpm/@anthropic-ai+claude-agent-sdk-${platform}-${arch}/.../claude`.
- **`lib/agents/config.server.ts`** — drop the `claudeExecutable` constant and the four `pathToClaudeCodeExecutable` injection sites. SDK uses its own bundled CLI, version drift impossible.
- **`Dockerfile`** — drop `RUN npm install -g @anthropic-ai/claude-code@2.1.92`. No second CLI install to fall out of sync with.
- **`package.json`** — pin the SDK to exact `0.2.114`. The `^0.2.92` caret is what let the lockfile silently drift in the first place; future bumps go via deliberate PR.
- **`scripts/check-standalone-sdk-binary.mjs`** (new) wired into `pnpm build` — fails the build if the platform package is missing from the standalone output. Catches this regression class in CI before it ships.

## Test plan

- [x] `pnpm check-types` clean
- [x] `pnpm test lib/agents/config.server.test.ts lib/agents/auth.server.test.ts` — 178 passing
- [x] `pnpm lint` clean
- [x] `pnpm format` clean
- [x] `pnpm build` succeeds and the new guardrail script reports the platform binary present
- [x] `find .next/standalone -path '*claude-agent-sdk-*' -name claude` finds the CLI binary
- [x] Deploy to one q-* instance, confirm planning produces `plan.md` and the model uses `Read → Write(plan.md)` rather than `Read → Agent → TodoWrite`
- [x] Roll out to the rest of the q-* fleet via `infra/scripts/deploy.sh`

## Follow-ups (separate)

- `infra/specs/deployment.md` references the old "Claude Code CLI installed globally" pattern in places — needs updating to reflect the SDK-bundles-its-own-CLI model. Will open a small docs-only PR in `infra/`.
- Issue #216 (silent stderr task failures) is still open — orthogonal but related: when this kind of regression bites in production, users see no error in the UI. Worth fixing too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)