### PR TITLE
fix(test): exclude .next build artifacts from vitest discovery

### DIFF
--- a/happyhq/vitest.config.mts
+++ b/happyhq/vitest.config.mts
@@ -10,7 +10,11 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.ts'],
     globals: true,
     testTimeout: 10_000,
-    exclude: [...configDefaults.exclude, 'tests/**/*.spec.ts'],
+    exclude: [
+      ...configDefaults.exclude,
+      'tests/**/*.spec.ts',
+      '.next/**',
+    ],
     pool: process.env.CI ? 'forks' : 'threads',
     maxWorkers: 2,
     clearMocks: true,


### PR DESCRIPTION
## Summary
- When a Next.js standalone build exists, vitest discovers and runs the duplicated test files under `.next/standalone/`. They fail on import resolution (the bundle re-rewrites paths), producing 45 spurious failures locally.
- Adding `.next/**` to vitest's `exclude` makes `pnpm test` work the same whether or not a build is present.

## Test plan
- [x] `pnpm test` (no flags) — 1470/1470 passing with a stale `.next/standalone/` present
- [x] `pnpm test` still passes when `.next/` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)