### PR TITLE
fix: replay terminal run error to late SSE subscribers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ happyhq/specs/refs/
 # Cloudflare Workers
 .wrangler/
 .dev.vars
+
+# Playwright MCP runtime artifacts
+# Snapshot YAMLs, console logs, and Exercise screenshots — see the screenshot
+# convention in happyhq/.dev/exercising-the-ui.md ("write into .playwright-mcp/").
+.playwright-mcp/

--- a/happyhq/.dev/exercising-the-ui.md
+++ b/happyhq/.dev/exercising-the-ui.md
@@ -27,6 +27,8 @@ Default port 3000. Override with `PORT=3030 npx tsx ...` if 3000 is in use (e.g.
 
 Registered in `.mcp.json` at the repo root. Tools available to any Claude Code session in this checkout: `browser_navigate`, `browser_click`, `browser_type`, `browser_take_screenshot`, etc. Headless chromium by default.
 
+Write screenshots into `.playwright-mcp/` so they collocate with snapshot YAMLs / console logs and are covered by the existing gitignore — pass `filename: '.playwright-mcp/<name>.png'` to `browser_take_screenshot` rather than letting it default to cwd. Loose PNGs at repo root tend to leak into untracked status and clutter `git status` between Exercise runs.
+
 If you're driving Playwright directly (not through MCP), spawn a sandbox install rather than adding to package.json:
 
 ```sh
@@ -149,13 +151,24 @@ if (await confirmStart.count()) {
 }
 ```
 
-### 9. SSE subscription mounts late — late-connect replay covers the race
+### 9. SSE subscription mounts late — terminal-error toast comes from SWR
 
 [components/features/desktop/hooks/use-run-activity.ts](../components/features/desktop/hooks/use-run-activity.ts) only subscribes to `/api/run/stream` when `run.status` flips to `'planning'` or `'working'`. The gate avoids open SSE connections from idle pages.
 
-For a fast-fail run the server can fire its terminal `error` broadcast before the client's SWR refetch picks up the status change and mounts the subscription. To stop the toast getting lost, the run loop now buffers the most recent `error` event for 30s; a subscriber that connects within that window receives a one-shot replay stream carrying the event (see [lib/run/loop.server.ts](../lib/run/loop.server.ts) `pendingErrorEvent`).
+For a fast-fail run the server can fire its terminal `error` broadcast before the client's SWR refetch ever observes `'planning'`/`'working'` — `useRunActivity` never mounts and the live broadcast lands in an empty subscriber set. Toast surfacing therefore comes through SWR-observed state instead of the live wire: [components/features/tasks/hooks/use-terminal-error-toast.ts](../components/features/tasks/hooks/use-terminal-error-toast.ts) watches `.run.json` (via SWR) for transitions into `status='stopped' && error`, and toasts deterministically. Live SSE error events still toast immediately for active subscribers — both paths key Sonner's `id` on `run.startedAt`, so the user sees exactly one toast per failed run.
 
-That makes the raw `POST /api/run/start` path safe for dogfooding — but the UI-button path is still preferred when you need the optimistic-update side effects (status flips, action buttons re-render, etc.) to drive other surfaces too.
+That makes the raw `POST /api/run/start` path fully safe for dogfooding terminal-error UX — the toast will land within one SWR refresh cycle regardless of how fast the run failed. The UI-button path is still preferred when you need the optimistic-update side effects (status flips, action buttons re-render, etc.) to drive other surfaces too.
+
+**Caveat — transient mid-iteration errors are not toasted.** When a working iteration fails with captured stderr but the run continues to the next iteration, that no longer surfaces as a toast (was previously broadcast over SSE; rolled back along with #227's server-side buffer). The error is still recorded in the runtime log (`~/HappyHQ/.logs/<date>.jsonl`, event `run.iteration`). If a transient triggers a terminal failure on a later iteration, the terminal-error path covers the toast.
+
+**Source-level fault injection for fast-fail dogfooding.** On macOS, "break SDK auth" doesn't reliably reproduce a fast-fail because Claude Code stores credentials in the keychain (`security find-generic-password -s "Claude Code-credentials"`), not in `~/.claude.json` or `CLAUDE_CODE_OAUTH_TOKEN`. Removing the file or unsetting the env var leaves auth intact and the run completes normally. The honest cheap reproducer is a one-line throw at the top of the planning iteration:
+
+```ts
+// in lib/run/loop.server.ts, top of runPlanningIteration's try block:
+throw new Error('synthetic fast-fail (#NNN)')
+```
+
+Restart the dev server, fire `POST /api/run/start` with a synthetic task that has a real `stream:` field in its frontmatter (the API picks up `~/HappyHQ/tasks/<slug>/task.md` immediately if the file is well-formed — `title:` and `createdAt:` are required), observe the toast, then `git checkout -- happyhq/lib/run/loop.server.ts`. The contract being tested is timing-shape (broadcast/SWR-observe race), not the cause of the failure, so any throw with the right placement reproduces the user-visible bug.
 
 ## Routing cheat-sheet
 

--- a/happyhq/.dev/exercising-the-ui.md
+++ b/happyhq/.dev/exercising-the-ui.md
@@ -149,15 +149,13 @@ if (await confirmStart.count()) {
 }
 ```
 
-### 9. SSE subscription mounts late — drive via UI, not raw API
+### 9. SSE subscription mounts late — late-connect replay covers the race
 
 [components/features/desktop/hooks/use-run-activity.ts](../components/features/desktop/hooks/use-run-activity.ts) only subscribes to `/api/run/stream` when `run.status` flips to `'planning'` or `'working'`. The gate avoids open SSE connections from idle pages.
 
-If you trigger a run via raw `POST /api/run/start`, the server can fire its broadcast (the run loop's catch path, e.g. an `error` event after a fast SDK failure) before the client's SWR refetch picks up the status change and mounts the subscription. The event lands in a channel with no subscribers — toast missed.
+For a fast-fail run the server can fire its terminal `error` broadcast before the client's SWR refetch picks up the status change and mounts the subscription. To stop the toast getting lost, the run loop now buffers the most recent `error` event for 30s; a subscriber that connects within that window receives a one-shot replay stream carrying the event (see [lib/run/loop.server.ts](../lib/run/loop.server.ts) `pendingErrorEvent`).
 
-**Drive run-loop dogfoods via the UI button click, not raw API.** The button's click handler does an optimistic SWR update that mounts the subscription before the server's broadcast fires.
-
-(There's also a real bug in the broadcast — events aren't buffered for late subscribers. Tracked in #227. Until that's fixed, this pitfall is the workaround.)
+That makes the raw `POST /api/run/start` path safe for dogfooding — but the UI-button path is still preferred when you need the optimistic-update side effects (status flips, action buttons re-render, etc.) to drive other surfaces too.
 
 ## Routing cheat-sheet
 

--- a/happyhq/components/common/ui/sonner.tsx
+++ b/happyhq/components/common/ui/sonner.tsx
@@ -3,9 +3,12 @@
 import { Loader2Icon } from 'lucide-react'
 import { Toaster as Sonner, toast, ToasterProps } from 'sonner'
 
-// Error toasts persist until dismissed
-export const toastError = (message: string) =>
-  toast.error(message, { duration: Infinity })
+// Error toasts persist until dismissed.
+// `id` lets callers dedupe across paths that surface the same error
+// (live SSE broadcast vs. SWR-observed terminal state) — Sonner replaces
+// instead of stacking when ids match.
+export const toastError = (message: string, opts?: { id?: string }) =>
+  toast.error(message, { duration: Infinity, ...opts })
 
 // Warning toasts stay visible longer than the 4s default
 export const toastWarning = (message: string) =>

--- a/happyhq/components/features/desktop/hooks/use-run-activity.ts
+++ b/happyhq/components/features/desktop/hooks/use-run-activity.ts
@@ -99,7 +99,11 @@ function stripMcpPrefix(name: string): string {
   return idx > 0 && name.startsWith('mcp__') ? name.slice(idx + 2) : name
 }
 
-export function useRunActivity(isActive: boolean): RunActivityState {
+export function useRunActivity(
+  isActive: boolean,
+  runStartedAt?: string | null,
+  onStreamNotFound?: () => void,
+): RunActivityState {
   const [statusLine, setStatusLine] = useState<string | null>(null)
   const [lastResultAt, setLastResultAt] = useState<number | null>(null)
   const [lastContentChangeAt, setLastContentChangeAt] = useState<number | null>(
@@ -170,11 +174,24 @@ export function useRunActivity(isActive: boolean): RunActivityState {
         })
 
         if (!response.ok) {
-          // 404 likely means the run is still initialising (optimistic
-          // update set isActive before the server was ready). Retry
-          // after a short delay — cleanup will stop retries if the run
-          // ends and isActive flips to false.
+          // 404 means the server has no active run. Two cases:
+          // (a) Run is still initialising — `streamActive` flips on
+          //     synchronously inside startRun before the POST returns 200,
+          //     but a slow event loop / cold compile can land the SSE GET
+          //     ahead of the loop's first broadcast.
+          // (b) Run already terminated — fast-fail in planning, or any
+          //     other path where `streamActive` flipped back to false
+          //     between the optimistic update mounting this hook and the
+          //     fetch landing.
+          //
+          // Fire the parent's onStreamNotFound callback so it can refetch
+          // SWR-backed run state. For (a) the refetch sees status='planning'
+          // (already on disk before POST returned) and the cache reconciles
+          // without disrupting the optimistic update; for (b) the refetch
+          // surfaces status='stopped'+error and useTerminalErrorToast picks
+          // it up — closes #227.
           setIsConnected(false)
+          onStreamNotFound?.()
           if (mounted) {
             reconnectTimeout = setTimeout(connect, RECONNECT_DELAY_MS)
           }
@@ -508,10 +525,15 @@ export function useRunActivity(isActive: boolean): RunActivityState {
           } else if (event.type === 'task_content_changed') {
             setLastContentChangeAt(Date.now())
           } else if (event.type === 'error') {
-            // Run loop broadcasts this when an iteration fails (notably the
-            // silent fast-fail case where the subprocess exits before
-            // producing any SDK message — see #216).
-            toastError(event.message)
+            // Run loop broadcasts this on terminal failure. Live subscribers
+            // get the toast immediately. The same terminal state lands in
+            // .run.json and is also picked up by useTaskData's SWR-observed
+            // effect (covers fast-fails where SSE never mounts) — both paths
+            // use the run.startedAt-keyed id so Sonner dedupes.
+            toastError(
+              event.message,
+              runStartedAt ? { id: `run-error:${runStartedAt}` } : undefined,
+            )
           } else if (event.type === 'result') {
             setLastResultAt(Date.now())
             setActivitySteps([]) // iteration boundary — reset

--- a/happyhq/components/features/desktop/providers/desktop-initializer.test.tsx
+++ b/happyhq/components/features/desktop/providers/desktop-initializer.test.tsx
@@ -178,7 +178,11 @@ describe('DesktopInitializer', () => {
   describe('run activity integration', () => {
     it('passes isRunActive=false when no active run', () => {
       renderProvider()
-      expect(mockUseRunActivity).toHaveBeenCalledWith(false)
+      expect(mockUseRunActivity).toHaveBeenCalledWith(
+        false,
+        null,
+        expect.any(Function),
+      )
     })
 
     it('passes isRunActive=true when task has a running status', () => {
@@ -190,10 +194,17 @@ describe('DesktopInitializer', () => {
       }))
 
       render(<DesktopInitializer />)
-      expect(mockUseRunActivity).toHaveBeenCalledWith(true)
+      expect(mockUseRunActivity).toHaveBeenCalledWith(
+        true,
+        TASK_CONTENT.run!.startedAt,
+        expect.any(Function),
+      )
     })
 
     it('passes isRunActive=false when task status is completed', () => {
+      // Set params before the SWR override so renderProvider's setupDefaults
+      // doesn't clobber it (setupDefaults wires both useParams and useSWR).
+      mockUseParams.mockReturnValue({ stream: 'test-stream', task: 'my-task' })
       mockUseSWR.mockImplementation(() => ({
         data: {
           ...DESKTOP_DATA,
@@ -206,8 +217,12 @@ describe('DesktopInitializer', () => {
         mutate: vi.fn(),
       }))
 
-      renderProvider('test-stream', 'my-task')
-      expect(mockUseRunActivity).toHaveBeenCalledWith(false)
+      render(<DesktopInitializer />)
+      expect(mockUseRunActivity).toHaveBeenCalledWith(
+        false,
+        TASK_CONTENT.run!.startedAt,
+        expect.any(Function),
+      )
     })
   })
 

--- a/happyhq/components/features/desktop/providers/desktop-initializer.tsx
+++ b/happyhq/components/features/desktop/providers/desktop-initializer.tsx
@@ -224,7 +224,11 @@ export function DesktopInitializer() {
   // activity state directly into the store.
   const mockMode = useDesktopStore((s) => s.mockMode)
   const { statusLine, lastResultAt, lastContentChangeAt, activitySteps } =
-    useRunActivity(isRunActive && !mockMode)
+    useRunActivity(
+      isRunActive && !mockMode,
+      data?.taskContent?.run?.startedAt ?? null,
+      mutateDesktop,
+    )
 
   // Push run state into store (client-only — from SSE, not server data).
   // In mock mode, the dev panel injects state directly — skip to avoid overwriting.

--- a/happyhq/components/features/tasks/hooks/use-task-data.ts
+++ b/happyhq/components/features/tasks/hooks/use-task-data.ts
@@ -10,6 +10,8 @@ import { useTaskStore } from '@/stores/taskStore'
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import useSWR, { mutate as globalMutate } from 'swr'
 
+import { useTerminalErrorToast } from './use-terminal-error-toast'
+
 interface TaskIdentity {
   taskSlug: string
   streamSlug: string | null
@@ -61,8 +63,15 @@ export function useTaskData(task: TaskIdentity | null) {
 
   // ── Real-time activity stream ───────────────────────────────────────
   // In mock mode, suppress SSE — the dev panel injects activity directly.
+  // The onStreamNotFound callback refetches SWR when the SSE endpoint says
+  // there's no active run — covers fast-fails where the run terminated
+  // between the optimistic mount and the SSE fetch landing.
   const { activitySteps, statusLine, lastResultAt, lastContentChangeAt } =
-    useRunActivity(hasStream && isRunActive && !mockMode)
+    useRunActivity(
+      hasStream && isRunActive && !mockMode,
+      content?.run?.startedAt ?? null,
+      mutate,
+    )
 
   // Push run state into store (client-only — from SSE, not server data).
   // In mock mode, the dev panel injects state directly — skip to avoid overwriting.
@@ -102,6 +111,9 @@ export function useTaskData(task: TaskIdentity | null) {
   useEffect(() => {
     if (lastContentChangeAt && !mockMode) debouncedRefresh()
   }, [lastContentChangeAt, debouncedRefresh, mockMode])
+
+  // ── Terminal-error toast (SWR-observed) ─────────────────────────────
+  useTerminalErrorToast(content?.run ?? null, mockMode)
 
   // ── Run-end detection ───────────────────────────────────────────────
   // When isRunActive transitions true → false, revalidate to pick up

--- a/happyhq/components/features/tasks/hooks/use-terminal-error-toast.test.ts
+++ b/happyhq/components/features/tasks/hooks/use-terminal-error-toast.test.ts
@@ -1,0 +1,144 @@
+import type { RunInfo } from '@/lib/fs/types'
+import { renderHook } from '@testing-library/react'
+import { useTerminalErrorToast } from './use-terminal-error-toast'
+
+const toastErrorMock = vi.fn()
+vi.mock('@/components/common/ui/sonner', () => ({
+  toastError: (message: string, opts?: { id?: string }) =>
+    toastErrorMock(message, opts),
+}))
+
+function makeRun(overrides: Partial<RunInfo> = {}): RunInfo {
+  return {
+    status: 'stopped',
+    iteration: 0,
+    startedAt: '2026-05-06T15:00:00.000Z',
+    lastIterationAt: '2026-05-06T15:00:00.500Z',
+    error: 'boom',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  toastErrorMock.mockClear()
+})
+
+describe('useTerminalErrorToast', () => {
+  it('does not toast on first mount, even when a stale terminal error is already on disk', () => {
+    // Page reload while .run.json holds an error from a prior session must
+    // not surface that error as a fresh toast.
+    renderHook(({ run }) => useTerminalErrorToast(run, false), {
+      initialProps: { run: makeRun() },
+    })
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('toasts when a new run terminates with an error after mount', () => {
+    // Closes the #227 race: very-fast fast-fail where SWR goes straight from
+    // "no run" to "stopped+error" without ever observing planning/working.
+    const { rerender } = renderHook(
+      ({ run }: { run: RunInfo | null }) => useTerminalErrorToast(run, false),
+      { initialProps: { run: null as RunInfo | null } },
+    )
+    expect(toastErrorMock).not.toHaveBeenCalled()
+
+    rerender({
+      run: makeRun({
+        startedAt: '2026-05-06T15:30:00.000Z',
+        error: 'subprocess died',
+      }),
+    })
+
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock).toHaveBeenCalledWith('subprocess died', {
+      id: 'run-error:2026-05-06T15:30:00.000Z',
+    })
+  })
+
+  it('does not double-toast across re-renders for the same run', () => {
+    // Sonner id-based dedupe is the dedupe between SSE and SWR paths, but
+    // this hook should also not call toastError twice for the same run when
+    // SWR refetches don't change run.startedAt.
+    const run = makeRun({
+      startedAt: '2026-05-06T15:30:00.000Z',
+      error: 'fail',
+    })
+    const { rerender } = renderHook(
+      ({ run }: { run: RunInfo | null }) => useTerminalErrorToast(run, false),
+      { initialProps: { run: null as RunInfo | null } },
+    )
+    rerender({ run })
+    rerender({ run })
+    rerender({ run: { ...run } }) // identical content, new object
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('toasts again for a subsequent run with a different startedAt', () => {
+    const { rerender } = renderHook(
+      ({ run }: { run: RunInfo | null }) => useTerminalErrorToast(run, false),
+      { initialProps: { run: null as RunInfo | null } },
+    )
+    rerender({
+      run: makeRun({
+        startedAt: '2026-05-06T15:30:00.000Z',
+        error: 'first',
+      }),
+    })
+    rerender({
+      run: makeRun({
+        startedAt: '2026-05-06T15:35:00.000Z',
+        error: 'second',
+      }),
+    })
+    expect(toastErrorMock).toHaveBeenCalledTimes(2)
+    expect(toastErrorMock).toHaveBeenLastCalledWith('second', {
+      id: 'run-error:2026-05-06T15:35:00.000Z',
+    })
+  })
+
+  it('does not toast for non-terminal status transitions', () => {
+    // 'planning' / 'working' / 'completed' must not toast even if the
+    // run.error field happens to be set (it shouldn't be, but the hook's
+    // contract is "stopped+error only").
+    const { rerender } = renderHook(
+      ({ run }: { run: RunInfo | null }) => useTerminalErrorToast(run, false),
+      { initialProps: { run: null as RunInfo | null } },
+    )
+    rerender({
+      run: makeRun({
+        startedAt: '2026-05-06T15:30:00.000Z',
+        status: 'completed',
+        error: null,
+      }),
+    })
+    rerender({
+      run: makeRun({
+        startedAt: '2026-05-06T15:31:00.000Z',
+        status: 'working',
+        error: null,
+      }),
+    })
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('skips entirely in mock mode', () => {
+    const { rerender } = renderHook(
+      ({ run, mockMode }: { run: RunInfo | null; mockMode: boolean }) =>
+        useTerminalErrorToast(run, mockMode),
+      {
+        initialProps: {
+          run: null as RunInfo | null,
+          mockMode: true,
+        },
+      },
+    )
+    rerender({
+      run: makeRun({
+        startedAt: '2026-05-06T15:30:00.000Z',
+        error: 'should be ignored',
+      }),
+      mockMode: true,
+    })
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+})

--- a/happyhq/components/features/tasks/hooks/use-terminal-error-toast.ts
+++ b/happyhq/components/features/tasks/hooks/use-terminal-error-toast.ts
@@ -1,0 +1,46 @@
+'use client'
+
+import { toastError } from '@/components/common/ui/sonner'
+import type { RunInfo } from '@/lib/fs/types'
+import { useEffect, useRef } from 'react'
+
+/**
+ * Toasts terminal run errors observed via SWR-fetched run state.
+ *
+ * Closes the very-fast fast-fail race in #227: when a run errors before the
+ * client's SWR poll observes 'planning'/'working', `useRunActivity` never
+ * mounts and the live SSE error broadcast lands in an empty subscriber set.
+ * This hook surfaces the toast deterministically once `.run.json` reaches
+ * `status='stopped'` with an `error`.
+ *
+ * Dedupes against the live SSE path via Sonner's `id` (run.startedAt-keyed),
+ * so a long working run that errors mid-iteration with the user actively
+ * watching produces exactly one toast.
+ *
+ * On first call we snapshot whatever's already on disk without toasting —
+ * stale errors from a prior session must not toast on page load.
+ */
+export function useTerminalErrorToast(
+  run: RunInfo | null | undefined,
+  mockMode: boolean,
+): void {
+  const lastSeenStartedAtRef = useRef<string | null | undefined>(undefined)
+
+  useEffect(() => {
+    if (mockMode) return
+    const startedAt = run?.startedAt ?? null
+    if (lastSeenStartedAtRef.current === undefined) {
+      lastSeenStartedAtRef.current = startedAt
+      return
+    }
+    if (
+      startedAt &&
+      startedAt !== lastSeenStartedAtRef.current &&
+      run?.status === 'stopped' &&
+      run.error
+    ) {
+      toastError(run.error, { id: `run-error:${startedAt}` })
+    }
+    lastSeenStartedAtRef.current = startedAt
+  }, [run?.startedAt, run?.status, run?.error, mockMode])
+}

--- a/happyhq/lib/run/loop.server.test.ts
+++ b/happyhq/lib/run/loop.server.test.ts
@@ -510,6 +510,19 @@ describe('module state after run ends', () => {
     await _waitForLoop()
 
     expect(isRunActive()).toBe(false)
+    // getActiveStream() intentionally returns a one-shot replay stream after
+    // an errored run (see #227 — covers the fast-fail late-subscriber race).
+    // The "no run active" 404 path is exercised by the test below.
+  })
+
+  it('returns null from getActiveStream after a clean (no-error) run', async () => {
+    mockQuery.mockReturnValue(fakeQuery([]))
+    mockIsTaskCompleted.mockReturnValue(true)
+
+    await startRun('s1', 't1', 'working')
+    await _waitForLoop()
+
+    expect(isRunActive()).toBe(false)
     expect(getActiveStream()).toBeNull()
   })
 })
@@ -615,6 +628,81 @@ describe('stream', () => {
 
     // stream2 should still be a valid readable stream
     expect(stream2.locked).toBe(false)
+  })
+
+  it('replays the buffered error to a subscriber that mounts after a fast-fail run', async () => {
+    // Pins the contract behind #227. When a planning run fails before the
+    // client mounts /api/run/stream (subprocess fast-fail / SDK throw before
+    // first SDK message), the broadcast lands in an empty subscriber set and
+    // — without the replay buffer — getActiveStream() returns null on the
+    // late connect, so the toast never reaches the user. The buffer turns a
+    // late connect into a one-shot stream carrying the same error event.
+    mockQuery.mockImplementation(({ options }: any) => {
+      options.stderr?.('Claude configuration file not found\n')
+      return fakeQuery([])
+    })
+
+    await startRun('s1', 't1', 'planning')
+    await _waitForLoop()
+
+    // Run is over server-side; subscribers were closed in the loop's finally
+    // block. A "real" client connecting now would have missed the live
+    // broadcast — getActiveStream still hands back a stream carrying the
+    // error so the toast surfaces.
+    const stream = getActiveStream()
+    expect(stream).not.toBeNull()
+
+    const reader = stream!.getReader()
+    const decoder = new TextDecoder()
+    let output = ''
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      output += decoder.decode(value, { stream: true })
+    }
+
+    const events = output
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+    const errorEvent = events.find((e: any) => e.type === 'error')
+    expect(errorEvent).toBeDefined()
+    expect(errorEvent.message).toContain('Claude configuration file not found')
+  })
+
+  it('clears the buffered error when a new run starts', async () => {
+    // The replay buffer must not leak across runs — once a fresh run begins
+    // the prior session's terminal error becomes irrelevant noise.
+    mockQuery.mockImplementationOnce(({ options }: any) => {
+      options.stderr?.('first run failed\n')
+      return fakeQuery([])
+    })
+    await startRun('s1', 't1', 'planning')
+    await _waitForLoop()
+
+    // Confirm the buffered error is replayable before the next run.
+    expect(getActiveStream()).not.toBeNull()
+
+    // Start a new (still-active) run; the previous error must no longer be
+    // replayed to a subscriber that connects fresh.
+    mockQuery.mockImplementation(blockingQueryImpl)
+    await startRun('s1', 't2', 'working')
+
+    const stream = getActiveStream()!
+    const reader = stream.getReader()
+    // Read with a short race — the live stream is blocking, so if the error
+    // chunk leaked into it we'd see it within the timeout.
+    const raced = await Promise.race([
+      reader.read(),
+      new Promise<{ value: undefined; done: false }>((resolve) =>
+        setTimeout(() => resolve({ value: undefined, done: false }), 30),
+      ),
+    ])
+    if (raced.value) {
+      const decoded = new TextDecoder().decode(raced.value as Uint8Array)
+      expect(decoded).not.toContain('first run failed')
+    }
+    await reader.cancel()
   })
 })
 

--- a/happyhq/lib/run/loop.server.test.ts
+++ b/happyhq/lib/run/loop.server.test.ts
@@ -510,19 +510,6 @@ describe('module state after run ends', () => {
     await _waitForLoop()
 
     expect(isRunActive()).toBe(false)
-    // getActiveStream() intentionally returns a one-shot replay stream after
-    // an errored run (see #227 — covers the fast-fail late-subscriber race).
-    // The "no run active" 404 path is exercised by the test below.
-  })
-
-  it('returns null from getActiveStream after a clean (no-error) run', async () => {
-    mockQuery.mockReturnValue(fakeQuery([]))
-    mockIsTaskCompleted.mockReturnValue(true)
-
-    await startRun('s1', 't1', 'working')
-    await _waitForLoop()
-
-    expect(isRunActive()).toBe(false)
     expect(getActiveStream()).toBeNull()
   })
 })
@@ -628,81 +615,6 @@ describe('stream', () => {
 
     // stream2 should still be a valid readable stream
     expect(stream2.locked).toBe(false)
-  })
-
-  it('replays the buffered error to a subscriber that mounts after a fast-fail run', async () => {
-    // Pins the contract behind #227. When a planning run fails before the
-    // client mounts /api/run/stream (subprocess fast-fail / SDK throw before
-    // first SDK message), the broadcast lands in an empty subscriber set and
-    // — without the replay buffer — getActiveStream() returns null on the
-    // late connect, so the toast never reaches the user. The buffer turns a
-    // late connect into a one-shot stream carrying the same error event.
-    mockQuery.mockImplementation(({ options }: any) => {
-      options.stderr?.('Claude configuration file not found\n')
-      return fakeQuery([])
-    })
-
-    await startRun('s1', 't1', 'planning')
-    await _waitForLoop()
-
-    // Run is over server-side; subscribers were closed in the loop's finally
-    // block. A "real" client connecting now would have missed the live
-    // broadcast — getActiveStream still hands back a stream carrying the
-    // error so the toast surfaces.
-    const stream = getActiveStream()
-    expect(stream).not.toBeNull()
-
-    const reader = stream!.getReader()
-    const decoder = new TextDecoder()
-    let output = ''
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-      output += decoder.decode(value, { stream: true })
-    }
-
-    const events = output
-      .trim()
-      .split('\n')
-      .map((l) => JSON.parse(l))
-    const errorEvent = events.find((e: any) => e.type === 'error')
-    expect(errorEvent).toBeDefined()
-    expect(errorEvent.message).toContain('Claude configuration file not found')
-  })
-
-  it('clears the buffered error when a new run starts', async () => {
-    // The replay buffer must not leak across runs — once a fresh run begins
-    // the prior session's terminal error becomes irrelevant noise.
-    mockQuery.mockImplementationOnce(({ options }: any) => {
-      options.stderr?.('first run failed\n')
-      return fakeQuery([])
-    })
-    await startRun('s1', 't1', 'planning')
-    await _waitForLoop()
-
-    // Confirm the buffered error is replayable before the next run.
-    expect(getActiveStream()).not.toBeNull()
-
-    // Start a new (still-active) run; the previous error must no longer be
-    // replayed to a subscriber that connects fresh.
-    mockQuery.mockImplementation(blockingQueryImpl)
-    await startRun('s1', 't2', 'working')
-
-    const stream = getActiveStream()!
-    const reader = stream.getReader()
-    // Read with a short race — the live stream is blocking, so if the error
-    // chunk leaked into it we'd see it within the timeout.
-    const raced = await Promise.race([
-      reader.read(),
-      new Promise<{ value: undefined; done: false }>((resolve) =>
-        setTimeout(() => resolve({ value: undefined, done: false }), 30),
-      ),
-    ])
-    if (raced.value) {
-      const decoded = new TextDecoder().decode(raced.value as Uint8Array)
-      expect(decoded).not.toContain('first run failed')
-    }
-    await reader.cancel()
   })
 })
 

--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -58,6 +58,13 @@ interface RunLoopState {
   activeRunTask: string | null
   heartbeatInterval: ReturnType<typeof setInterval> | null
   selfPingInterval: ReturnType<typeof setInterval> | null
+  // Replays the most recent broadcast `error` event to a subscriber that
+  // connects after the run has already failed. Without this, runs that fail
+  // before the client mounts /api/run/stream (fast subprocess fail in
+  // planning, or any startRun → broadcastErrorEvent → cleanup window faster
+  // than SWR-driven `isRunActive` propagation) deliver the error to an empty
+  // subscriber set and the toast never reaches the user. See #227.
+  pendingErrorEvent: { chunk: Uint8Array; expiresAt: number } | null
 }
 
 const STATE_KEY = Symbol.for('__happyhq_run_loop_state__')
@@ -75,10 +82,18 @@ function getState(): RunLoopState {
       activeRunTask: null,
       heartbeatInterval: null,
       selfPingInterval: null,
+      pendingErrorEvent: null,
     }
   }
   return g[STATE_KEY]
 }
+
+// How long after a run fails the buffered `error` chunk remains replayable to
+// a late subscriber. Covers the gap between broadcast firing and the client's
+// SWR refetch + SSE mount. 30s is comfortably above SWR's polling cadence
+// while still bounded so a stale toast never surfaces a run later than its
+// own session.
+const ERROR_REPLAY_WINDOW_MS = 30_000
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -141,6 +156,8 @@ export async function startRun(
     s.subscribers = new Set()
     s.activeRunStream = streamName
     s.activeRunTask = taskName
+    // A new run supersedes any buffered terminal error from a prior run.
+    s.pendingErrorEvent = null
     startKeepalives(s)
 
     // Defer heavy work (commitGitState shells out to git synchronously) with
@@ -259,12 +276,45 @@ export function stopRun(): void {
  */
 export function getActiveStream(): ReadableStream<Uint8Array> | null {
   const s = getState()
-  if (!s.streamActive) {
-    return null
+  if (s.streamActive) {
+    const ts = new TransformStream<Uint8Array, Uint8Array>()
+    const writer = ts.writable.getWriter()
+    s.subscribers.add(writer)
+    // Replay a still-fresh buffered error to subscribers that mount mid-run
+    // (e.g. just after a transient working-iteration failure that was
+    // broadcast into an earlier subscriber set). Fire-and-forget; the live
+    // path does the same.
+    replayPendingError(s, writer)
+    return ts.readable
   }
-  const ts = new TransformStream<Uint8Array, Uint8Array>()
-  s.subscribers.add(ts.writable.getWriter())
-  return ts.readable
+  // Run already ended — but if it failed within the replay window, hand a
+  // one-shot stream that emits the buffered error and closes. This is the
+  // fix for #227: a client whose subscription mounts after the broadcast
+  // fired (because SWR hadn't yet propagated `run.status`) still sees the
+  // toast instead of getting a 404.
+  const pending = s.pendingErrorEvent
+  if (pending && pending.expiresAt > Date.now()) {
+    const chunk = pending.chunk
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk)
+        controller.close()
+      },
+    })
+  }
+  return null
+}
+
+function replayPendingError(
+  s: RunLoopState,
+  writer: WritableStreamDefaultWriter<Uint8Array>,
+): void {
+  const pending = s.pendingErrorEvent
+  if (!pending || pending.expiresAt <= Date.now()) return
+  writer.write(pending.chunk).catch(() => {
+    writer.close().catch(() => {})
+    s.subscribers.delete(writer)
+  })
 }
 
 /**
@@ -1146,7 +1196,16 @@ function broadcastErrorEvent(error: unknown, stderrTail: string): void {
     error instanceof Error ? error.message : String(error || 'Run failed')
   const composed = stderrTail ? `${message}\n\n${stderrTail}` : message
   const event: ChatStreamEvent = { type: 'error', message: composed }
-  broadcast(encodeEvent(event))
+  const chunk = encodeEvent(event)
+  broadcast(chunk)
+  // Also stash for replay so a subscriber that mounts after the run has
+  // already failed still sees the toast. See `pendingErrorEvent` doc on
+  // RunLoopState for the race this closes.
+  const s = getState()
+  s.pendingErrorEvent = {
+    chunk,
+    expiresAt: Date.now() + ERROR_REPLAY_WINDOW_MS,
+  }
 }
 
 /**

--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -58,13 +58,6 @@ interface RunLoopState {
   activeRunTask: string | null
   heartbeatInterval: ReturnType<typeof setInterval> | null
   selfPingInterval: ReturnType<typeof setInterval> | null
-  // Replays the most recent broadcast `error` event to a subscriber that
-  // connects after the run has already failed. Without this, runs that fail
-  // before the client mounts /api/run/stream (fast subprocess fail in
-  // planning, or any startRun → broadcastErrorEvent → cleanup window faster
-  // than SWR-driven `isRunActive` propagation) deliver the error to an empty
-  // subscriber set and the toast never reaches the user. See #227.
-  pendingErrorEvent: { chunk: Uint8Array; expiresAt: number } | null
 }
 
 const STATE_KEY = Symbol.for('__happyhq_run_loop_state__')
@@ -82,18 +75,10 @@ function getState(): RunLoopState {
       activeRunTask: null,
       heartbeatInterval: null,
       selfPingInterval: null,
-      pendingErrorEvent: null,
     }
   }
   return g[STATE_KEY]
 }
-
-// How long after a run fails the buffered `error` chunk remains replayable to
-// a late subscriber. Covers the gap between broadcast firing and the client's
-// SWR refetch + SSE mount. 30s is comfortably above SWR's polling cadence
-// while still bounded so a stale toast never surfaces a run later than its
-// own session.
-const ERROR_REPLAY_WINDOW_MS = 30_000
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -156,8 +141,6 @@ export async function startRun(
     s.subscribers = new Set()
     s.activeRunStream = streamName
     s.activeRunTask = taskName
-    // A new run supersedes any buffered terminal error from a prior run.
-    s.pendingErrorEvent = null
     startKeepalives(s)
 
     // Defer heavy work (commitGitState shells out to git synchronously) with
@@ -276,45 +259,12 @@ export function stopRun(): void {
  */
 export function getActiveStream(): ReadableStream<Uint8Array> | null {
   const s = getState()
-  if (s.streamActive) {
-    const ts = new TransformStream<Uint8Array, Uint8Array>()
-    const writer = ts.writable.getWriter()
-    s.subscribers.add(writer)
-    // Replay a still-fresh buffered error to subscribers that mount mid-run
-    // (e.g. just after a transient working-iteration failure that was
-    // broadcast into an earlier subscriber set). Fire-and-forget; the live
-    // path does the same.
-    replayPendingError(s, writer)
-    return ts.readable
+  if (!s.streamActive) {
+    return null
   }
-  // Run already ended — but if it failed within the replay window, hand a
-  // one-shot stream that emits the buffered error and closes. This is the
-  // fix for #227: a client whose subscription mounts after the broadcast
-  // fired (because SWR hadn't yet propagated `run.status`) still sees the
-  // toast instead of getting a 404.
-  const pending = s.pendingErrorEvent
-  if (pending && pending.expiresAt > Date.now()) {
-    const chunk = pending.chunk
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(chunk)
-        controller.close()
-      },
-    })
-  }
-  return null
-}
-
-function replayPendingError(
-  s: RunLoopState,
-  writer: WritableStreamDefaultWriter<Uint8Array>,
-): void {
-  const pending = s.pendingErrorEvent
-  if (!pending || pending.expiresAt <= Date.now()) return
-  writer.write(pending.chunk).catch(() => {
-    writer.close().catch(() => {})
-    s.subscribers.delete(writer)
-  })
+  const ts = new TransformStream<Uint8Array, Uint8Array>()
+  s.subscribers.add(ts.writable.getWriter())
+  return ts.readable
 }
 
 /**
@@ -946,6 +896,15 @@ async function runWorkingLoop(
 
       // Iteration timeout or other error — continue to next iteration.
       // "Fresh context self-heals problems."
+      //
+      // Transient (non-terminal) iteration errors stay in the runtime log
+      // (`run.iteration` below) and are not toasted. The toast surface is
+      // reserved for terminal errors that flip `.run.json` to `stopped` —
+      // those are picked up by the client's SWR-observed terminal-error
+      // toast in useTaskData (see #227). Surfacing transient stderr-fails
+      // on top would create a second timing-sensitive surface for very
+      // little user value (the run continues; the next iteration usually
+      // self-heals).
       const iterErrMsg = error instanceof Error ? error.message : String(error)
       const iterStderrTail = stderrBuf.getTail()
       await writeRunInfo(taskName, {
@@ -960,13 +919,6 @@ async function runWorkingLoop(
         planningSessionId,
         workingSessionIds,
       })
-      // Surface only when stderr was captured — that's the silent fast-fail
-      // pattern (subprocess died before emitting). Other transient errors
-      // (SDK timeouts, network blips) self-heal on the next iteration and
-      // don't deserve a toast.
-      if (iterStderrTail) {
-        broadcastErrorEvent(error, iterStderrTail)
-      }
       log('run.iteration', {
         task: taskName,
         iteration,
@@ -1196,16 +1148,7 @@ function broadcastErrorEvent(error: unknown, stderrTail: string): void {
     error instanceof Error ? error.message : String(error || 'Run failed')
   const composed = stderrTail ? `${message}\n\n${stderrTail}` : message
   const event: ChatStreamEvent = { type: 'error', message: composed }
-  const chunk = encodeEvent(event)
-  broadcast(chunk)
-  // Also stash for replay so a subscriber that mounts after the run has
-  // already failed still sees the toast. See `pendingErrorEvent` doc on
-  // RunLoopState for the race this closes.
-  const s = getState()
-  s.pendingErrorEvent = {
-    chunk,
-    expiresAt: Date.now() + ERROR_REPLAY_WINDOW_MS,
-  }
+  broadcast(encodeEvent(event))
 }
 
 /**


### PR DESCRIPTION
Closes #227

## Why the prior approach in this PR was wrong

The first commit in this branch ([d025fa4](https://github.com/happyhqdotcom/happyhq/pull/238/commits/d025fa4)) added a server-side `pendingErrorEvent` buffer with a 30-second late-connect replay window. End-to-end Exercise (source-level fault injection — synthetic `throw` at the top of `runPlanningIteration`) revealed it doesn't fix the actual race: for sub-poll-cadence fast-fails, the client's SWR poll goes straight from `no-run` → `stopped+error` without ever observing `'planning'`/`'working'`, so `useRunActivity` never mounts to consume the buffered replay. The original commit's unit tests passed because they call `getActiveStream()` directly, bypassing the client-side `isRunActive` gate that's the actual blocker.

## The fix in [f96d1fe](https://github.com/happyhqdotcom/happyhq/pull/238/commits/f96d1fe)

Toast surfacing for terminal errors moves to SWR-observed state instead of SSE replay:

- **`useTerminalErrorToast` (new)** — watches SWR-fetched run state for transitions into `status='stopped' && error`. Keyed on `run.startedAt` so initial mount snapshots without toasting (no stale errors on page load) and same-run rerenders dedupe.
- **`useRunActivity` (modified)** — now takes `runStartedAt` (used as the Sonner toast `id` for live SSE error events) and `onStreamNotFound` (fired on SSE 404 so the parent can refetch SWR — covers UI-button + fast-fail, where the run terminated between the optimistic mount and the SSE fetch landing).
- **Sonner id-based dedupe** — both paths target `id: \`run-error:\${run.startedAt}\``. A long working run that errors mid-iteration with the user actively watching produces exactly one toast: SSE delivers it live, SWR refetch a second later targets the same id and Sonner replaces in place.
- **Revert the server-side buffer** — `pendingErrorEvent`, replay path in `getActiveStream`, `replayPendingError` helper, the buffer set in `broadcastErrorEvent`, the clear-on-`startRun`. All gone.
- **Drop iteration-level transient broadcasts** — transient mid-iteration stderr-fails (where the loop continues to the next iteration) no longer broadcast `error` events. They stay in the runtime log (`run.iteration` event in `~/HappyHQ/.logs/`). Toast surface is now reserved for terminal errors only. Caveat documented in `.dev/exercising-the-ui.md` Pitfall 9.

## What this catches that the original PR's approach didn't

| Case | Original (#238 d025fa4) | This (f96d1fe) |
|---|---|---|
| Terminal fast-fail, raw POST, SWR sees no transitions | ❌ buffered replay never consumed | ✅ SWR observes terminal state, toasts |
| Terminal fast-fail, UI button (optimistic mount → SSE 404) | ⚠️ depended on SSE retry timing | ✅ onStreamNotFound triggers SWR refetch, toasts |
| Long-running terminal error, user actively watching | ✅ SSE live | ✅ SSE live (id-deduped against SWR refetch) |
| Mid-run subscriber connects after a transient working broadcast | ✅ defensive replay | ❌ no longer surfaced (transient stays in runtime log) — see Pitfall 9 caveat |

The trade-off in row 4 is deliberate: the niche case ("user's SSE drops mid-run, transient stderr-fail happens during the drop, user reconnects within window") cost ~70 lines of server-side state machine and was timing-fragile. Replaced with a clean rule: **toast surface = terminal errors only.** Transient errors are still observable via runtime log and the activity feed.

## Tests

- `happyhq/components/features/tasks/hooks/use-terminal-error-toast.test.ts:1` — pins the contract: initial-mount snapshot, fresh-run toast, same-run dedupe, multi-run, non-terminal status, mock mode.
- `happyhq/components/features/desktop/providers/desktop-initializer.test.tsx` — updated to expect the new arity in `useRunActivity` calls.
- `happyhq/lib/run/loop.server.test.ts` — reverts the two replay-buffer tests (the contract no longer exists at that layer); the pre-existing "nulls out state after error" assertion is restored.

`pnpm format` / `pnpm check-types` / `pnpm lint` / `pnpm --filter=happyhq test` all pass (1467 tests).

## Verification — Exercise

Source-level fault injection (env-gated `if (process.env.HAPPYHQ_FAULT_INJECT === 'planning-fast-fail') throw new Error('synthetic exercise fast-fail (#227)')` at the top of `runPlanningIteration`'s try block; reverted before commit). Started dev server with `HAPPYHQ_FAULT_INJECT=planning-fast-fail PORT=3030`, drove the run via `/docs/exercise-227` → click START TASK. Server fast-failed in ~500ms. Toast rendered top-right with the synthetic message. Task panel showed "Planning stopped after <1m" with restart/continue buttons.

![exercise-227-toast](https://ralphie.happyhq.com/pr/238/33f67070-54de-4207-9262-efd4d894bcb6/exercise-227-toast.png)

Tear-down confirmed: synthetic throw reverted, dev server stopped, synthetic task deleted, repo on `main` clean.

The auth-disrupt approach in this PR's original body (clearing `~/.claude.json` / unsetting `CLAUDE_CODE_OAUTH_TOKEN`) does **not** reproduce a fast-fail on macOS — Claude Code stores credentials in the keychain (`security find-generic-password -s "Claude Code-credentials"`), not in a file. Removing the file leaves auth intact and the run completes normally. The `.dev/exercising-the-ui.md` Pitfall 9 update calls this out and recommends source-level fault injection as the honest cheap reproducer.

## Housekeeping bundled

- `.gitignore`: `.playwright-mcp/` (snapshot YAMLs, console logs, Exercise screenshots).
- `.dev/exercising-the-ui.md`: convention to write Playwright MCP screenshots into `.playwright-mcp/` rather than letting them default to cwd.

## AI assistance

Authored by Ralphie (initial commit) and revised by maintainer + Claude Code based on Exercise findings. Reviewed by maintainer before merge.