### PR TITLE
chore: ralphie evidence bucket — upload screenshots to R2 for inline PR comments

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -20,3 +20,5 @@ paths-ignore:
   - '**/build/**'
   - '**/*.test.ts'
   - '**/*.test.tsx'
+  # Local dev tooling.
+  - 'happyhq/scripts/**'

--- a/happyhq/.dev/PROMPT_bugs_fix.md
+++ b/happyhq/.dev/PROMPT_bugs_fix.md
@@ -46,7 +46,7 @@
    - **Deviations from the report's framing** (if any) — what you concluded was actually broken vs. what was reported
    - **"Why this is over threshold but low risk"** section (if rule 6 sub-case applied)
    - Link to the regression test (`<file>:<line>`) if one was written
-   - **Visual evidence** — one sentence on what was exercised in step 5b, plus the screenshot(s) or log excerpt(s). For UI changes, embed screenshots via `gh pr comment` or upload as PR attachments. For server-only changes, paste the relevant log lines or API response in a fenced block.
+   - **Visual evidence** — one sentence on what was exercised in step 5b, plus the screenshot(s) or log excerpt(s). For UI changes, upload screenshots via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <screenshot-dir>` and embed the returned URLs as inline `![alt](url)` markdown. For server-only changes, paste the relevant log lines or API response in a fenced block.
    - AI-assistance disclosure per @CONTRIBUTING.md (e.g., "Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.")
 
 9. **Label.** `gh issue edit ${ISSUE_NUMBER} --add-label "ralphie:fixed-in-pr"`. The PR's `Closes #` is the rest of the breadcrumb.

--- a/happyhq/.dev/PROMPT_tech_debt_fix.md
+++ b/happyhq/.dev/PROMPT_tech_debt_fix.md
@@ -76,7 +76,7 @@
    - **Deviations from the issue body** (if any) — what you did differently and why
    - **"Why this is over threshold but low risk"** section (if rule 8 sub-case applied)
    - Verification summary (lint/types/test all green; rule active if applicable)
-   - **Visual evidence** — one sentence per surface exercised in step 6a, plus the screenshot(s) or log excerpt(s). For UI changes, embed screenshots via `gh pr comment` or upload as PR attachments. For server-only changes, paste the relevant log lines or API response in a fenced block.
+   - **Visual evidence** — one sentence per surface exercised in step 6a, plus the screenshot(s) or log excerpt(s). For UI changes, upload screenshots via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <screenshot-dir>` and embed the returned URLs as inline `![alt](url)` markdown. For server-only changes, paste the relevant log lines or API response in a fenced block.
    - AI-assistance disclosure per [CONTRIBUTING.md](CONTRIBUTING.md) (e.g., "Authored by the tech-debt loop. Reviewed by maintainer before merge.")
 
 10. **Label.** `gh issue edit ${ISSUE_NUMBER} --add-label "ralphie:fixed-in-pr"`. The PR's `Closes #` is the rest of the breadcrumb.

