### PR TITLE
feat(smoke): golden-path end-to-end test + .txt/.md input support

### DIFF
--- a/happyhq/CLAUDE.md
+++ b/happyhq/CLAUDE.md
@@ -107,7 +107,7 @@ Key endpoints:
 - `GET  /api/fs/task?task=<slug>` — read task content, inputs, outputs, run state
 - `GET  /api/fs/task-items` — list all tasks
 - `POST /api/run/start` — start a run: `{"task":"<slug>","stream":"<slug>","mode":"planning"|"working"}`
-- `GET  /api/run/active` — poll run status (404 means done)
+- `GET  /api/run/active` — poll run status (returns `{ stream, task }` while a run is active, `null` when idle — always status 200)
 - `POST /api/run/stop` — stop active run
 - `GET  /api/run/stream` — stream NDJSON run output in real time
 - `POST /api/chat` — chat with agent: `{"message":"...","sessionId":"<uuid>","streamSlug":"<slug>"}`
@@ -116,7 +116,7 @@ Verification workflow:
 
 1. Start HappyHQ in the background (`pnpm dev &` or production build)
 2. Trigger the behavior to verify (start a run, send a chat message, etc.)
-3. Poll `/api/run/active` until 404 (run finished)
+3. Poll `/api/run/active` until the body is `null` (run finished — body stays an object while active)
 4. Read logs: `npx tsx scripts/read-logs.ts --task=<slug>`
 5. Read outputs: `curl localhost:3000/api/fs/task?task=<slug>`
 6. Kill the server when done
@@ -127,8 +127,9 @@ Run these checks after making changes. Stop at first failure and fix.
 
 1. `pnpm check-types && pnpm lint && pnpm test` — must all pass
 2. If the dev server is running: `npx tsx scripts/smoke-test.ts` — API health + error check
-3. Check for client errors: `npx tsx scripts/read-logs.ts --event=client. --last=10`
-4. Check for server errors: `npx tsx scripts/read-logs.ts --event=api.error --last=10`
-5. If you changed agent behavior, start a run and check: `npx tsx scripts/read-logs.ts --event=run. --last=10`
+3. For changes that touch task creation, run loop, agent config, or file ingestion: `pnpm smoke:e2e` — golden-path end-to-end test that creates a task with an attached file, runs planning + working, and asserts outputs
+4. Check for client errors: `npx tsx scripts/read-logs.ts --event=client. --last=10`
+5. Check for server errors: `npx tsx scripts/read-logs.ts --event=api.error --last=10`
+6. If you changed agent behavior, start a run and check: `npx tsx scripts/read-logs.ts --event=run. --last=10`
 
 Client-side errors (React crashes, failed fetches, unhandled exceptions) are forwarded to the server log automatically via `reportError()` in `lib/report-error.ts`. They appear as `client.*` events in the same log files.

