### PR TITLE
chore: refactor UsageSettings to consume useBillingData

### DIFF
--- a/happyhq/components/features/billing/use-billing-data.test.tsx
+++ b/happyhq/components/features/billing/use-billing-data.test.tsx
@@ -93,6 +93,43 @@ describe('useBillingData', () => {
     expect(result!.includedMinutes).toBe(60)
     expect(result!.remainingMinutes).toBe(30)
     expect(result!.remainingPercent).toBe(50)
+    expect(result!.isPastDue).toBe(false)
+    expect(result!.periodEnd).toBe(now + 86400000)
+  })
+
+  it('flags isPastDue when the active subscription is past_due', async () => {
+    const now = Date.now()
+    mockUseCurrentUser.mockReturnValue({
+      user: { id: 'user-1', email: 'test@example.com', createdAt: 0 },
+      isLoading: false,
+      isAuthenticated: true,
+    })
+    mockUseQuery.mockReturnValue({
+      data: {
+        subscriptions: [{ id: 'sub-1', tier: 'starter', status: 'past_due' }],
+        usage: [
+          {
+            id: 'usage-1',
+            periodStart: now - 86400000,
+            periodEnd: now + 86400000,
+            usedMinutes: 10,
+            includedMinutes: 60,
+          },
+        ],
+      },
+    })
+
+    const { useBillingData } = await import('./use-billing-data')
+    let result: UsageData | null | undefined
+
+    function TestComponent() {
+      result = useBillingData()
+      return null
+    }
+
+    render(<TestComponent />)
+    expect(result!.currentTier).toBe('starter')
+    expect(result!.isPastDue).toBe(true)
   })
 
   it('defaults to free tier when no active subscription exists', async () => {
@@ -121,6 +158,8 @@ describe('useBillingData', () => {
     expect(result!.currentTier).toBe('free')
     expect(result!.includedMinutes).toBe(5)
     expect(result!.remainingMinutes).toBe(5)
+    expect(result!.isPastDue).toBe(false)
+    expect(result!.periodEnd).toBeNull()
   })
 
   it('clamps remaining minutes to zero when usage exceeds limit', async () => {

--- a/happyhq/components/features/billing/use-billing-data.ts
+++ b/happyhq/components/features/billing/use-billing-data.ts
@@ -16,6 +16,8 @@ export type UsageData = {
   includedMinutes: number
   remainingMinutes: number
   remainingPercent: number
+  isPastDue: boolean
+  periodEnd: number | null
 }
 
 /**
@@ -68,6 +70,9 @@ export function useBillingData(): UsageData | null {
   const remainingMinutes = Math.max(includedMinutes - usedMinutes, 0)
   const remainingPercent =
     includedMinutes > 0 ? (remainingMinutes / includedMinutes) * 100 : 0
+  const isPastDue = activeSubscription?.status === 'past_due'
+  const periodEnd =
+    currentUsage?.periodEnd != null ? Number(currentUsage.periodEnd) : null
 
   return {
     currentTier,
@@ -75,5 +80,7 @@ export function useBillingData(): UsageData | null {
     includedMinutes,
     remainingMinutes,
     remainingPercent,
+    isPastDue,
+    periodEnd,
   }
 }

--- a/happyhq/components/features/settings/usage-settings.tsx
+++ b/happyhq/components/features/settings/usage-settings.tsx
@@ -1,70 +1,28 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-
 import { Link } from '@/components/common/catalyst/link'
+import { useBillingData } from '@/components/features/billing/use-billing-data'
 import { getTierLimits } from '@/ee/lib/billing/plans'
-import type { TierName } from '@/ee/lib/billing/types'
-import { useCurrentUser } from '@/lib/accounts/hooks'
-import { db } from '@/lib/database/instant'
 import { formatMinutes, formatPrice } from '@/lib/format'
-
-// Cadence for re-checking the active billing period (see `now` state below).
-const PERIOD_TICK_MS = 60_000
 
 /**
  * Usage settings — shows current plan and runtime usage meter.
  * Extracted from BillingSettings so usage has its own page.
  */
 export function UsageSettings() {
-  const { user } = useCurrentUser()
+  const billing = useBillingData()
 
-  const billingQuery = db?.useQuery(
-    user
-      ? {
-          subscriptions: { $: { where: { 'user.id': user.id } } },
-          usage: { $: { where: { 'user.id': user.id } } },
-        }
-      : null,
-  )
+  if (!billing) {
+    return null
+  }
 
-  const subscriptions = billingQuery?.data?.subscriptions ?? []
-  const usageRecords = billingQuery?.data?.usage ?? []
-
-  // Find the active subscription (active or past_due)
-  const activeSubscription = subscriptions.find(
-    (s: { status: string }) => s.status === 'active' || s.status === 'past_due',
-  )
-
-  const currentTier: TierName = (activeSubscription?.tier as TierName) ?? 'free'
+  const { currentTier, usedMinutes, includedMinutes, isPastDue, periodEnd } =
+    billing
   const tierLimits = getTierLimits(currentTier)
-
-  // Re-evaluate the active period periodically so the meter switches over when
-  // a billing period boundary crosses while the page is open. Cadence is
-  // sub-minute because monthly boundaries don't need higher precision and the
-  // re-render is cheap.
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), PERIOD_TICK_MS)
-    return () => clearInterval(id)
-  }, [])
-
-  const currentUsage = usageRecords.find(
-    (u: { periodStart: string | number; periodEnd: string | number }) =>
-      Number(u.periodStart) <= now && Number(u.periodEnd) >= now,
-  )
-
-  const usedMinutes = currentUsage?.usedMinutes ?? 0
-  const includedMinutes =
-    currentUsage?.includedMinutes ?? tierLimits.runtimeMinutes
   const usagePercent =
     includedMinutes > 0
       ? Math.min((usedMinutes / includedMinutes) * 100, 100)
       : 0
-
-  if (!user) {
-    return null
-  }
 
   return (
     <div>
@@ -77,7 +35,7 @@ export function UsageSettings() {
             {' — '}
             {formatPrice(tierLimits.priceMonthly)}
           </p>
-          {activeSubscription?.status === 'past_due' && (
+          {isPastDue && (
             <p className="text-sm font-medium text-amber-600">
               Payment past due
             </p>
@@ -101,13 +59,13 @@ export function UsageSettings() {
             style={{ width: `${usagePercent}%` }}
           />
         </div>
-        {currentUsage?.periodEnd && (
+        {periodEnd != null && (
           <p className="mt-1 text-sm text-zinc-500">
             Resets{' '}
-            {new Date(Number(currentUsage.periodEnd)).toLocaleDateString(
-              'en-US',
-              { month: 'short', day: 'numeric' },
-            )}
+            {new Date(periodEnd).toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+            })}
           </p>
         )}
         {usagePercent >= 90 && (

--- a/happyhq/components/features/sidebar/atoms/usage-indicator.test.tsx
+++ b/happyhq/components/features/sidebar/atoms/usage-indicator.test.tsx
@@ -16,6 +16,8 @@ describe('UsageIndicator', () => {
           includedMinutes: 60,
           remainingMinutes: 42,
           remainingPercent: 70,
+          isPastDue: false,
+          periodEnd: null,
         }}
       />,
     )
@@ -32,6 +34,8 @@ describe('UsageIndicator', () => {
           includedMinutes: 300,
           remainingMinutes: 135,
           remainingPercent: 45,
+          isPastDue: false,
+          periodEnd: null,
         }}
       />,
     )
@@ -48,6 +52,8 @@ describe('UsageIndicator', () => {
           includedMinutes: 60,
           remainingMinutes: 0,
           remainingPercent: 0,
+          isPastDue: false,
+          periodEnd: null,
         }}
       />,
     )
@@ -64,6 +70,8 @@ describe('UsageIndicator', () => {
           includedMinutes: 60,
           remainingMinutes: 10,
           remainingPercent: 16.7,
+          isPastDue: false,
+          periodEnd: null,
         }}
       />,
     )
@@ -81,6 +89,8 @@ describe('UsageIndicator', () => {
           includedMinutes: 60,
           remainingMinutes: 20,
           remainingPercent: 33.3,
+          isPastDue: false,
+          periodEnd: null,
         }}
       />,
     )
@@ -98,6 +108,8 @@ describe('UsageIndicator', () => {
           includedMinutes: 60,
           remainingMinutes: 50,
           remainingPercent: 83.3,
+          isPastDue: false,
+          periodEnd: null,
         }}
       />,
     )

--- a/happyhq/specs/billing.md
+++ b/happyhq/specs/billing.md
@@ -275,7 +275,7 @@ Current plan display, usage meter (visual bar showing hours used vs remaining), 
 
 ### Usage Indicator
 
-`UsageIndicator` component in the sidebar account footer dropdown. Shows remaining time as compact text (e.g., "42m left", "2h 15m left", "No runtime left"). Color-coded: muted (>50% remaining), amber (25–50%), red (<25% or exhausted). Updates in real-time via `db.useQuery()` on usage and subscription records. The `useBillingData()` hook (in `usage-indicator.tsx`) provides the shared data source.
+`UsageIndicator` component in the sidebar account footer dropdown. Shows remaining time as compact text (e.g., "42m left", "2h 15m left", "No runtime left"). Color-coded: muted (>50% remaining), amber (25–50%), red (<25% or exhausted). Updates in real-time via `db.useQuery()` on usage and subscription records. The `useBillingData()` hook (in `components/features/billing/use-billing-data.ts`) provides the shared data source.
 
 `TierBadge` shows the capitalized tier name (e.g., "Starter") in the dropdown.
 
@@ -373,7 +373,8 @@ For local dev with billing, use Stripe test mode keys. Webhooks are handled by t
 | `app/api/billing/checkout/route.ts`                     | Create Stripe Checkout session (thin wrapper)                                                          |
 | `app/api/billing/portal/route.ts`                       | Create Stripe Customer Portal session (thin wrapper)                                                   |
 | `components/features/settings/billing-settings.tsx`     | Billing card in settings: plan, usage meter, manage/upgrade                                            |
-| `components/features/sidebar/atoms/usage-indicator.tsx` | `UsageIndicator`, `TierBadge`, `useBillingData()` hook                                                 |
+| `components/features/sidebar/atoms/usage-indicator.tsx` | `UsageIndicator`, `TierBadge` (presentational)                                                         |
+| `components/features/billing/use-billing-data.ts`       | `useBillingData()` hook — shared data source for usage indicators and the Usage settings page          |
 | `components/features/billing/upgrade-prompt.tsx`        | Reusable upgrade CTA (inline + overlay variants)                                                       |
 | `components/features/billing/limit-reached.tsx`         | `LimitReachedOverlay`, `LowBalanceWarning`                                                             |
 

--- a/happyhq/specs/sidebar.md
+++ b/happyhq/specs/sidebar.md
@@ -137,7 +137,7 @@ When `NEXT_PUBLIC_ACCOUNTS_ENABLED` is `'true'`, `SidebarFooter` renders `Accoun
 
 **Loading state:** `AccountFooter` returns `null` while `isLoading` is true or `user` is missing — no skeleton; the footer area collapses cleanly.
 
-> The footer does not currently surface tier, usage minutes, or a billing link. `usage-indicator.tsx` defines `TierBadge` / `UsageIndicator` / `useBillingData()` for use elsewhere; integration into the footer is deferred.
+> The footer does not currently surface tier, usage minutes, or a billing link. `usage-indicator.tsx` defines `TierBadge` / `UsageIndicator` (with `useBillingData()` in `components/features/billing/use-billing-data.ts`) for use elsewhere; integration into the footer is deferred.
 
 ### Development Footer Item
 


### PR DESCRIPTION
Closes #217

## Summary

`UsageSettings` was running a parallel implementation of `useBillingData()` — same InstantDB query, same active-subscription selection, same `getTierLimits()` lookup, same `setInterval(60_000)` tick, same `usedMinutes` / `includedMinutes` derivations. Two `setInterval`s were ticking out of phase for the same boundary-crossing detection. This change extends `UsageData` with the two pieces of state the settings page needs that the hook didn't expose (`isPastDue`, `periodEnd`) and routes `UsageSettings` through the shared hook.

Per the maintainer comment on the issue, the chosen path is the full refactor with `isPastDue` (option A).

## Per-site classification

| Change | Verdict | Rationale |
| --- | --- | --- |
| `useBillingData.ts`: add `isPastDue` + `periodEnd` to `UsageData` | Improvement | Two fields the settings page needs that previously forced a full re-implementation of the hook. Both are derivable from data the hook already loads — exposing them costs nothing. |
| `UsageSettings`: drop duplicate query + derivations + interval | Improvement | The whole point. One hook, one tick, one source of truth. |
| `useBillingData.test.tsx`: pin new field shapes (`isPastDue` past-due path, `periodEnd` exposure, free-tier null cases) | Real bug fixed (defensive) | The hook contract grew; the test pins it so a future refactor that drops a field is caught. The "what bug would this catch" anchor: someone refactors the hook and silently stops returning `isPastDue` — the past-due banner disappears in production. |
| `usage-indicator.test.tsx`: add the two new fields to existing test fixtures | Directive-conformance only | Type-check fallout from widening `UsageData`. Mechanical. |

## Adjacent latent issues

None — `useBillingData()` is the only code in this neighborhood relevant to the duplication described in #217.

## Adjacent follow-ups filed

None — the duplication this issue identified is the only shape-level finding I'd flag, and it's resolved here.

## Deviations from the issue body

- The body suggested the consumer could derive `tierLimits` from `currentTier` rather than exposing `tierLimits` on `UsageData`. I followed that — `UsageSettings` calls `getTierLimits(billing.currentTier)` itself.
- The body didn't mention `periodEnd` (used by the "Resets …" line). Same shape as `isPastDue` — exposed on `UsageData` so the settings page doesn't need to keep its own DB query just to read one field off the active usage record.

## Spec drift

`specs/billing.md` and `specs/sidebar.md` previously claimed `useBillingData()` lives in `usage-indicator.tsx`. It actually lives in `components/features/billing/use-billing-data.ts` — pre-existing surgical drift. Fixed inline since the drift is in lines that name the symbol I'm extending.

## Verification

- `pnpm format` — clean
- `pnpm lint` — clean
- `pnpm check-types` — clean (had to widen `usage-indicator.test.tsx` fixtures for the new required `UsageData` fields)
- `pnpm --filter=happyhq test` — 1468 passed, including the new `isPastDue` past-due test and the `periodEnd` assertions

## AI assistance

Authored by the tech-debt loop (Claude Opus 4.7). Reviewed by maintainer before merge.