### PR TITLE
test(agents): pin agentEnv() process.env preservation across all factories

### DIFF
--- a/happyhq/lib/agents/config.server.test.ts
+++ b/happyhq/lib/agents/config.server.test.ts
@@ -144,6 +144,28 @@ describe('learningAgentOptions', () => {
     })
   })
 
+  it('preserves process.env when no override is given', async () => {
+    // Regression: the SDK passes opts.env verbatim to the spawned process, so
+    // when there's no override we must spread process.env ourselves. A bug
+    // where the spread was conditional stripped ANTHROPIC_API_KEY, HOME, and
+    // PATH on the env-var auth path and the agent failed with "Not logged in".
+    const original = process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY = 'sk-from-process-env'
+    try {
+      const opts = await learningAgentOptions('my-stream', 'session-uuid-1')
+      expect(opts.env).toMatchObject({
+        ANTHROPIC_API_KEY: 'sk-from-process-env',
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+        ENABLE_TOOL_SEARCH: 'false',
+      })
+    } finally {
+      if (original === undefined) delete process.env.ANTHROPIC_API_KEY
+      else process.env.ANTHROPIC_API_KEY = original
+    }
+  })
+
   describe('canUseTool', () => {
     async function getCanUseTool(
       notifyClient?: (event: ChatStreamEvent) => void,
@@ -390,6 +412,10 @@ describe('planningAgentOptions', () => {
   })
 
   it('preserves process.env when no override is given', async () => {
+    // Regression: the SDK passes opts.env verbatim to the spawned process, so
+    // when there's no override we must spread process.env ourselves. A bug
+    // where the spread was conditional stripped ANTHROPIC_API_KEY, HOME, and
+    // PATH on the env-var auth path and the agent failed with "Not logged in".
     const original = process.env.ANTHROPIC_API_KEY
     process.env.ANTHROPIC_API_KEY = 'sk-from-process-env'
     try {
@@ -400,6 +426,8 @@ describe('planningAgentOptions', () => {
       )
       expect(opts.env).toMatchObject({
         ANTHROPIC_API_KEY: 'sk-from-process-env',
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
         CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
         ENABLE_TOOL_SEARCH: 'false',
       })
@@ -645,6 +673,32 @@ describe('workingAgentOptions', () => {
       CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
       ENABLE_TOOL_SEARCH: 'false',
     })
+  })
+
+  it('preserves process.env when no override is given', async () => {
+    // Regression: the SDK passes opts.env verbatim to the spawned process, so
+    // when there's no override we must spread process.env ourselves. A bug
+    // where the spread was conditional stripped ANTHROPIC_API_KEY, HOME, and
+    // PATH on the env-var auth path and the agent failed with "Not logged in".
+    const original = process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY = 'sk-from-process-env'
+    try {
+      const opts = await workingAgentOptions(
+        'my-stream',
+        'my-task',
+        new AbortController(),
+      )
+      expect(opts.env).toMatchObject({
+        ANTHROPIC_API_KEY: 'sk-from-process-env',
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+        ENABLE_TOOL_SEARCH: 'false',
+      })
+    } finally {
+      if (original === undefined) delete process.env.ANTHROPIC_API_KEY
+      else process.env.ANTHROPIC_API_KEY = original
+    }
   })
 
   it('includes PostToolUse hook that notifies on Write/Edit', async () => {


### PR DESCRIPTION
## Summary

- Adds `preserves process.env when no override is given` test cases to `learningAgentOptions` and `workingAgentOptions`. `planningAgentOptions` already had one.
- Strengthens all three to assert `PATH` and `HOME` pass through, not just `ANTHROPIC_API_KEY`.

## Why

The Claude Agent SDK passes `opts.env` verbatim to the spawned process — no merge with `process.env`. So when no override is provided, `agentEnv()` must spread `process.env` itself. A version of this where the spread was conditional (`{ ...override, ...flags }` with `override === undefined`) silently stripped `ANTHROPIC_API_KEY`, `HOME`, and `PATH` on the env-var auth path and the agent failed with "Not logged in." The OAuth and stored-API-key paths happened to spread `process.env` explicitly, so they masked the bug — the failure shape was *inconsistency between auth paths*, not absence of a check.

The fix landed in 536074a; this PR pins the contract so the same shape can't silently come back. Verified by reverting `agentEnv()` in `lib/agents/config.server.ts:46` to `...override` (the broken form) — all three new assertions fail with `-ANTHROPIC_API_KEY`, `-HOME`, `-PATH` missing from the diff.

This is pass 1 of a three-pass plan to back-fill regression coverage for the integration-boundary failures that have been slipping past CI.

## Test plan

- [x] `pnpm --filter happyhq test lib/agents/config.server.test.ts` — green (54/54)
- [x] Revert `lib/agents/config.server.ts:46` from `...(override ?? process.env)` to `...override` — three preservation tests fail with `ANTHROPIC_API_KEY` / `HOME` / `PATH` missing
- [x] Restore — green again

🤖 Generated with [Claude Code](https://claude.com/claude-code)