--- a/happyhq/.dev/exercising-the-ui.md
+++ b/happyhq/.dev/exercising-the-ui.md
@@ -35,6 +35,28 @@ npm install playwright && npx playwright install chromium
 # write your script, run with `node script.mjs`
 ```
 
+### `scripts/upload-evidence.ts` — push screenshots to R2 for inline-rendering in PR comments
+
+```sh
+npx tsx scripts/upload-evidence.ts <pr-number> <local-dir>
+```
+
+Uploads every `.png` / `.jpg` / `.gif` / `.webp` in `<local-dir>` to `ralphie.happyhq.com/pr/<n>/<uuid>/` and prints the public URLs to stdout (one per line) plus ready-to-paste markdown to stderr. Pipe stdout into a file or paste the markdown block into `gh pr comment --body-file`.
+
+Example:
+
+```sh
+$ npx tsx scripts/upload-evidence.ts 220 /tmp/happyhq-dogfood/screenshots-216
+Uploading 4 file(s) to pr/220/<uuid>/ on ralphie
+https://ralphie.happyhq.com/pr/220/<uuid>/01-task-page-pre-start.png
+...
+Paste into a comment:
+![01-task-page-pre-start](https://ralphie.happyhq.com/pr/220/<uuid>/01-task-page-pre-start.png)
+...
+```
+
+The bucket auto-deletes objects under `pr/` after 90 days (R2 lifecycle rule), so don't rely on these URLs for long-term reference. GitHub's Camo proxy caches each image on first fetch though, so already-rendered comments keep working even after the source expires.
+
 ## Pitfalls (the things we keep tripping on)
 
 ### 1. `networkidle` lies in Next dev mode
@@ -156,11 +178,50 @@ What URL gets you which surface. Add to this as you discover more.
 ## Conventions
 
 - **Where to put exercise scripts.** For Ralphie's autonomous loop, `/tmp/ralphie-exercise-<issue>.mjs`. For ad-hoc maintainer use, `/tmp/happyhq-dogfood/<name>.mjs`. Don't commit these — they're scratch.
-- **Where to put screenshots.** `/tmp/ralphie-screenshots/<issue>/` or `/tmp/happyhq-dogfood/screenshots/`. Reference the absolute path in the PR body so reviewers can `open` it.
+- **Where to put screenshots.** Local working dir: `/tmp/ralphie-screenshots/<issue>/` or `/tmp/happyhq-dogfood/screenshots/`. **Then upload to R2** with `npx tsx scripts/upload-evidence.ts <pr> <dir>` and embed the returned URLs as inline images in the PR-body Visual evidence section. Don't reference local `/tmp` paths in the PR — reviewers can't `open` them, and a screenshot embedded inline is the whole point.
 - **Pre-clean screenshot dir before each run** so a stale shot from a prior attempt doesn't masquerade as success: `for (const f of fs.readdirSync(OUT_DIR)) fs.unlinkSync(path.join(OUT_DIR, f))`.
 - **Wait between actions, but not blindly.** Prefer `waitForSelector` / `waitForFunction` over `waitForTimeout`. A 500ms `waitForTimeout` after a click is fine for letting CSS transitions settle; a 30s `waitForTimeout` waiting for compile is a sign you should be waiting on a signal instead.
 - **Capture a screenshot at every step**, not just the final one. When something fails, the trail of screenshots is what tells you which step broke. Cheap insurance.
 - **Synthetic tasks for failure-mode dogfooding.** When you need a stream-bound task to exercise a run-loop failure path (and don't want to disturb the user's real tasks), write directly to `~/HappyHQ/tasks/<slug>/task.md` with frontmatter that includes a `stream:` field. The API picks it up immediately. Delete the directory after the dogfood.
+
+## Maintainer setup (one-time, per machine)
+
+Most of the helpers above work out of the box. The exception is `upload-evidence.ts` — it talks to a Cloudflare R2 bucket, so each machine that runs it (your laptop, any Fly machine running an autonomous loop) needs the bucket creds.
+
+**One-time on the Cloudflare side** (already done as of this writing — listed for re-creation if the bucket is ever rebuilt or someone else needs to set it up on a fresh account):
+
+```sh
+# Wrangler is the Cloudflare CLI — global install if you don't have it.
+npm install -g wrangler
+wrangler login
+
+# Create the bucket.
+wrangler r2 bucket create ralphie
+
+# Attach the custom domain. Look up your zone-id with:
+#   curl -sS "https://api.cloudflare.com/client/v4/zones?name=happyhq.com" \
+#     -H "Authorization: Bearer $(grep '^oauth_token' ~/Library/Preferences/.wrangler/config/default.toml | cut -d'"' -f2)"
+wrangler r2 bucket domain add ralphie --domain ralphie.happyhq.com --zone-id <zone-id> --min-tls 1.2 --force
+
+# 90-day auto-expire on PR evidence.
+wrangler r2 bucket lifecycle add ralphie --name "expire-evidence-90d" --prefix "pr/" --expire-days 90 --force
+```
+
+**One-time per machine:**
+
+1. Generate an S3-compatible token at `https://dash.cloudflare.com/<account-id>/r2/api-tokens`. Pick **Account API Token**, **Object Read & Write** permission, scoped to the `ralphie` bucket. Save the **Access Key ID** + **Secret Access Key** — Cloudflare only shows the secret once.
+2. Add to `happyhq/.env.local` (gitignored). On a multi-worktree setup, mirror to each worktree's `.env.local`:
+
+   ```
+   # Cloudflare R2 — Ralphie evidence bucket
+   R2_ACCOUNT_ID=<account-id>
+   R2_BUCKET=ralphie
+   R2_ACCESS_KEY_ID=<from dashboard>
+   R2_SECRET_ACCESS_KEY=<from dashboard>
+   R2_PUBLIC_BASE_URL=https://ralphie.happyhq.com
+   ```
+
+3. Smoke-test: `npx tsx scripts/upload-evidence.ts 1 /path/to/some/screenshots`. Should print URLs and `curl -sI <url>` should return `200 image/png` from `server: cloudflare`.
 
 ## Updating this doc
 

--- a/happyhq/package.json
+++ b/happyhq/package.json
@@ -84,11 +84,13 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/react": "^16.3.0",
+    "@types/aws4": "^1.11.6",
     "@types/mailparser": "^3.4.6",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/turndown": "^5.0.6",
+    "aws4": "^1.13.2",
     "eslint": "^9.39.4",
     "eslint-config-next": "16.2.4",
     "fast-check": "^4.6.0",

--- a/happyhq/scripts/upload-evidence.ts
+++ b/happyhq/scripts/upload-evidence.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env npx tsx
+/**
+ * Upload visual evidence (screenshots) to the ralphie R2 bucket and print the
+ * public URLs to stdout — one per line, ready to pipe into `gh pr comment`.
+ *
+ * Used by:
+ *   - Ralphie's Exercise step (autonomous, after the screenshot pass)
+ *   - Maintainer running it manually to attach evidence to a PR
+ *
+ *   npx tsx scripts/upload-evidence.ts <pr-number> <local-dir>
+ *
+ * Example:
+ *   $ npx tsx scripts/upload-evidence.ts 220 /tmp/happyhq-dogfood/screenshots-216
+ *   https://ralphie.happyhq.com/pr/220/<uuid>/01-task-page-pre-start.png
+ *   https://ralphie.happyhq.com/pr/220/<uuid>/02-just-after-click.png
+ *   ...
+ *
+ * Env (set in happyhq/.env.local — see exercising-the-ui.md "Maintainer setup"):
+ *   R2_ACCOUNT_ID, R2_BUCKET, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_PUBLIC_BASE_URL
+ *
+ * Note on `aws4`: the Cloudflare-recommended way to talk to R2's data plane is
+ * the S3-compatible API. `aws4` is a lightweight (~10KB) SigV4 request signer
+ * — it doesn't talk to AWS, it just signs requests in the SigV4 format that
+ * R2 also accepts. We avoid the full @aws-sdk/client-s3 (~3MB) since this
+ * script only needs to PUT a handful of objects.
+ */
+
+import aws4 from 'aws4'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Env
+// ---------------------------------------------------------------------------
+
+loadEnvLocal()
+
+const REQUIRED = [
+  'R2_ACCOUNT_ID',
+  'R2_BUCKET',
+  'R2_ACCESS_KEY_ID',
+  'R2_SECRET_ACCESS_KEY',
+  'R2_PUBLIC_BASE_URL',
+] as const
+
+for (const k of REQUIRED) {
+  if (!process.env[k]) {
+    console.error(`Missing env var: ${k}`)
+    console.error(
+      'Configure R2 credentials in happyhq/.env.local — see exercising-the-ui.md.',
+    )
+    process.exit(1)
+  }
+}
+
+const ACCOUNT_ID = process.env.R2_ACCOUNT_ID!
+const BUCKET = process.env.R2_BUCKET!
+const ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID!
+const SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY!
+const PUBLIC_BASE_URL = process.env.R2_PUBLIC_BASE_URL!.replace(/\/$/, '')
+const HOST = `${ACCOUNT_ID}.r2.cloudflarestorage.com`
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+}
+
+function loadEnvLocal(): void {
+  // happyhq/.env.local sits next to happyhq/scripts/. Load it manually so the
+  // script doesn't need a runtime dotenv dep — Next.js loads it automatically
+  // for the app, but tsx scripts don't get that treatment.
+  const cwd = process.cwd()
+  const candidates = [
+    path.join(cwd, '.env.local'),
+    path.join(cwd, '..', 'happyhq', '.env.local'),
+  ]
+  const envPath = candidates.find((p) => fs.existsSync(p))
+  if (!envPath) return
+  for (const rawLine of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/)
+    if (m && process.env[m[1]] === undefined) {
+      process.env[m[1]] = m[2].replace(/^["']|["']$/g, '')
+    }
+  }
+}
+
+async function uploadOne(key: string, localPath: string): Promise<string> {
+  const body = fs.readFileSync(localPath)
+  const ext = path.extname(localPath).toLowerCase()
+  const contentType = CONTENT_TYPES[ext] || 'application/octet-stream'
+
+  const opts: aws4.Request = {
+    host: HOST,
+    method: 'PUT',
+    path: `/${BUCKET}/${key}`,
+    service: 's3',
+    region: 'auto',
+    headers: {
+      'Content-Type': contentType,
+      'Content-Length': body.length.toString(),
+    },
+    body,
+  }
+
+  aws4.sign(opts, {
+    accessKeyId: ACCESS_KEY_ID,
+    secretAccessKey: SECRET_ACCESS_KEY,
+  })
+
+  const res = await fetch(`https://${HOST}${opts.path}`, {
+    method: 'PUT',
+    headers: opts.headers as Record<string, string>,
+    body,
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`PUT ${key}: ${res.status} ${res.statusText}\n${text}`)
+  }
+
+  return `${PUBLIC_BASE_URL}/${key}`
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const [prArg, dirArg] = process.argv.slice(2)
+  if (!prArg || !dirArg) {
+    console.error('Usage: upload-evidence.ts <pr-number> <local-dir>')
+    console.error(
+      '  Uploads images to ralphie/pr/<n>/<uuid>/ and prints public URLs.',
+    )
+    process.exit(2)
+  }
+  if (!/^\d+$/.test(prArg)) {
+    console.error(`PR number must be numeric, got: ${prArg}`)
+    process.exit(2)
+  }
+
+  const dir = path.resolve(dirArg)
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    console.error(`Not a directory: ${dir}`)
+    process.exit(2)
+  }
+
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => CONTENT_TYPES[path.extname(f).toLowerCase()])
+    .sort()
+
+  if (files.length === 0) {
+    console.error(
+      `No image files in ${dir} (looking for: ${Object.keys(CONTENT_TYPES).join(', ')})`,
+    )
+    process.exit(2)
+  }
+
+  const runId = crypto.randomUUID()
+  console.error(
+    `Uploading ${files.length} file(s) to pr/${prArg}/${runId}/ on ${BUCKET}`,
+  )
+
+  for (const f of files) {
+    const key = `pr/${prArg}/${runId}/${f}`
+    const url = await uploadOne(key, path.join(dir, f))
+    // URLs to stdout — caller can pipe into `gh pr comment --body-file`
+    // or paste into a markdown body. Per-file feedback to stderr.
+    console.log(url)
+    console.error(`  ✓ ${f}`)
+  }
+
+  console.error(`\nPaste into a comment:\n`)
+  for (const f of files) {
+    console.error(
+      `![${path.basename(f, path.extname(f))}](${PUBLIC_BASE_URL}/pr/${prArg}/${runId}/${f})`,
+    )
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err))
+  process.exit(1)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/aws4':
+        specifier: ^1.11.6
+        version: 1.11.6
       '@types/mailparser':
         specifier: ^3.4.6
         version: 3.4.6
