### PR TITLE
chore(deps): group anthropic SDKs and add 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,31 @@ updates:
     # so the traditional "don't overwhelm the maintainer" cap matters less.
     # The constraint now is loop session cost + queue management.
     open-pull-requests-limit: 15
+    # Cooldown only applies to the anthropic LLM clients: claude-agent-sdk
+    # ships ~daily for Claude Code parity, and ~half of releases are pure
+    # version bumps. A 7-day cooldown collapses the parity churn so the
+    # PR that does open contains real surface-area changes worth reviewing.
+    cooldown:
+      default-days: 7
+      include:
+        - '@anthropic-ai/*'
     groups:
-      # Two principles for grouping:
+      # Three principles for grouping:
       # - Packages that release together get a group (one PR keeps versions
       #   in lockstep). Add new SDK families here as we encounter them.
-      # - Packages whose behavior tests can't catch get their own PR
-      #   (excluded from groups; LLM clients are the canonical case).
+      # - LLM clients can be grouped *with each other* (related surface area,
+      #   often need coordinated bumps) but not with the broader patch
+      #   firehose, since behavior tests can't catch model/SDK regressions.
+      # - Everything else flows through npm-minor-patch.
+      anthropic-llm-clients:
+        patterns:
+          - '@anthropic-ai/*'
       npm-minor-patch:
         update-types:
           - minor
           - patch
         exclude-patterns:
-          - '@anthropic-ai/claude-agent-sdk'
-          - '@anthropic-ai/sdk'
+          - '@anthropic-ai/*'
       instantdb:
         # @instantdb/core, @instantdb/react, @instantdb/admin release in
         # lockstep; bumping one without the others causes type-inference


### PR DESCRIPTION
## Summary
- Group `@anthropic-ai/*` packages into one PR (related surface area, often need coordinated bumps). Still excluded from `npm-minor-patch` because behavior tests can't catch model/SDK regressions.
- Add a **7-day cooldown scoped to `@anthropic-ai/*`** so the PR that does open bundles real surface-area changes rather than parity bumps.
- Other ecosystems (instantdb, npm-minor-patch, github-actions) are unaffected.

## Why
`claude-agent-sdk` ships ~daily for Claude Code parity. In the recent 0.2.114 → 0.2.128 window, ~half of releases were pure "Updated to parity with Claude Code v2.1.x" bumps with no surface-area change. Previous policy gave each release its own PR; the parity churn drowned out the real feature releases.

## Note on existing #173
This config change only affects *new* Dependabot runs. The currently-open #173 (0.2.114 → 0.2.128) is unaffected and can be reviewed/merged on its own merits — it captures the real feature releases (0.2.118 managedSettings, 0.2.119 forwardSubagentText/MCP reconnect, 0.2.120 skills, 0.2.121 updatedToolOutput, 0.2.126 origin on result messages).

## Test plan
- [x] After merge, watch next Dependabot run: should see one grouped `anthropic-llm-clients` PR appear ~7 days after the most recent SDK release rather than per-version PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)