--- a/happyhq/components/features/chat/composer.test.tsx
+++ b/happyhq/components/features/chat/composer.test.tsx
@@ -233,19 +233,22 @@ describe('Composer', () => {
       const emlFile = new File(['content'], 'deal.eml', {
         type: 'message/rfc822',
       })
-      const txtFile = new File(['content'], 'notes.txt', {
-        type: 'text/plain',
+      // .xyz is the canonical "permanently unsupported" extension for tests
+      // here — pick something obscure on purpose so the test doesn't churn
+      // every time ALLOWED_INPUT_EXTENSIONS grows.
+      const unsupported = new File(['content'], 'mystery.xyz', {
+        type: 'application/octet-stream',
       })
 
       fireEvent.drop(dropZone, {
-        dataTransfer: { files: [pdfFile, emlFile, txtFile] },
+        dataTransfer: { files: [pdfFile, emlFile, unsupported] },
       })
 
       await waitFor(() => {
         expect(screen.getByText('doc.pdf')).not.toBeNull()
         expect(screen.getByText('deal.eml')).not.toBeNull()
       })
-      expect(screen.queryByText('notes.txt')).toBeNull()
+      expect(screen.queryByText('mystery.xyz')).toBeNull()
     })
 
     it('clears staged files after submission', async () => {

--- a/happyhq/lib/file-types.ts
+++ b/happyhq/lib/file-types.ts
@@ -2,10 +2,17 @@
  * Single source of truth for file types accepted across upload surfaces:
  * task file pickers, chat composer, sample intake, and the agent's intake tool.
  *
- * Eager extraction in `lib/actions/ingestion.ts` only knows how to read these
- * three formats — adding others requires extending the extraction pipeline first.
+ * Binary formats (.pdf, .docx, .eml) require eager extraction in
+ * `lib/actions/ingestion.ts`. Plain-text formats (.txt, .md) need no extractor
+ * — the agent reads the original file directly via the reading list.
  */
-export const ALLOWED_INPUT_EXTENSIONS = ['.pdf', '.eml', '.docx'] as const
+export const ALLOWED_INPUT_EXTENSIONS = [
+  '.pdf',
+  '.eml',
+  '.docx',
+  '.txt',
+  '.md',
+] as const
 
 export type AllowedInputExtension = (typeof ALLOWED_INPUT_EXTENSIONS)[number]
 

--- a/happyhq/package.json
+++ b/happyhq/package.json
@@ -11,6 +11,7 @@
     "check-types": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest --watch",
+    "smoke:e2e": "npx tsx scripts/smoke-e2e.ts",
     "db:push-schema": "pnpm dlx instant-cli push schema",
     "db:push-perms": "pnpm dlx instant-cli push perms",
     "db:push": "pnpm dlx instant-cli push schema && pnpm dlx instant-cli push perms"
@@ -95,6 +96,7 @@
     "eslint-config-next": "16.2.4",
     "fast-check": "^4.6.0",
     "jsdom": "^29.1.1",
+    "playwright": "^1.59.1",
     "postcss": "^8.5.14",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",

--- a/happyhq/scripts/smoke-e2e.ts
+++ b/happyhq/scripts/smoke-e2e.ts
@@ -1,0 +1,418 @@
+#!/usr/bin/env npx tsx
+/**
+ * Golden-path smoke test — exercises the task plan→work loop end-to-end
+ * against a real dev server, real browser, real Claude SDK call.
+ *
+ *   pnpm smoke:e2e            # headless
+ *   pnpm smoke:e2e --headed   # visible chromium (debugging)
+ *
+ * Boots a fresh Next dev server with HAPPYHQ_ROOT pointed at a per-run
+ * /tmp/happyhq-smoke-<uuid>, pre-seeds a synthetic stream (playbook + spec),
+ * drives Chromium through the task creation flow, then triggers planning
+ * and working iterations via the API and asserts the produced artifacts.
+ *
+ * Run from the happyhq/ directory.
+ *
+ * See `.dev/exercising-the-ui.md` for the Playwright pitfalls this respects
+ * (networkidle lies in dev mode, first-compile is slow, hidden file inputs).
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { chromium } from 'playwright'
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const PORT = process.env.SMOKE_PORT || '3457'
+const BASE_URL = `http://localhost:${PORT}`
+const HEADED = process.argv.includes('--headed')
+const ITERATION_TIMEOUT_MS = 180_000
+const FIXTURE_DIR = path.join(process.cwd(), 'scripts', 'smoke-fixtures')
+const SMOKE_ROOT = path.join(
+  os.tmpdir(),
+  `happyhq-smoke-${crypto.randomUUID()}`,
+)
+const STREAM_SLUG = 'smoke'
+const TASK_SLUG = 'smoke-task'
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+const START = Date.now()
+
+function log(stage: string, detail?: string): void {
+  const elapsed = ((Date.now() - START) / 1000).toFixed(1).padStart(5)
+  console.log(`[smoke +${elapsed}s] ${stage}${detail ? ` — ${detail}` : ''}`)
+}
+
+class SmokeError extends Error {}
+
+function fail(stage: string, message: string): never {
+  throw new SmokeError(`${stage}: ${message}`)
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function seedFixtures(): void {
+  fs.mkdirSync(SMOKE_ROOT, { recursive: true, mode: 0o700 })
+
+  const streamDir = path.join(SMOKE_ROOT, STREAM_SLUG)
+  fs.mkdirSync(path.join(streamDir, 'specs'), { recursive: true })
+
+  fs.copyFileSync(
+    path.join(FIXTURE_DIR, 'playbook.md'),
+    path.join(streamDir, 'playbook.md'),
+  )
+  fs.copyFileSync(
+    path.join(FIXTURE_DIR, 'spec-haiku.md'),
+    path.join(streamDir, 'specs', 'haiku.md'),
+  )
+
+  // git init + initial commit so commitGitState() doesn't warn its way
+  // through every server action. Errors are silent on purpose — git absence
+  // is not a smoke failure.
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: SMOKE_ROOT, stdio: 'pipe' })
+    execFileSync(
+      'git',
+      ['-c', 'user.name=smoke', '-c', 'user.email=smoke@local', 'add', '-A'],
+      { cwd: SMOKE_ROOT, stdio: 'pipe' },
+    )
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'user.name=smoke',
+        '-c',
+        'user.email=smoke@local',
+        'commit',
+        '-q',
+        '-m',
+        'seed',
+      ],
+      { cwd: SMOKE_ROOT, stdio: 'pipe' },
+    )
+  } catch {
+    // git absent or misconfigured — fine.
+  }
+
+  log('fixtures seeded', SMOKE_ROOT)
+}
+
+// ---------------------------------------------------------------------------
+// Dev server lifecycle (delegated to scripts/dev-server.ts)
+// ---------------------------------------------------------------------------
+
+function devServer(action: 'start' | 'wait-ready' | 'stop'): void {
+  const result = spawnSync('npx', ['tsx', 'scripts/dev-server.ts', action], {
+    cwd: process.cwd(),
+    env: { ...process.env, HAPPYHQ_ROOT: SMOKE_ROOT, PORT },
+    stdio: 'inherit',
+    timeout: action === 'wait-ready' ? 120_000 : 30_000,
+  })
+  if (result.status !== 0) {
+    throw new Error(`dev-server ${action} exited with status ${result.status}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Browser flow — task creation via the real UI
+// ---------------------------------------------------------------------------
+
+async function createTaskViaUI(): Promise<void> {
+  const browser = await chromium.launch({ headless: !HEADED })
+  try {
+    const ctx = await browser.newContext({
+      viewport: { width: 1280, height: 800 },
+    })
+    const page = await ctx.newPage()
+    page.setDefaultTimeout(20_000)
+    page.setDefaultNavigationTimeout(90_000)
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error' || msg.type() === 'warning') {
+        log(`browser ${msg.type()}`, msg.text().slice(0, 300))
+      }
+    })
+    page.on('pageerror', (err) => {
+      log('browser pageerror', err.message.slice(0, 300))
+    })
+    page.on('requestfailed', (req) => {
+      log('browser requestfailed', `${req.method()} ${req.url()}`)
+    })
+
+    const url = `${BASE_URL}/tasks/${STREAM_SLUG}`
+    log('navigating', url)
+    await page.goto(url, { waitUntil: 'domcontentloaded' })
+
+    // Title is set from generateMetadata after the route compiles —
+    // a reliable post-compile signal in Next dev mode. First compile in
+    // dev mode can take 30+s, so we override the default timeout here.
+    try {
+      await page.waitForFunction(
+        () => document.title.toLowerCase().includes('smoke'),
+        null,
+        { timeout: 90_000 },
+      )
+    } catch {
+      const actualTitle = await page.title().catch(() => '<unknown>')
+      const failedUrl = page.url()
+      const screenshotPath = path.join(SMOKE_ROOT, 'failure.png')
+      await page
+        .screenshot({ path: screenshotPath, fullPage: true })
+        .catch(() => undefined)
+      fail(
+        'page load',
+        `title check timed out. url=${failedUrl} title="${actualTitle}" screenshot=${screenshotPath} (saved before cleanup)`,
+      )
+    }
+
+    log('typing task title')
+    const titleInput = page.getByPlaceholder('New task').first()
+    await titleInput.click()
+    await page.keyboard.type('smoke task')
+
+    log('typing task description')
+    await page
+      .getByPlaceholder('Add context')
+      .first()
+      .fill('Write a haiku inspired by the attached notes.')
+
+    log('attaching input file')
+    await page
+      .locator('input[type="file"]')
+      .first()
+      .setInputFiles(path.join(FIXTURE_DIR, 'input.txt'))
+
+    // Wait for the file row to render — `displayTitle` capitalises the
+    // filename, so "input.txt" shows up as "Input.txt".
+    await page
+      .getByRole('button', { name: /input\.txt$/i })
+      .waitFor({ timeout: 5_000 })
+
+    log('clicking Add task')
+    await page.getByRole('button', { name: /add task/i }).click()
+
+    // handleSubmit writes task.md first, then iterates stagedFiles and
+    // calls ingestTaskInput per file. Both are sequential awaits, so the
+    // inputs directory is the right "task creation done" signal.
+    log('waiting for task and inputs to land on disk')
+    const taskDir = path.join(SMOKE_ROOT, 'tasks', TASK_SLUG)
+    const inputsDir = path.join(taskDir, 'inputs')
+    const deadline = Date.now() + 30_000
+    while (
+      !fs.existsSync(path.join(taskDir, 'task.md')) ||
+      !fs.existsSync(inputsDir) ||
+      fs.readdirSync(inputsDir).length === 0
+    ) {
+      if (Date.now() > deadline) {
+        const taskExists = fs.existsSync(path.join(taskDir, 'task.md'))
+        const inputs = fs.existsSync(inputsDir) ? fs.readdirSync(inputsDir) : []
+        fail(
+          'createTask',
+          `task=${taskExists} inputs=[${inputs.join(',')}]; never finished`,
+        )
+      }
+      await sleep(500)
+    }
+    log('task created with inputs', fs.readdirSync(inputsDir).join(', '))
+  } finally {
+    await browser.close()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run iterations via API
+// ---------------------------------------------------------------------------
+
+async function runIteration(mode: 'planning' | 'working'): Promise<void> {
+  log(`POST /api/run/start ${mode}`)
+  const startRes = await fetch(`${BASE_URL}/api/run/start`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ task: TASK_SLUG, stream: STREAM_SLUG, mode }),
+  })
+  if (!startRes.ok) {
+    fail(
+      `run.start (${mode})`,
+      `${startRes.status} ${(await startRes.text()).slice(0, 300)}`,
+    )
+  }
+
+  // /api/run/active returns 200 with `null` body when no run is active —
+  // never 404. Poll until the body is null.
+  const deadline = Date.now() + ITERATION_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    const r = await fetch(`${BASE_URL}/api/run/active`)
+    if (!r.ok) {
+      fail(
+        `run.active (${mode})`,
+        `${r.status} ${(await r.text()).slice(0, 200)}`,
+      )
+    }
+    const info = (await r.json()) as { stream: string; task: string } | null
+    if (info === null) {
+      log(`${mode} done`, `${((Date.now() - START) / 1000).toFixed(1)}s total`)
+      return
+    }
+    await sleep(2_000)
+  }
+  fail(`run.${mode}`, `did not finish within ${ITERATION_TIMEOUT_MS / 1000}s`)
+}
+
+// ---------------------------------------------------------------------------
+// Assertions
+// ---------------------------------------------------------------------------
+
+function assertOutputs(): void {
+  const taskDir = path.join(SMOKE_ROOT, 'tasks', TASK_SLUG)
+
+  const planMd = path.join(taskDir, 'plan.md')
+  if (!fs.existsSync(planMd)) fail('assertions', 'plan.md missing')
+  const planText = fs.readFileSync(planMd, 'utf8').trim()
+  if (!planText) fail('assertions', 'plan.md empty')
+  log('plan.md OK', `${planText.length} chars`)
+
+  const outputsDir = path.join(taskDir, 'outputs')
+  if (!fs.existsSync(outputsDir)) fail('assertions', 'outputs/ missing')
+  const outputs = fs.readdirSync(outputsDir).filter((f) => f.endsWith('.md'))
+  if (outputs.length === 0) fail('assertions', 'no .md files in outputs/')
+
+  for (const f of outputs) {
+    const content = fs.readFileSync(path.join(outputsDir, f), 'utf8').trim()
+    if (!content) fail('assertions', `outputs/${f} empty`)
+    const lines = content.split('\n').filter((l) => l.trim().length > 0)
+    if (lines.length < 3) {
+      fail(
+        'assertions',
+        `outputs/${f} has fewer than 3 non-empty lines (got ${lines.length})`,
+      )
+    }
+  }
+  log('outputs OK', outputs.join(', '))
+}
+
+function assertNoErrors(): void {
+  const today = new Date()
+  const y = today.getFullYear()
+  const m = String(today.getMonth() + 1).padStart(2, '0')
+  const d = String(today.getDate()).padStart(2, '0')
+  const logFile = path.join(SMOKE_ROOT, '.logs', `${y}-${m}-${d}.jsonl`)
+
+  if (!fs.existsSync(logFile)) {
+    log('logs', 'no log file produced (skipping error scan)')
+    return
+  }
+
+  const ERROR_EVENTS = new Set([
+    'run.error',
+    'api.error',
+    'client.error',
+    'client.unhandled_rejection',
+    'client.react.error',
+    'client.react.render_error',
+  ])
+
+  const errors: { event: string; line: number }[] = []
+  const lines = fs.readFileSync(logFile, 'utf8').split('\n')
+  lines.forEach((line, i) => {
+    if (!line.trim()) return
+    try {
+      const entry = JSON.parse(line)
+      if (typeof entry.event === 'string' && ERROR_EVENTS.has(entry.event)) {
+        errors.push({ event: entry.event, line: i + 1 })
+      }
+    } catch {
+      // ignore malformed lines
+    }
+  })
+
+  if (errors.length > 0) {
+    const summary = errors
+      .slice(0, 5)
+      .map((e) => `${e.event}@${e.line}`)
+      .join(', ')
+    fail('logs', `${errors.length} error event(s): ${summary}`)
+  }
+  log('logs clean', `${lines.length} entries scanned`)
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+let stopped = false
+function stopServer(): void {
+  if (stopped) return
+  stopped = true
+  try {
+    devServer('stop')
+  } catch {
+    // best-effort
+  }
+}
+
+process.on('SIGINT', () => {
+  stopServer()
+  console.log(`\n[smoke] interrupted; smoke root preserved: ${SMOKE_ROOT}`)
+  process.exit(130)
+})
+process.on('SIGTERM', () => {
+  stopServer()
+  process.exit(143)
+})
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  log('start', `port=${PORT} root=${SMOKE_ROOT} headed=${HEADED}`)
+  let success = false
+  try {
+    seedFixtures()
+    devServer('start')
+    devServer('wait-ready')
+    await createTaskViaUI()
+    await runIteration('planning')
+    await runIteration('working')
+    assertOutputs()
+    assertNoErrors()
+    log('PASS')
+    success = true
+  } finally {
+    stopServer()
+    if (success) {
+      try {
+        fs.rmSync(SMOKE_ROOT, { recursive: true, force: true })
+      } catch {
+        // best-effort
+      }
+    } else {
+      console.log(`[smoke] smoke root preserved for debugging: ${SMOKE_ROOT}`)
+    }
+  }
+}
+
+main().catch((err) => {
+  if (err instanceof SmokeError) {
+    console.error(`\n[smoke FAIL] ${err.message}`)
+  } else {
+    console.error(
+      '\n[smoke] crashed:',
+      err instanceof Error ? err.stack : String(err),
+    )
+  }
+  process.exit(1)
+})

--- a/happyhq/scripts/smoke-fixtures/input.txt
+++ b/happyhq/scripts/smoke-fixtures/input.txt
@@ -1,0 +1,4 @@
+Three small notes for the smoke test:
+- The cat sat on the mat.
+- The mat was woven from blue yarn.
+- The yarn came from a hill in Tuscany.

--- a/happyhq/scripts/smoke-fixtures/playbook.md
+++ b/happyhq/scripts/smoke-fixtures/playbook.md
@@ -1,0 +1,10 @@
+# Smoke playbook
+
+A bare-minimum stream used by the end-to-end smoke test. Tasks here ask for
+a small piece of writing inspired by an attached input.
+
+## Process
+
+1. Read the task description and any attached input under `inputs/`.
+2. Plan a haiku that meets the criteria in `specs/haiku.md`.
+3. Write the haiku to `outputs/haiku.md`.

--- a/happyhq/scripts/smoke-fixtures/spec-haiku.md
+++ b/happyhq/scripts/smoke-fixtures/spec-haiku.md
@@ -1,0 +1,12 @@
+# Haiku
+
+A short three-line poem inspired by an attached input. Lives at
+`outputs/haiku.md`.
+
+## Format
+
+- Three lines. The traditional 5-7-5 syllable shape is encouraged but not
+  enforced — readability and resonance matter more than syllable count.
+- No title, no front matter, no surrounding prose. Just the three lines.
+- Draws imagery or phrasing from something that actually appears in the
+  input — at least one concrete noun should be recognisable.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       postcss:
         specifier: ^8.5.14
         version: 8.5.14
@@ -3005,6 +3008,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3982,6 +3990,16 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -7346,8 +7364,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -7369,7 +7387,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7380,22 +7398,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7406,7 +7424,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7691,6 +7709,9 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   fresh@2.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -8940,6 +8961,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- New `pnpm smoke:e2e` script that exercises the task plan→work loop end-to-end against a real dev server, real browser, and real Claude SDK call. ~70s per run; local-only for now.
- Adds `.txt` and `.md` to `ALLOWED_INPUT_EXTENSIONS`. Plain-text formats need no extractor — the agent reads the original file via the reading list, so the existing extractor chain in `lib/actions/ingestion.ts` falls through cleanly.
- Updates the chat composer's "filters out unsupported files" test to use `.xyz` so the assertion doesn't churn every time the allowlist grows.
- Corrects the `/api/run/active` doc in `CLAUDE.md` (returns 200 with `null` body when idle, never 404).

## What the smoke does

1. Sets `HAPPYHQ_ROOT=/tmp/happyhq-smoke-<uuid>` and seeds a synthetic stream with a playbook + haiku spec.
2. Boots `pnpm dev` on port 3457 via `scripts/dev-server.ts`.
3. Drives Chromium through `/tasks/smoke`: types a title, types a description, attaches `scripts/smoke-fixtures/input.txt`, clicks Add task.
4. Polls disk for `tasks/smoke-task/task.md` and `inputs/<file>` to land.
5. Starts a planning iteration via `POST /api/run/start`, polls `/api/run/active` until idle.
6. Starts a working iteration the same way.
7. Asserts `plan.md` and `outputs/haiku.md` are non-empty and no `run.error` / `api.error` / `client.error` events are in the smoke root's logs.
8. Stops the dev server. Smoke root is removed on success, preserved for inspection on failure.

## Test plan

- [ ] `pnpm --filter happyhq smoke:e2e` from the repo root — passes in ~60–90s, ~$0.30–$1.50 in real Claude API spend
- [ ] `pnpm smoke:e2e --headed` works visually for debugging
- [ ] `pnpm test` — all 1465 unit tests pass (composer test updated)
- [ ] `pnpm check-types && pnpm lint` clean

## Follow-up (not in this PR)

CI workflow + scheduled deployed-target run land separately as Pass 2.5 / Pass 3 of the broader confidence-backstop plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)