@@ -268,6 +271,9 @@ importers:
       '@types/turndown':
         specifier: ^5.0.6
         version: 5.0.6
+      aws4:
+        specifier: ^1.13.2
+        version: 1.13.2
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
@@ -1970,6 +1976,9 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/aws4@1.11.6':
+    resolution: {integrity: sha512-5CnVUkHNyLGpD9AnOcK66YyP0qvIh6nhJJoeK8zSl5YKikUcUbdB7SlHevUYVqicgeh6j5AJa1qa/h08dSZHoA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2337,6 +2346,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
@@ -6462,6 +6474,10 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/aws4@1.11.6':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -6860,6 +6876,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  aws4@1.13.2: {}
 
   axe-core@4.11.3: {}
 
@@ -7316,8 +7334,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -7339,7 +7357,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7350,22 +7368,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7376,7 +7394,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Closes the gap from #228's #220 dogfood: we captured screenshots but couldn't embed them inline in the PR comment because the github user-attachments endpoint is session-cookie-only.

This adds a small uploader (`scripts/upload-evidence.ts`) that pushes screenshots to a Cloudflare R2 bucket served via the custom domain `ralphie.happyhq.com`. The returned URLs render as inline images in any github comment — github's Camo proxy fetches and caches them, so already-posted comments keep working even after the 90-day R2 lifecycle rule expires the objects.

## Visual evidence (dogfood of itself)

This PR's tooling was used to retroactively embed the #220 dogfood screenshots in [comment 4380669000](https://github.com/happyhqdotcom/happyhq/pull/220#issuecomment-4380669000). Same flow: `npx tsx scripts/upload-evidence.ts <pr-number> <screenshot-dir>` → URLs printed → pasted as `![](url)` markdown → comment now renders with 4 actual screenshots in place of a path reference.

A reviewer on this PR can see the result directly by clicking through to that comment.

## Files

- **[happyhq/scripts/upload-evidence.ts](happyhq/scripts/upload-evidence.ts)** — new helper. `<pr> <dir>` → uploads every image to `ralphie/pr/<n>/<uuid>/<filename>`, prints URLs to stdout, prints ready-to-paste markdown to stderr.
- **[happyhq/package.json](happyhq/package.json)** — `aws4` and `@types/aws4` as devDeps. `aws4` is a 10KB SigV4 signer; combined with node fetch we avoid the 3MB `@aws-sdk/client-s3`.
- **[happyhq/.dev/exercising-the-ui.md](happyhq/.dev/exercising-the-ui.md)** — new Helpers entry for upload-evidence.ts; Conventions updated to "upload + embed" rather than path references; new Maintainer-setup section with the wrangler commands for re-creating the bucket on a fresh account.
- **[happyhq/.dev/PROMPT_bugs_fix.md](happyhq/.dev/PROMPT_bugs_fix.md) / [PROMPT_tech_debt_fix.md](happyhq/.dev/PROMPT_tech_debt_fix.md)** — Visual evidence bullet in the PR-body convention now points at upload-evidence.ts.

## Bucket setup (one-time, already done)

Done via wrangler CLI on the HappyHQ Cloudflare account:

- Bucket `ralphie` created in ENAM region
- Custom domain `ralphie.happyhq.com` attached, TLS 1.2 min, SSL active
- Lifecycle rule `expire-evidence-90d`: auto-delete objects under `pr/` prefix after 90 days

The wrangler commands are documented in `exercising-the-ui.md` so the bucket can be recreated on a fresh account if ever needed.

## Per-machine setup

R2 API token generated via dashboard (Account API Token, Object Read & Write, scoped to `ralphie`). Five env vars added to `.env.local` (gitignored): `R2_ACCOUNT_ID`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_PUBLIC_BASE_URL`.

## Risk

Low. No production code changes. New devDep (aws4 — single-purpose SigV4 signer, very small). New script that only runs from CLI. R2 bucket is a separate, scoped thing — no path back into the app.

## Test plan

- [ ] Click through to [PR #220's updated comment](https://github.com/happyhqdotcom/happyhq/pull/220#issuecomment-4380669000) — confirm 4 screenshots render inline.
- [ ] On a fresh local clone, follow the Maintainer-setup section in [exercising-the-ui.md](happyhq/.dev/exercising-the-ui.md) — should produce a working uploader without re-deriving the steps.
- [ ] Run `npx tsx scripts/upload-evidence.ts 1 /path/to/test/dir` with a friendly error if `.env.local` is missing R2 vars.

🤖 Authored as a collaborative session with the maintainer. Reviewed by maintainer before merge.