### PR TITLE
feat(qa): local QA loop — agent-driven, batch-aware, with bisect

### DIFF
--- a/happyhq/.dev/PROMPT_qa_execute.md
+++ b/happyhq/.dev/PROMPT_qa_execute.md
@@ -1,0 +1,139 @@
+0a. Read @qa-rubric.md — this is the spec. Apply it literally.
+0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
+0c. Read [@.dev/exercising-the-ui.md](.dev/exercising-the-ui.md) — owns the Playwright knowledge you'll use for bespoke driving (helpers, pitfalls, routing cheat-sheet).
+0d. **Read the triage plan.** Find the latest plan: `ls -t ~/.cache/qa/triage-*.md | head -1`. If empty, exit with `No triage plan found — run with --triage-only or full pipeline first`. Read the plan in full; you'll execute its test units in order.
+
+1. **Pre-flight.** Confirm you're in the qa worktree: `git rev-parse --show-toplevel` should end in `happyhq-qa`. Confirm `${BASE_BRANCH}` is set (the wrapper exports it). Confirm the working tree is clean — if not, error out (the wrapper should have hard-reset already).
+
+2. **For each test unit in plan order**, run the matching strategy below. Between units, **always** return to `${BASE_BRANCH}` with a clean tree (`git checkout ${BASE_BRANCH} && git reset --hard origin/main`) and **always** stop any orphan dev server (`npx tsx scripts/dev-server.ts stop` from `happyhq/`). Skip units gracefully on error: log the failure, label `ralphie:qa-fail` with the error detail, move on to the next unit.
+
+## Strategy: `evidence-sufficient`
+
+For a single non-critical-path PR with adequate Exercise evidence in its body.
+
+1. Re-read the PR body and embedded evidence: `gh pr view ${PR_NUMBER} --comments`.
+2. Apply the rubric's "What makes Exercise evidence sufficient" check. If the embedded evidence really does cover the changed surface, proceed; if it's thin, **promote this unit to `smoke-bespoke`** for the actual surface and re-run from that strategy.
+3. Apply label: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-pass"`.
+4. Post the qa-pass comment per the rubric's "Comment shape (qa-pass)" — strategy `evidence-sufficient`. Cite the specific evidence relied on.
+
+## Strategy: `smoke-isolated`
+
+For a single critical-path PR.
+
+1. `git checkout ${BASE_BRANCH}` (in case a prior unit left state). Hard reset to origin/main.
+2. `gh pr checkout ${PR_NUMBER}` from the qa worktree's `happyhq-qa` directory.
+3. If `pnpm-lock.yaml` changed in the diff: `pnpm install`. Else skip (saves time).
+4. From `happyhq/`: `pnpm smoke:e2e`. Capture the full output (stdout + stderr) — you'll quote the last 30 lines on failure.
+5. **On pass:**
+   - Apply label: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-pass"`.
+   - Post the qa-pass comment — strategy `smoke`. Quote the timing (`PASS in Xs`), note the fixture used, note that no `run.error` events appeared in the smoke logs.
+6. **On fail:**
+   - Apply label: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-fail"`.
+   - Post the qa-fail comment per the rubric's "Comment shape (qa-fail)" — strategy `smoke`. Quote the failing step, the last 30 log lines, and the preserved smoke root path. If the smoke produced a `failure.png` screenshot, upload via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <screenshot-dir>` and embed the URL.
+7. Return to `${BASE_BRANCH}`. Stop any dev server.
+
+## Strategy: `smoke-bespoke`
+
+For a critical-path PR where the smoke alone wouldn't cover a specific surface (e.g., chat composer drag-and-drop, learning-mode flow). The triage plan names the surface and the scenario.
+
+1. Same as `smoke-isolated` steps 1–4 — get the smoke baseline.
+2. **On smoke fail:** label `ralphie:qa-fail` and stop. The bespoke scenario only runs after smoke baseline passes.
+3. **On smoke pass:** drive the bespoke scenario the triage plan specified.
+   - Use the Playwright MCP tools (registered in `.mcp.json`) to drive the affected screen. Follow the conventions in `.dev/exercising-the-ui.md` (waits, hidden file inputs, dynamic button labels, etc.).
+   - For server-only bespoke scenarios, drive via the API per CLAUDE.md's "Using HappyHQ's API for verification" section.
+   - Capture screenshots for each step. Save to a directory like `/tmp/qa-bespoke-${PR_NUMBER}/`.
+4. **On bespoke scenario pass:**
+   - Upload screenshots: `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} /tmp/qa-bespoke-${PR_NUMBER}/`. Capture the returned URLs.
+   - Apply label: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-pass"`.
+   - Post the qa-pass comment — strategy `bespoke`. Describe what was driven, what was asserted, and embed the screenshot URLs as inline `![](url)` markdown.
+5. **On bespoke scenario fail:**
+   - Apply label: `ralphie:qa-fail`.
+   - Post the qa-fail comment — strategy `bespoke`. Describe what broke, embed the screenshot of the broken state, link the smoke root.
+6. Return to `${BASE_BRANCH}`. Stop any dev server.
+
+## Strategy: `smoke-batched`
+
+For N PRs that the triage judged integration-safe to test together.
+
+1. `git checkout ${BASE_BRANCH}` and hard reset to origin/main.
+2. Create a fresh integration branch: `git checkout -b qa/integration-$(date +%Y%m%dT%H%M%S)`.
+3. For each PR in the unit (in plan order):
+   - Fetch its head: `gh pr view <#> --json headRefName,headRefOid --jq '.headRefOid'`. Cherry-pick the merge: `git fetch origin pull/<#>/head:qa-pr-<#> && git merge --no-ff qa-pr-<#> -m "qa: integrate #<#>"`.
+   - On merge conflict: abort the integration (`git merge --abort && git reset --hard ${BASE_BRANCH}`). Label all PRs in the unit `ralphie:qa-fail` with a "merge conflict on QA integration with #X" comment. Move on to next unit.
+4. If any PR in the unit changed `pnpm-lock.yaml`: `pnpm install`.
+5. Run smoke: `pnpm smoke:e2e`.
+6. **On pass:**
+   - For each PR in the unit: apply `ralphie:qa-pass` label, post the qa-pass comment — strategy `batched`. Note which other PRs were in the integration (`PRs #X, #Y, #Z were tested together`) and the smoke output.
+7. **On fail:** enter the bisect flow (next section).
+8. Return to `${BASE_BRANCH}`. Stop any dev server. Delete the integration branch (`git branch -D qa/integration-...`).
+
+### Bisect flow (only when `smoke-batched` fails)
+
+The integration branch contains all N PRs and smoke just failed against it.
+
+1. Initialize:
+   - `BISECT_BUDGET=6` — the rubric's cost cap on additional smoke runs.
+   - `BISECT_RUNS=0`.
+   - `INNOCENT=[]` (PRs proven not at fault).
+   - `SUSPECTS=[all N PRs]`.
+
+2. **For cohorts of size ≥ 4: halving bisect.** Otherwise: drop-one bisect.
+
+   **Halving:**
+   - Split SUSPECTS into HALF_A and HALF_B.
+   - Build an integration branch with INNOCENT + HALF_A. Run smoke. `BISECT_RUNS += 1`.
+   - If pass: HALF_A is innocent. Move HALF_A into INNOCENT. SUSPECTS = HALF_B.
+   - If fail: HALF_B is innocent (or independent). Move HALF_B into INNOCENT. SUSPECTS = HALF_A.
+   - When SUSPECTS = single PR: that's the culprit. Stop bisect.
+
+   **Drop-one:**
+   - For each PR in SUSPECTS (largest-diff or critical-path-touching first):
+     - Build integration branch with `(SUSPECTS - {pr}) + INNOCENT`. Run smoke. `BISECT_RUNS += 1`.
+     - If pass: `pr` is the culprit. Stop bisect.
+     - If fail: `pr` is innocent. Move it to INNOCENT. Continue.
+
+3. **Cost cap:** if `BISECT_RUNS >= BISECT_BUDGET` and SUSPECTS is still > 1, abandon bisect.
+   - Label every PR in the original unit `ralphie:qa-fail`.
+   - Post the qa-fail comment — strategy `bisect-non-converge`. Describe what was tried (each integration tried, each result), name the SUSPECTS that remained.
+
+4. **On convergence:**
+   - Label the culprit `ralphie:qa-fail`. Post the qa-fail comment — strategy `bisect-converged-here`. Quote the failing smoke output. Note the bisect path (`tested with [A, B, C] → fail; with [B, C] → pass; culprit is A`). Note which PRs are now `qa-pass`.
+   - For every PR in INNOCENT: label `ralphie:qa-pass`. Post the qa-pass comment — strategy `batched`. Note the bisect path that proved innocence.
+
+5. Return to `${BASE_BRANCH}`. Stop any dev server. Delete all integration branches and `qa-pr-*` branches.
+
+## After all units processed
+
+1. Print a summary to stdout:
+   ```
+   QA execute complete.
+     Units processed: N
+     PRs labeled qa-pass: X
+     PRs labeled qa-fail: Y
+     PRs deferred (errors): Z
+   ```
+2. Return to `${BASE_BRANCH}`. Confirm clean tree. Exit.
+
+## Common operations
+
+**Stopping the dev server.** Always run `npx tsx scripts/dev-server.ts stop` from `happyhq/` after every smoke invocation, even between units. The dev server's pid file is per-CWD-hashed, so the qa worktree's pid file is distinct from the maintainer's primary, but leaving an orphan running ties up port and memory.
+
+**Killing background processes on unexpected exit.** If a session aborts mid-bisect, also `pkill -f "next dev"` and `pkill -f "node.*vitest"` as belt-and-braces.
+
+**Preserving evidence on failure.** The smoke script preserves its smoke root on failure (under `/tmp/happyhq-smoke-*`). When labeling `ralphie:qa-fail`, cite that path in the comment — the maintainer can inspect the artifacts there. Do **not** delete the smoke root after a failure.
+
+**Comment formatting.** Use the rubric's "Comment shape" formats verbatim. Substitute the strategy name into the first line. The maintainer reads these comments in their queue review — make them scan-friendly.
+
+**${DRY_RUN_NOTE}**
+
+**${OVERRIDE_NOTE}**
+
+3. Exit.
+
+**[1]** ONE QA execute pass per session. Process all units in the triage plan, then exit. The orchestrator handles re-runs.
+**[2]** Hard constraints from @qa-rubric.md are non-negotiable: never auto-merge, never push to a PR's branch, never apply both `qa-pass` and `qa-fail` to the same PR, never QA fork PRs (apply qa-fail with v1-limitation comment), only operate in the qa worktree.
+**[3]** Cite evidence in every comment. Quote smoke output, link smoke roots, embed screenshot URLs. Comments are the artifact future-readers consume — they need to stand alone.
+**[4]** Bisect cheaply. The 6-run cost cap is a real budget; abandoning is a legitimate outcome.
+**[5]** Always end on `${BASE_BRANCH}` with a clean working tree, between units AND at session exit. Even on failed units. Even on bisect non-converge.
+**[6]** Stop the dev server between units. Smoke leaves it running on success/fail (the script's own cleanup), but defensively `dev-server.ts stop` so the next unit boots fresh.
+**[7]** AI disclosure not required on QA comments — the comment isn't the author claim, it's the verification artifact. The PR body's existing AI disclosure stands.

--- a/happyhq/.dev/PROMPT_qa_triage.md
+++ b/happyhq/.dev/PROMPT_qa_triage.md
@@ -1,0 +1,58 @@
+0a. Read @qa-rubric.md — this is the spec. Apply it literally.
+0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
+
+1. Get the queue: `gh pr list --state open --limit 100 --json number,title,author,headRefName,labels,createdAt,body --jq '[.[] | select(.labels | map(.name) | any(. == "ralphie:ready-to-merge")) | select(.labels | map(.name) | any(. == "ralphie:qa-pass" or . == "ralphie:qa-fail") | not)] | sort_by(.createdAt)'`. Empty → exit cleanly.
+
+2. For each PR in the queue, in parallel where it makes sense (use Sonnet subagents for diff reads), gather context:
+   - Read the diff: `gh pr diff <#>`. Capture the full diff in working memory; you'll classify against the rubric's critical-path table.
+   - Read the body and comments: `gh pr view <#> --comments`. Note the **Exercise evidence** — embedded `![](...)` screenshot URLs, "Visual evidence" sections, log excerpts, the "what was exercised" sentence.
+   - Note the author. PRs from the bugs / tech-debt / dependency loops will have a different author signature in the body's AI-disclosure paragraph than human-authored PRs. Don't treat one source as more trustworthy — read the diff regardless.
+
+3. For each PR, classify against the rubric's **critical path** definition:
+   - **Critical-path** if the diff touches any path in the rubric's table (lib/agents, lib/run, lib/fs, lib/actions, app/api/run, app/api/fs, lib/file-types.ts, components/features/tasks, components/features/chat, etc.) OR is a dep bump in the elevated-scrutiny list.
+   - **Non-critical-path** if the diff is purely `*.md`/`*.mdx`, `*.css`, Tailwind, or string-literal copy changes in `.tsx` (no logic / prop / handler changes).
+   - **Straddle case** (a TSX file with both copy and a new conditional, etc.): treat as critical-path. When in doubt, smoke.
+
+4. **Decide cohort policy.** Apply the rubric's cohort heuristics (`Batch when` / `Isolate when`) to produce a list of **test units**. Each unit has:
+   - One or more PRs (by number).
+   - A strategy: `evidence-sufficient`, `smoke-isolated`, `smoke-bespoke`, or `smoke-batched`.
+   - A one-paragraph reasoning.
+   - For `smoke-bespoke` units: the specific surface or scenario the smoke wouldn't cover and that bespoke driving will exercise (e.g., "drive the chat composer's drag-and-drop with a docx").
+   - For `smoke-batched` units: a one-line note on why these PRs are integration-safe to test together.
+
+5. **Order the test units.** Riskier first — `smoke-isolated` and `smoke-bespoke` before `smoke-batched` and `evidence-sufficient`. Within a tier, follow the queue order (oldest createdAt first).
+
+6. **Write the plan** to `~/.cache/qa/triage-$(date +%Y%m%dT%H%M%S).md`. Format:
+
+   ```markdown
+   # QA triage — <UTC timestamp>
+
+   Queue: <N> PRs. Test units: <M>.
+
+   ## Unit 1 — <strategy>: PR #X (and #Y, #Z if batched)
+
+   **Reasoning:** <one paragraph — why this strategy fits, what surface to verify, what to look for>
+
+   **Diff summary:** <one or two sentences — what changed>
+
+   **Exercise evidence:** <link to or quote the embedded evidence; "none" if absent>
+
+   **Bespoke scenario** (if smoke-bespoke): <one paragraph — the specific flow to drive, the assertion>
+
+   **Batch context** (if smoke-batched): <why these are integration-safe together>
+
+   ---
+
+   ## Unit 2 — ...
+   ```
+
+7. Print a one-line summary to stdout: `Triaged N PRs into M test units. Plan: ~/.cache/qa/triage-<timestamp>.md`. Exit.
+
+8. ${DRY_RUN_NOTE}
+
+**[1]** Triage is read-only on the repo and write-only on the local plan file (`~/.cache/qa/triage-*.md`). Never label, comment, branch, commit, push, or open a PR in this phase. The execute phase does all of that.
+**[2]** Apply the critical-path table literally. If the diff touches a path in the table, the PR is critical-path — don't talk yourself into "but it's a small change in `lib/run/`." The whole point of the table is to remove that judgment call.
+**[3]** When the rubric is ambiguous about a PR, lean toward smoking. The cost of a false-positive smoke run is ~90s; the cost of a false-negative pass is a regression in main.
+**[4]** If a PR's diff is empty or `gh pr diff` errors (e.g., the PR was just rebased mid-triage), skip it from this run — it'll be picked up on the next pass. Note in the plan: `Unit N — skipped: diff fetch failed, retry next run`.
+**[5]** Do not run smoke yet. Triage produces a plan; execute is what actually drives the dev server.
+**[6]** Do not write the plan to anywhere other than `~/.cache/qa/triage-<timestamp>.md`. The execute phase reads from there.

--- a/happyhq/.dev/qa-rubric.md
+++ b/happyhq/.dev/qa-rubric.md
@@ -1,0 +1,184 @@
+# QA Rubric
+
+Source of truth for how Ralphie acts as the QA gate on PRs marked `ralphie:ready-to-merge`. Both `PROMPT_qa_triage.md` and `PROMPT_qa_execute.md` load this file. Edit here, not in the prompts.
+
+## Queue contract
+
+- The queue is: GitHub PRs that are `state:open`, labeled `ralphie:ready-to-merge`, and have neither `ralphie:qa-pass` nor `ralphie:qa-fail`.
+- `ralphie:qa-pass` and `ralphie:qa-fail` are terminal — Ralphie never re-evaluates a labeled PR. The maintainer removes the label to re-queue (e.g., after rebasing past a fix).
+- One outcome per PR per session. Cohorts (multi-PR test units) may produce multiple terminal labels in a single execute pass.
+
+## What this rubric is not
+
+The QA loop is not "run smoke on every PR." A static gate doing that would catch a slice of regressions and miss the more interesting ones — integration failures across a queue, judgment calls about whether the author's Exercise evidence already covers the surface, decisions about batching that need diff-level reading. This rubric encodes the engineering judgment a senior reviewer would apply, not a substitute for it.
+
+The author of the PR (whether human or an upstream Ralphie loop) has already done their own work — `pnpm test`, `pnpm lint`, `pnpm check-types`, and an Exercise step that drove the user-visible surface and embedded evidence in the PR body. The QA loop reads all of that as context. It's the _second_ pair of eyes, not the first.
+
+## Phases
+
+The loop runs in two phases, like the other Ralphie loops:
+
+- **Phase 1 — Triage.** Reads the queue, reads diffs and PR bodies, decides cohort policy. Output is a markdown plan listing test units in execute order. Triage never writes code, never labels, never comments. Just plans.
+- **Phase 2 — Execute.** Reads the triage plan, runs each test unit in order, applies terminal labels and explanatory comments.
+
+Triage and execute share this rubric. Triage uses it to decide what to test and how to group; execute uses it to decide what counts as evidence and what counts as failure.
+
+## Critical path
+
+Whether a PR's diff touches the **critical path** is the central question. Critical-path PRs require _actual verification_ (smoke, bespoke driving, or both). Non-critical-path PRs can be passed on Exercise evidence alone, or passed as trivial when the diff is purely cosmetic.
+
+A PR is **critical-path** if its diff touches any of:
+
+| Surface                                                                             | Why                                                              |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `lib/agents/`                                                                       | Agent config, prompt assembly, env spread to spawned SDK         |
+| `lib/run/`                                                                          | Run loop state machine                                           |
+| `lib/fs/`                                                                           | Filesystem helpers, path resolution, read/write boundaries       |
+| `lib/actions/`                                                                      | Server actions (`createTask`, `ingestTaskInput`, etc.)           |
+| `app/api/run/`                                                                      | Run start / active / stream endpoints                            |
+| `app/api/fs/`                                                                       | Filesystem APIs powering the UI                                  |
+| `app/api/auth/` or `lib/accounts/auth.server.ts`                                    | Auth resolution                                                  |
+| `lib/file-types.ts`                                                                 | Input format gating                                              |
+| `lib/config/`                                                                       | Config defaults the loop reads                                   |
+| `components/features/tasks/`                                                        | Task UI: create dialog, file staging, panel                      |
+| `components/features/chat/`                                                         | Chat composer: drag/drop, file upload                            |
+| `components/features/desktop/hooks/use-run-activity.ts`                             | SSE subscription to the run stream                               |
+| `package.json` / `pnpm-lock.yaml` bumping any of:                                   | These shift runtime semantics in ways tests don't always observe |
+| &nbsp;&nbsp;&nbsp;`@anthropic-ai/claude-agent-sdk`                                  |                                                                  |
+| &nbsp;&nbsp;&nbsp;`@anthropic-ai/sdk`                                               |                                                                  |
+| &nbsp;&nbsp;&nbsp;`next`, `react`, `react-dom`                                      |                                                                  |
+| &nbsp;&nbsp;&nbsp;`playwright` (smoke-e2e depends on it)                            |                                                                  |
+| &nbsp;&nbsp;&nbsp;Any auth/billing primitive (`stripe`, `instantdb`, JWT/OIDC libs) |                                                                  |
+
+A PR that _only_ touches:
+
+- `*.md` and `*.mdx` (docs and specs)
+- `*.css` and Tailwind config
+- Files outside `lib/`, `app/`, `components/`, root package.json
+- String-literal copy changes in `.tsx` files (no logic change, no prop change, no handler change — judged by reading the diff)
+
+is **not critical-path**.
+
+When the diff straddles the line — e.g., a TSX file with both a copy change and a new conditional — treat as critical-path. The diff-reading judgment is conservative: when in doubt, smoke.
+
+## Triage outcomes (Phase 1)
+
+Triage groups the queue into **test units**, each a list of one or more PRs and a strategy. The plan is written to `~/.cache/qa/triage-<timestamp>.md` so the maintainer can eyeball it before execute kicks off.
+
+For each test unit, the strategy is one of:
+
+- **`evidence-sufficient`** (1 PR, non-critical-path). Diff is cosmetic / docs / clearly-trivial. Execute passes on Exercise evidence (or the trivial nature itself) without running smoke.
+- **`smoke-isolated`** (1 PR, critical-path). Smoke runs against this PR alone.
+- **`smoke-bespoke`** (1 PR, critical-path with a specific surface the smoke doesn't cover). Smoke runs as sanity, plus a bespoke Playwright scenario the triage flagged.
+- **`smoke-batched`** (N PRs, none critical-path _or_ all touching disjoint non-overlapping surfaces with low integration risk). Smoke runs once against the integrated branch.
+
+### Cohort policy
+
+Triage decides batching circumstantially. Heuristics:
+
+**Batch (`smoke-batched`) when:**
+
+- All PRs in the batch are non-critical-path, OR
+- Multiple PRs all touch the _same_ low-risk surface (e.g., three Tailwind tweaks in different components — integration is unlikely to surprise), OR
+- All PRs are mechanical / codemod-shaped (e.g., a sweep of `displayTitle` rename across many call-sites).
+
+**Isolate (`smoke-isolated`) when:**
+
+- PR touches critical path AND another PR in the queue also touches critical path (different code paths under the same critical surface = real integration risk).
+- PR is large (>10 files or >300 lines, excluding `*.md`/`*.mdx`).
+- PR is a dep bump in the elevated-scrutiny list (agent SDK, framework, playwright).
+- PR's diff straddles two distant areas of the codebase that don't normally co-evolve.
+
+**Order:** within a single execute run, riskier units first (`smoke-isolated` and `smoke-bespoke` before `smoke-batched` and `evidence-sufficient`). If a high-risk unit fails, the maintainer sees it before the low-risk batch consumes attention.
+
+## Execute outcomes (Phase 2)
+
+For each test unit in plan order:
+
+| Outcome             | Label applied                                                | Comment                                                                                                       |
+| ------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Evidence sufficient | `ralphie:qa-pass` per PR                                     | Cite the Exercise evidence relied on; explain why it covers the changed surface                               |
+| Smoke pass          | `ralphie:qa-pass` per PR                                     | Cite the smoke run output (timing, scenarios run); link to logs / screenshots if bespoke driving produced any |
+| Batch pass          | `ralphie:qa-pass` per PR                                     | Note batch context (which PRs were tested together) and the smoke result                                      |
+| Bespoke pass        | `ralphie:qa-pass` per PR                                     | Describe the bespoke scenario driven (what was clicked, what was asserted), link to evidence                  |
+| Smoke fail (single) | `ralphie:qa-fail` per PR                                     | Quote the failure (last 30 log lines), link the smoke root path / preserved screenshots                       |
+| Batch fail → bisect | `ralphie:qa-fail` on culprit; `ralphie:qa-pass` on innocents | Comment on each PR explaining the bisect path; only the culprit gets the failure detail                       |
+| Bisect non-converge | `ralphie:qa-fail` on all                                     | Note that bisect couldn't isolate (likely flake / env drift); recommend manual investigation                  |
+
+### What makes Exercise evidence sufficient
+
+For `evidence-sufficient` units, the agent reads the PR body and judges whether the author's Exercise step adequately covers the changed surface. Sufficient if:
+
+- The PR body has a "Visual evidence" or equivalent section with embedded screenshots / log excerpts.
+- The driven scenario matches what a senior reviewer's first concern would be — for a file-upload bug fix, the Exercise drove a file upload; for a chat composer change, the Exercise sent a message.
+- For server-only changes, the cited log excerpt or API response demonstrates the expected behavior on the actual code path.
+- The "what was exercised" sentence in the PR body is concrete enough that a reader can verify the claim against the embedded evidence (not "I tested it thoroughly").
+
+If any of those is missing or thin, the unit is not `evidence-sufficient` even if the diff looks small. Reclassify as `smoke-bespoke` (or escalate to maintainer with a `qa-fail` if smoke is also unable to verify the surface in question).
+
+### Bisect on batch failure
+
+When a `smoke-batched` unit fails:
+
+1. The current integration branch contains all PRs in the batch.
+2. Drop one PR (drop the riskiest first — the one closest to critical path or the largest diff). Re-run smoke against the smaller integration.
+3. If the smaller integration **passes**: the dropped PR is the culprit. Label it `ralphie:qa-fail`; label the rest `ralphie:qa-pass`.
+4. If the smaller integration **fails**: the dropped PR is innocent. Re-add it; drop the next-riskiest. Repeat.
+5. **Halving heuristic for cohorts ≥ 4:** instead of dropping one at a time, drop half. Identifies the culprit in `log2(N)` smoke runs.
+6. **Cost cap:** 6 additional smoke runs (~10 min). Beyond that, abandon bisect, label all `ralphie:qa-fail` with a "bisect non-converge" comment.
+
+### Comment shape (qa-pass)
+
+```
+QA: pass — <evidence-sufficient | smoke | bespoke | batched>
+
+What was checked: <1–2 sentences — the surface, the scenario, what evidence was relied on>
+
+Evidence: <link to screenshots / log excerpts / smoke output>
+
+<For batched: list the other PRs tested in the same integration>
+```
+
+### Comment shape (qa-fail)
+
+```
+QA: fail — <smoke | bespoke | bisect-converged-here | bisect-non-converge>
+
+What broke: <1–2 sentences — the failure mode, where it surfaced>
+
+Evidence: <last 30 lines of relevant log; link to preserved smoke root or screenshots>
+
+<For bisect-converged: which other PRs were innocent and got qa-pass>
+<For bisect-non-converge: what was tried, why it didn't isolate>
+
+What unblocks it: <one sentence — what the maintainer or upstream loop should fix>
+```
+
+## Hard constraints (never violate)
+
+- **Never auto-merge.** The QA loop only labels and comments. The maintainer is always the merge gate.
+- **Never modify a PR's branch.** No `git push` to the PR's head. No force-push. No commits made on the PR's behalf.
+- **Never apply both `ralphie:qa-pass` and `ralphie:qa-fail` to the same PR.** Terminal-label rule.
+- **Never QA a PR from a fork** (v1 limitation — `gh pr checkout` permissions complexity not solved yet). Apply `ralphie:qa-fail` with a "v1 doesn't support fork PRs" comment and surface for manual review.
+- **Never run smoke against a PR's branch in the maintainer's primary checkout** — only in `../happyhq-qa`.
+- **Never delete or close a PR.** Labels and comments only.
+
+## Principles
+
+These tune _how_ the allowed work gets done. Not gates.
+
+**Judgment is the load-bearing thing.** The reason this loop exists rather than a static GH Action is that path-rules can't tell UI copy from logic. When the rubric is ambiguous about whether to smoke, lean toward smoking — false positive smoke runs cost ~90s; false negative passes ship regressions.
+
+**Cite evidence, always.** Every comment links or quotes specific artifacts. "QA: pass — looked fine" is never the comment; "QA: pass — smoke ran in 78s, plan.md and outputs/haiku.md both produced; preserved at /tmp/...." is the comment.
+
+**Trust but verify Exercise.** When the author claims Exercise covered the surface, look at the embedded evidence and judge for yourself. The Exercise step is upstream defense, not blank trust.
+
+**Smaller cohorts when uncertain.** Batching saves smoke runs but multiplies failure ambiguity. When unsure whether two PRs interact, isolate.
+
+**Bisect cheaply, escalate fast.** When bisect hits the cost cap, surface the situation rather than burning more runs. The maintainer's time is more valuable than another 10 minutes of smoke.
+
+**A pass isn't just the label.** The comment is the artifact a future reader uses to understand what was verified. Write it like that — with enough detail that someone reading the PR a month later understands what evidence the QA loop saw.
+
+## Tuning signal
+
+When the QA loop gets it wrong — passes a PR that broke main, fails a PR that was actually fine, batches things it shouldn't have — that's a rubric-tuning signal, not a one-off correction. Edit this file. The next run picks up the change.

--- a/happyhq/.dev/qa.sh
+++ b/happyhq/.dev/qa.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+set -o pipefail
+# Usage: ./qa.sh [options]
+#   ./qa.sh                    # triage + execute on PRs labeled ralphie:ready-to-merge
+#   ./qa.sh --triage-only      # Phase 1 only — write the cohort plan, don't execute
+#   ./qa.sh --execute-only     # Phase 2 only — read latest plan, run it
+#   ./qa.sh --pr 240           # skip triage; QA one specific PR (treated as smoke-isolated)
+#   ./qa.sh --pr 240 --override # also bypass any soft-skip rules for that PR
+#   ./qa.sh --dry-run          # Phase 1 preview only, no plan file written
+
+DIM='\033[2m'
+BOLD='\033[1m'
+GREEN='\033[32m'
+CYAN='\033[36m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+TRIAGE_ONLY=0
+EXECUTE_ONLY=0
+SINGLE_PR=""
+DRY_RUN=""
+OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --triage-only)
+            TRIAGE_ONLY=1
+            shift
+            ;;
+        --execute-only)
+            EXECUTE_ONLY=1
+            shift
+            ;;
+        --pr)
+            SINGLE_PR="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --override)
+            OVERRIDE=1
+            shift
+            ;;
+        -h|--help)
+            sed -n '3,9p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ $TRIAGE_ONLY -eq 1 ] && [ $EXECUTE_ONLY -eq 1 ]; then
+    echo "Error: --triage-only and --execute-only are mutually exclusive" >&2
+    exit 1
+fi
+if [ $EXECUTE_ONLY -eq 1 ] && [ -n "$DRY_RUN" ]; then
+    echo "Error: --execute-only --dry-run isn't supported (dry-run on execute would burn smoke runs and skip writes — pointless)." >&2
+    exit 1
+fi
+if [ -n "$OVERRIDE" ] && [ -z "$SINGLE_PR" ]; then
+    echo "Error: --override is only valid with --pr <#>." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+# ── Worktree-aware base branch resolution ──
+# Same pattern as bugs.sh / dependency.sh — the QA worktree owns `loop/qa`,
+# the primary checkout is `main`. Anything else is an error: QA must run
+# from a known location.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+case "$REPO_ROOT" in
+    */happyhq-qa)
+        BASE_BRANCH="loop/qa"
+        ;;
+    */happyhq)
+        BASE_BRANCH="main"
+        ;;
+    *)
+        echo -e "  ${RED}Error: qa.sh must run from the primary checkout (.../happyhq) or the qa worktree (.../happyhq-qa). Current: ${REPO_ROOT}${RESET}" >&2
+        exit 1
+        ;;
+esac
+export BASE_BRANCH
+
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]; then
+    echo -e "  ${RED}Error: ${REPO_ROOT} should be on '${BASE_BRANCH}', not '${CURRENT_BRANCH}'.${RESET}" >&2
+    echo -e "  ${DIM}Fix: git -C ${REPO_ROOT} checkout ${BASE_BRANCH}${RESET}" >&2
+    exit 1
+fi
+
+# Guard against losing uncommitted work — the next step is `git reset --hard`.
+if [ -n "$(git status --porcelain)" ]; then
+    echo -e "  ${RED}Error: uncommitted changes in ${REPO_ROOT}. Commit, stash, or discard before running the loop — the next step hard-resets to origin/main.${RESET}" >&2
+    git status --short >&2
+    exit 1
+fi
+
+echo -e "  ${DIM}Snapping ${BASE_BRANCH} → origin/main (hard reset), then pnpm install…${RESET}"
+git fetch origin --quiet || { echo -e "  ${RED}git fetch failed${RESET}" >&2; exit 1; }
+git reset --hard origin/main >/dev/null || { echo -e "  ${RED}git reset failed${RESET}" >&2; exit 1; }
+(cd "$REPO_ROOT" && (pnpm install --frozen-lockfile || pnpm install)) || { echo -e "  ${RED}pnpm install failed${RESET}" >&2; exit 1; }
+
+# Ensure the triage-plan directory exists.
+mkdir -p ~/.cache/qa
+
+cleanup() {
+    echo -e "\n${DIM}Cleaning up child processes...${RESET}"
+    pkill -P $$ 2>/dev/null
+    pkill -f "next dev" 2>/dev/null
+    pkill -f "node.*vitest" 2>/dev/null
+    # Stop any lingering dev server from a smoke run mid-execute.
+    (cd "$REPO_ROOT/happyhq" && npx tsx scripts/dev-server.ts stop 2>/dev/null) || true
+    exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+if [ -n "$DRY_RUN" ]; then
+    export DRY_RUN_NOTE="**DRY RUN MODE**: This is a triage-phase preview. Read the queue, classify each PR, group into test units, but do NOT write the plan file to ~/.cache/qa/. Print the would-be plan to stdout instead. Do not invoke any 'gh pr edit', 'gh pr comment', 'git commit', 'git push', or filesystem write."
+else
+    export DRY_RUN_NOTE=""
+fi
+
+if [ -n "$OVERRIDE" ]; then
+    export OVERRIDE_NOTE="**OVERRIDE MODE**: The maintainer invoked --override on this single-PR session. Treat the PR as critical-path even if the diff suggests otherwise (smoke runs unconditionally). Do not promote to evidence-sufficient regardless of how thin or thick the Exercise evidence is. Hard constraints (no auto-merge, no push to PR branch, only operate in qa worktree) remain non-negotiable. Note the override in the qa-pass / qa-fail comment: 'Maintainer invoked --override; evidence-sufficient promotion was bypassed.'"
+else
+    export OVERRIDE_NOTE=""
+fi
+
+run_session() {
+    local prompt_file="$1"
+    local label="$2"
+
+    echo -e "\n  ${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "  ${BOLD}${label}${RESET}"
+    echo -e "  ${DIM}Prompt:${RESET}  $prompt_file"
+    [ -n "$DRY_RUN" ] && echo -e "  ${YELLOW}DRY RUN${RESET}"
+    echo -e "  ${DIM}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+
+    if [ ! -f "$prompt_file" ]; then
+        echo -e "  ${RED}Error: $prompt_file not found${RESET}"
+        return 1
+    fi
+
+    envsubst < "$prompt_file" | claude -p \
+        --dangerously-skip-permissions \
+        --output-format=stream-json \
+        --model opus \
+        --verbose 2>&1 | node "$SCRIPT_DIR/format-stream.mjs"
+
+    return ${PIPESTATUS[1]}
+}
+
+# ── Single-PR mode: write a one-unit plan, then run execute against it ──
+if [ -n "$SINGLE_PR" ]; then
+    # Synthesise a minimal triage plan with this PR as a smoke-isolated unit.
+    PLAN_FILE=~/.cache/qa/triage-$(date +%Y%m%dT%H%M%S).md
+    cat > "$PLAN_FILE" <<EOF
+# QA triage — single-PR mode
+
+Queue: 1 PR (forced via --pr ${SINGLE_PR}). Test units: 1.
+
+## Unit 1 — smoke-isolated: PR #${SINGLE_PR}
+
+**Reasoning:** Single-PR mode invoked via --pr; treating as smoke-isolated regardless of diff classification. ${OVERRIDE:+Override mode active.}
+
+**Diff summary:** (single-PR mode — diff not pre-classified by triage)
+
+**Exercise evidence:** (read the PR body during execute and decide)
+
+EOF
+    echo -e "  ${DIM}Wrote single-PR plan to ${PLAN_FILE}${RESET}"
+    run_session "PROMPT_qa_execute.md" "Execute · PR #${SINGLE_PR}"
+    exit $?
+fi
+
+# ── Phase 1: Triage (skipped with --execute-only) ──
+if [ $EXECUTE_ONLY -eq 0 ]; then
+    run_session "PROMPT_qa_triage.md" "Phase 1 · Triage"
+    TRIAGE_EXIT=$?
+    if [ $TRIAGE_EXIT -ne 0 ]; then
+        echo -e "  ${RED}Triage exited with status $TRIAGE_EXIT — stopping${RESET}"
+        exit $TRIAGE_EXIT
+    fi
+
+    if [ $TRIAGE_ONLY -eq 1 ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Triage complete (--triage-only). Plan: ~/.cache/qa/triage-*.md"
+        exit 0
+    fi
+
+    if [ -n "$DRY_RUN" ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Phase 1 preview complete. Skipping Phase 2 in --dry-run (no plan file written, execute would have nothing to read)."
+        exit 0
+    fi
+fi
+
+# ── Phase 2: Execute ──
+run_session "PROMPT_qa_execute.md" "Phase 2 · Execute"
+EXECUTE_EXIT=$?
+
+# Belt-and-braces dev server cleanup in case execute exited unexpectedly.
+(cd "$REPO_ROOT/happyhq" && npx tsx scripts/dev-server.ts stop 2>/dev/null) || true
+pkill -f "next dev" 2>/dev/null || true
+
+if [ $EXECUTE_EXIT -ne 0 ]; then
+    echo -e "  ${RED}Execute exited with status $EXECUTE_EXIT${RESET}"
+    exit $EXECUTE_EXIT
+fi
+
+echo -e "\n  ${GREEN}✓${RESET} QA pass complete."


### PR DESCRIPTION
## Summary

A new local Ralphie loop (mirrors `bugs.sh` / `dependency.sh` shape) that processes PRs labeled `ralphie:ready-to-merge`. Splits into a triage phase that plans cohorts and an execute phase that drives smoke + bespoke scenarios and labels outcomes.

## Files

- `happyhq/.dev/qa-rubric.md` — judgment heuristics: critical-path definition, cohort policy, what makes Exercise evidence sufficient, comment shapes, hard constraints. Source of truth that both prompts load.
- `happyhq/.dev/PROMPT_qa_triage.md` — Phase 1 prompt: read the queue, classify each PR against the rubric's critical path, group into test units (`evidence-sufficient`, `smoke-isolated`, `smoke-bespoke`, `smoke-batched`), order riskier-first, write the plan to `~/.cache/qa/triage-<ts>.md`. Read-only on the repo and write-only on the local plan file.
- `happyhq/.dev/PROMPT_qa_execute.md` — Phase 2 prompt: read the latest triage plan, run each unit. Includes the bisect flow for failed batches (drop-one or halving for cohorts ≥4, 6-run cost cap, abandon-and-surface on non-converge).
- `happyhq/.dev/qa.sh` — orchestrator. `--triage-only`, `--execute-only`, `--pr <#>`, `--dry-run`, `--override` flags matching the conventions of `bugs.sh` and `dependency.sh`. Worktree-aware base branch (`loop/qa` in `../happyhq-qa`, `main` in primary).

## Worktree setup

A `../happyhq-qa` worktree was spun up alongside the existing `happyhq-bugs` / `happyhq-debt` / `happyhq-deps` worktrees, on a new `loop/qa` branch tracking `origin/main`. Deps + chromium installed.

## What v1 deliberately doesn't do

- **No auto-merge.** Comments + labels only. Maintainer is the merge gate.
- **No replacement for CI lint/types/test.** Those still run on every PR.
- **No deployed-target verification.** Pass 3, separate concern.
- **No fork PR support.** v1 limitation; applies `qa-fail` with a "v1 doesn't support fork PRs" comment.
- **No agentic remediation of `qa-fail`.** Maintainer decides what to do.

## Test plan

- [ ] `bash happyhq/.dev/qa.sh --help` from the qa worktree prints usage
- [ ] `bash happyhq/.dev/qa.sh --dry-run` runs Phase 1 against the current queue, prints would-be plan to stdout, writes nothing
- [ ] `bash happyhq/.dev/qa.sh --triage-only` writes a real plan to `~/.cache/qa/triage-<ts>.md` once there's a `ralphie:ready-to-merge` PR to triage
- [ ] After a few real triage runs, review whether the cohort decisions match what a senior reviewer would do; tune `qa-rubric.md` if not

The loop won't be exercised end-to-end until there's an actual `ralphie:ready-to-merge` PR flowing through. That's expected; this is a "ship the framework, iterate as we use it" delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)