### PR TITLE
docs(discovery): harden spec for build handoff (issue #39)

### DIFF
--- a/happyhq/specs/agent-config.md
+++ b/happyhq/specs/agent-config.md
@@ -23,6 +23,34 @@ Configuration is built per-query via factory functions — fresh options each ca
 
 ## Four Mode Configurations
 
+### Mode Orientation: Heads-up vs. Heads-down
+
+Q's modes split on a single architectural axis: whether Q is **interacting with the user** (heads-up) or **running autonomously** (heads-down). This orientation determines the plumbing each mode inherits, not the prompt content.
+
+| Orientation | Modes                            | Key trait                                                     |
+| ----------- | -------------------------------- | ------------------------------------------------------------- |
+| Heads-up    | general, learning, **discovery** | Q asks the user questions and may wait on a wall-clock answer |
+| Heads-down  | planning, working                | Q runs to a completion signal without user input              |
+
+**Heads-up modes share infrastructure:**
+
+- `AskUserQuestion` handled via `canUseTool` blocking (not in `allowedTools`).
+- The pending-questions store (`lib/chat/pending-questions.ts` — `waitForAnswer` / `submitAnswer`) holds the resolved promise across the wait.
+- `pending: 'clarification'` is set on the surface (`task.md` for discovery, chat session state for learning) before blocking and cleared after.
+- A question event is broadcast on the relevant SSE stream (chat stream for learning; run stream for discovery) — the fast path. The disk (`pendingQuestions` in `.run.json` for discovery; chat session state for learning) is authoritative on reconnect.
+- An answer endpoint resolves the pending promise: `POST /api/chat/answer` for chat-side modes, `POST /api/run/answer` for discovery.
+- A UI surface renders the question (composer for chat; island for discovery during a run).
+
+A heads-up session can be alive but idle for hours — billing accrues on token usage, not wall-clock. This becomes acute when channel adapters land (a Slack reply 6h later is a normal heads-up wait).
+
+**Heads-down modes share infrastructure:**
+
+- `createAutomatedCanUseTool()` — auto-approves safe Bash commands (`isSafeBashCommand()`), denies everything else with no user prompt.
+- No question events on their SSE streams. No answer endpoint.
+- Token-only billing semantics. A stalled heads-down session is a bug, not a wait.
+
+**When adding a new mode**, classify it on this axis first. The classification picks the plumbing — write new automated logic only when the heads-up infrastructure genuinely doesn't fit. Discovery's only true delta from learning's heads-up plumbing is the SSE stream it broadcasts on (run vs. chat) and the prompt; everything else is reuse.
+
 ### General Mode
 
 The default for all new chats. Conversational, lightweight, workspace-aware. No stream-specific context loading, no learning interview. See [Chat Modes](chat-modes.md) for the full mode system — how Q transitions between general and learning mode, the composer toggle, and system prompt injection mechanics.
@@ -131,6 +159,10 @@ The MCP tool executes immediately and returns a tool_result. The client renders 
 
 Q assesses a task before planning — reads the task, evaluates whether it has enough context, asks structured questions if not, and enriches `task.md` with what it learns. Runs automatically as the first phase when the user clicks Start.
 
+**Orientation:** Heads-up (see [Mode Orientation](#mode-orientation-heads-up-vs-heads-down)). Discovery joins learning as a heads-up mode and inherits the heads-up infrastructure pattern — `canUseTool` blocking on `AskUserQuestion`, the pending-questions store, `pending: 'clarification'`, a question event on its SSE stream, an answer endpoint, an island UI surface.
+
+**Discovery vs. learning.** Both are heads-up; they differ in _what they enrich_. Learning mutates the **stream** (playbook, samples, specs accrue across tasks — how Q approaches a _class_ of work). Discovery enriches **one task** (does this specific task have what's needed to plan well?). A task created right after a learning conversation still benefits from discovery — the stream got smarter, but this specific task hasn't been triaged.
+
 **Purpose**: Pre-planning assessment and clarification. Ensure Q has enough context to plan well. See [Discovery](discovery.md) for the full spec.
 
 **Characteristics**:
@@ -154,7 +186,11 @@ Q assesses a task before planning — reads the task, evaluates whether it has e
 - Bash (git, ls only)
 - AskUserQuestion (via `canUseTool` — not in `allowedTools`)
 
-**`canUseTool` callback**: Same pattern as learning mode's AskUserQuestion handling, with one addition: sets `pending: clarification` on `task.md` before blocking, clears it after the user answers. This drives the "needs clarification" indicator in the task list.
+**`canUseTool` callback**: Same pattern as learning mode's `AskUserQuestion` handling, with three additions specific to running inside the run loop rather than a chat session:
+
+1. Broadcasts a `question` event through the **run** SSE stream via `notifyClient` (learning broadcasts on the chat stream).
+2. Sets `pending: 'clarification'` on `task.md` before blocking, clears it after the user answers. This drives the "needs clarification" indicator in the task list.
+3. Writes the current question input to `pendingQuestions` on `.run.json` before blocking, clears it after — disk is authoritative on reconnect, the SSE event is a fast path (see [Discovery](discovery.md)).
 
 **Prompt**: `prompts/discovery.md` — tuned for speed and judgment. Bias toward proceeding. 1–3 focused questions max.
 
@@ -377,7 +413,7 @@ When Q tries to use a tool that isn't in `allowedTools`, the `canUseTool` callba
 
 The pending-confirmations store (`lib/chat/pending-confirmations.ts`) is separate from pending-questions but uses the same answer endpoint. **Keyed by `toolUseId`** (not `sessionId`) so multiple blocking tools in the same assistant turn each get their own slot — the SDK can fire parallel tool calls within a single message, and keying by `sessionId` would clobber earlier entries. Confirmations always resolve (true/false) — rejection is reserved for abort signals. See [Chat](chat.md) for the `AskUserConfirmation` design.
 
-**Scope:** The interactive `canUseTool` flow (blocking on user confirmation) is learning mode only. Planning and working modes use `automatedCanUseTool` — a deterministic callback that auto-approves safe Bash commands (via `isSafeBashCommand()` from `lib/agents/bash-safety.server.ts`) and immediately denies everything else. No user prompt, no blocking. This ensures automated agents can run git, ls, cat, and other safe commands without interruption while preventing unexpected tool usage.
+**Scope:** The interactive `canUseTool` flow (blocking on user input) is used by **heads-up modes** — learning and discovery (see [Mode Orientation](#mode-orientation-heads-up-vs-heads-down)). Both modes' callbacks block on the same pending-questions store (`lib/chat/pending-questions.ts`); they differ in which SSE stream broadcasts the question event and which answer endpoint resolves the promise. **Heads-down modes** (planning, working) use `automatedCanUseTool` — a deterministic callback that auto-approves safe Bash commands (via `isSafeBashCommand()` from `lib/agents/bash-safety.server.ts`) and immediately denies everything else. No user prompt, no blocking. This ensures automated agents can run git, ls, cat, and other safe commands without interruption while preventing unexpected tool usage.
 
 ## Design Decisions
 

--- a/happyhq/specs/agent-config.md
+++ b/happyhq/specs/agent-config.md
@@ -173,9 +173,9 @@ Q assesses a task before planning — reads the task, evaluates whether it has e
 - Writes `## Discovery` section to `task.md` with synthesized context
 - Auto-transitions to planning when complete
 
-**Model**: Sonnet with adaptive thinking. Configurable via `config.models.discovery`.
+**Model**: Opus with adaptive thinking — same as learning, planning, and working. Consistency at v0; downshift to Sonnet behind `config.models.discovery` once we have a feel for ask-rates and per-Start cost.
 
-**Budget**: `config.limits.discoveryBudgetUsd` — default low. Discovery should be fast and cheap.
+**Budget**: `config.limits.discoveryBudgetUsd` — default conservative. Discovery should still be fast and cheap on Opus since it's read-and-assess, not synthesize-and-create.
 
 **Tools available**:
 

--- a/happyhq/specs/chat-modes.md
+++ b/happyhq/specs/chat-modes.md
@@ -12,6 +12,8 @@ This spec owns the mode system: what each mode does, how transitions work, how t
 
 ## Two Modes
 
+Both modes here are **heads-up** — Q interacts with the user through the chat UI. The broader heads-up vs. heads-down classification (which also covers discovery, planning, and working) lives in [Agent Configuration → Mode Orientation](agent-config.md#mode-orientation-heads-up-vs-heads-down). The general/learning split below is the _chat-side_ axis layered on top of that broader classification.
+
 ### General Mode (default)
 
 Q is a helpful collaborator. Conversational, lightweight, no forced structure. This is the default for every new chat — top-level and desktop.

--- a/happyhq/specs/discovery.md
+++ b/happyhq/specs/discovery.md
@@ -139,11 +139,12 @@ The run stream already broadcasts activity events via `notifyClient` in the run 
 | { type: 'question'; sessionId: string; questions: AskUserQuestionInput['questions'] }
 ```
 
-When the discovery agent calls AskUserQuestion, the `canUseTool` callback:
+When the discovery agent calls AskUserQuestion, the `canUseTool` callback runs the setup sequence (see [canUseTool Callback](#canusetool-callback) for the canonical ordering — disk write first, then task.md pending, then broadcast, then block). The summary:
 
-1. Broadcasts `{ type: 'question', sessionId, questions }` through the existing `notifyClient` callback
-2. Sets `pending: clarification` on `task.md`
-3. Calls `waitForAnswer(sessionId)` to block until the user answers
+1. Write `pendingQuestions` to `.run.json`.
+2. Set `pending: 'clarification'` on `task.md`.
+3. Broadcast `{ type: 'question', sessionId, questions }` through `notifyClient`.
+4. Block on `Promise.race([waitForAnswer(sessionId), abortPromise])`.
 
 The client receives the question event via `GET /api/run/stream` (same SSE connection it's already using for activity steps) and renders the question UI. This uses the same `notifyClient` callback pattern that PostToolUse hooks already use to emit activity step events — it does not go through `filterMessage` (which converts SDK messages into events, a separate path).
 
@@ -151,7 +152,7 @@ The client receives the question event via `GET /api/run/stream` (same SSE conne
 
 If the client disconnects and reconnects while discovery is waiting for answers, it needs to recover the pending questions. The `pendingQuestions` field on `RunInfo` stores the current AskUserQuestion input when discovery is blocking. The task content API (`GET /api/fs/task`) returns this as part of `.run.json`, so on reconnect the client sees `status: 'discovering'` + `pendingQuestions` and re-renders the question UI. This also serves the multi-channel case — a Slack adapter reads `pendingQuestions` from `.run.json` to know what to relay.
 
-The `canUseTool` callback writes `pendingQuestions` to `.run.json` before blocking and clears it after the user answers (same write that sets/clears `pending: clarification`).
+The `canUseTool` callback writes `pendingQuestions` to `.run.json` before blocking and clears it after the user answers. `pendingQuestions` (on `.run.json`) and `pending: 'clarification'` (on `task.md`) are two separate writes that the callback keeps in sync — see [canUseTool Callback](#canusetool-callback) for the exact setup and cleanup ordering.
 
 ### Event vs. disk precedence (rule)
 
@@ -181,7 +182,7 @@ New endpoint: `POST /api/run/answer` — thin wrapper that calls `submitAnswer(s
 
 **Race with Stop:** the user could submit answers while a Stop request is in flight (or vice versa). The Promise.race in `canUseTool` already handles the SDK side — abort wins, the answer is dropped harmlessly. The endpoint side: if `submitAnswer` returns false because the session was just aborted, surface 404 — the client renders the run as stopped on its next state read.
 
-When the promise resolves, `canUseTool` clears `pending: clarification` on `task.md` and returns the answers to the SDK. Q continues within the same `query()` call — more activity events stream through the existing connection.
+When the promise resolves, `canUseTool` clears `pending: 'clarification'` on `task.md` and returns the answers to the SDK. Q continues within the same `query()` call — more activity events stream through the existing connection.
 
 ### Why Not a Chat Session
 
@@ -231,11 +232,16 @@ allowedTools: [
 ```typescript
 canUseTool: async (toolName, input, { signal }) => {
   if (toolName === 'AskUserQuestion') {
-    // Broadcast question to client via run stream
+    // Setup ordering: disk first (most critical for reconnect), then
+    // task.md pending, then broadcast, then block.
+    try {
+      await updateRunInfoPendingQuestions(taskName, input.questions)
+      await updateTaskMdPending(taskPath(taskName), 'clarification')
+    } catch (err) {
+      // Setup-write failure: deny rather than block on input we can't surface.
+      return { result: 'deny', message: 'Discovery state write failed' }
+    }
     notifyClient({ type: 'question', sessionId, questions: input.questions })
-    // Set pending + store questions in .run.json for reconnect/multi-channel
-    await updateTaskMdPending(taskPath(taskName), 'clarification')
-    await updateRunInfoPendingQuestions(taskName, input.questions)
     try {
       const answers = await Promise.race([
         waitForAnswer(sessionId),
@@ -247,9 +253,10 @@ canUseTool: async (toolName, input, { signal }) => {
       ])
       return { result: 'allow', updatedInput: { ...input, answers } }
     } finally {
-      // Clear pending + questions whether answered or aborted
-      await updateTaskMdPending(taskPath(taskName), undefined).catch(() => {})
+      // Clear pendingQuestions + pending whether answered or aborted.
+      // Fire-and-forget — the loop's next status write reconciles disk state.
       await updateRunInfoPendingQuestions(taskName, undefined).catch(() => {})
+      await updateTaskMdPending(taskPath(taskName), undefined).catch(() => {})
     }
   }
   return {
@@ -328,20 +335,21 @@ startRun(stream, task, 'discovery')
   │     │
   │     ├── has questions → AskUserQuestion
   │     │     ├── canUseTool broadcasts question event to run stream
-  │     │     ├── canUseTool sets pending: clarification
+  │     │     ├── canUseTool sets pending: 'clarification'
   │     │     ├── user answers via POST /api/run/answer → canUseTool clears pending → Q continues
   │     │     └── user stops run → abort signal → session ends
   │     │
   │     ├── Q synthesizes → appends ## Discovery to task.md
   │     └── session ends
   │
-  ├── commits: [stream/task] Discovery complete
+  ├── commits: [stream/task] Discovery complete (no-op if Q wrote nothing)
   │
-  └── transitions to planning (server-driven, no client round-trip)
-      ├── appends PhaseRecord { phase: 'discovery', sessionId, costUsd, durationMs, ... }
-      │   to phases array on .run.json
-      ├── writes .run.json { status: 'planning' }
-      └── runs planning agent (same as today)
+  ├── appends PhaseRecord { phase: 'discovery', sessionId, costUsd, durationMs, ... }
+  │   to phases array on .run.json
+  │
+  ├── flips .run.json { status: 'planning' }   (single write where possible)
+  │
+  └── runs planning agent (same as today)
 ```
 
 The auto-transition from discovery to planning happens inside the server process. There is no conditional — planning always follows discovery. The only branching is if discovery errors or is stopped, in which case planning doesn't run. The user can close the tab after answering Q's last question and come back to find planning done (or `plan_ready`).
@@ -364,10 +372,13 @@ In `loop.server.ts`, the `runLoop` function dispatches based on mode:
 if (mode === 'discovery') {
   // Run discovery, then planning sequentially
   const discoveryStatus = await runDiscoveryIteration(...)
-  if (discoveryStatus === 'stopped') {
-    finalStatus = 'stopped'
+  if (discoveryStatus !== 'completed') {
+    // 'stopped' (user/error) or 'budget' — don't continue to planning
+    finalStatus = discoveryStatus
   } else {
-    // Discovery succeeded — commit and continue to planning
+    // Discovery succeeded — commit and continue to planning.
+    // commitGitState is a no-op on a clean tree, so this only creates a
+    // commit if Q wrote a ## Discovery section to task.md.
     commitGitState(`[${streamName}/${taskName}] Discovery complete`)
     finalStatus = await runPlanningIteration(...)
   }
@@ -378,7 +389,7 @@ if (mode === 'discovery') {
 }
 ```
 
-`runDiscoveryIteration` follows the same structure as `runPlanningIteration`: create a session, run `query()`, handle abort/budget/error, return status. The key difference: discovery uses `canUseTool` with AskUserQuestion blocking and question broadcasting, while planning uses `createAutomatedCanUseTool()` (fully automated).
+`runDiscoveryIteration` follows the same structure as `runPlanningIteration`: create a session, run `query()`, handle abort/budget/error, return `'completed' | 'stopped' | 'budget'`. The key difference: discovery uses `canUseTool` with AskUserQuestion blocking and question broadcasting, while planning uses `createAutomatedCanUseTool()` (fully automated). Only `'completed'` continues to the planning iteration; both `'stopped'` and `'budget'` halt the run.
 
 **Type changes required.** Add `'discovery'` to every `mode` union and `'discovering'` to every `RunInfo.status` union. The concrete sites:
 
@@ -536,11 +547,11 @@ This lives in the playbook because it's the right granularity — "I trust Q to 
 
 There is no dedicated "skip discovery" button during the live Q&A. The Stop button (already present during every run phase) serves this purpose. When the user stops during discovery:
 
-- The session is aborted, `status: 'stopped'`, `stoppedDuring: 'discovery'` is written
-- The island clears (questions dismissed)
-- The task panel shows restart options including "Restart from plan" which skips discovery and goes straight to planning with the current task.md
+- The session is aborted; `status: 'stopped'`, `stoppedDuring: 'discovery'` is written.
+- The `canUseTool` `finally` clears `pendingQuestions` and `pending: 'clarification'`. The island clears.
+- The task panel shows the standard stopped affordances: **Continue** (resumes discovery — sends `mode: 'discovery'`, picks up where it stopped) and **Restart from plan** (sends `mode: 'planning'`, runs planning against the current `task.md`).
 
-This keeps the UI simple (one Stop button, not Stop + Skip) and gives the user clear choices after stopping.
+This keeps the UI simple (one Stop button, not Stop + Skip) and gives the user a clear choice between "let Q keep triaging" (Continue) and "I'm done with triage, just plan it" (Restart from plan).
 
 ## Multi-Channel Awareness
 
@@ -548,14 +559,14 @@ This spec covers the in-app experience only. The design is channel-agnostic by c
 
 - **Q writes task.md, not the channel.** A Slack adapter's job is I/O: relay the user's message to create the task, relay Q's questions to a Slack thread, relay the user's answers back to Q. Q does all the thinking and writing. The adapter never needs to understand markdown or frontmatter.
 - **AskUserQuestion is the abstraction.** In-app, it renders in the island. In Slack, an adapter translates it to message actions. In email, it becomes a reply template. The agent code is identical — it calls AskUserQuestion regardless of channel.
-- **`pending: clarification` is the notification trigger.** When the multi-channel layer exists, it watches for `pending` changes on tasks and notifies the appropriate channel (tracked in a future `notify` field on `task.md` — see [Task List](task-list.md) multi-channel section).
+- **`pending: 'clarification'` is the notification trigger.** When the multi-channel layer exists, it watches for `pending` changes on tasks and notifies the appropriate channel (tracked in a future `notify` field on `task.md` — see [Task List](task-list.md) multi-channel section).
 - **task.md is the single truth.** After discovery, the task description is complete regardless of which channel the user answered from. Anyone reading the task sees the full picture.
 
 A separate spec will cover the channel routing layer, adapters, and the `source`/`notify` fields. The key architectural insight: channels are dumb pipes, Q is the only writer, and task.md is the canonical object.
 
 ### Future: Stream Selection During Discovery
 
-Today, Start requires a stream assignment. A natural extension: tasks created with just a title could enter discovery without a stream, and Q could suggest which stream to assign based on the task description — "This looks like an Acme Client task — should I assign it there?" This would make quick-add even faster (title → Start → Q figures out the rest). Not v1 scope, but the architecture supports it.
+Today, Start requires a stream assignment. A natural extension: tasks created with just a title could enter discovery without a stream, and Q could suggest which stream to assign based on the task description — "This looks like an Acme Client task — should I assign it there?" This would make quick-add even faster (title → Start → Q figures out the rest). Deferred from v0 (see [v0 vs. v1 scope](#v0-vs-v1-scope)); the architecture supports it.
 
 ## Design Decisions
 
@@ -614,7 +625,7 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 
 **Scenario 3 — Restart from plan preserves `## Discovery`.** After Scenario 2 reaches `plan_ready`, click "Restart from plan." Assert: `task.md` still contains the `## Discovery` section from Scenario 2; `plan.md` is regenerated; planning runs.
 
-**Where the scenarios live.** Scenario 1 extends `scripts/smoke-e2e.ts` (the golden path). Scenarios 2–5 can live in the same script as additional test functions or split into `scripts/smoke-discovery.ts` with a sibling `smoke:discovery` package.json script — implementer's call. The harness pattern (boot a fresh dev server pointed at a per-run `/tmp/happyhq-smoke-<uuid>`, pre-seed the fixture stream, drive Chromium, assert filesystem + DOM state) is established; reuse it.
+**Where the scenarios live.** Scenario 1 extends `scripts/smoke-e2e.ts` (the golden path). Scenarios 2 and 3 can live in the same script as additional test functions or split into `scripts/smoke-discovery.ts` with a sibling `smoke:discovery` package.json script — implementer's call. The harness pattern (boot a fresh dev server pointed at a per-run `/tmp/happyhq-smoke-<uuid>`, pre-seed the fixture stream, drive Chromium, assert filesystem + DOM state) is established; reuse it.
 
 **Why this is worth the cost.** Smoke runs against real Opus calls, so each run is several dollars. Worth it because: (a) discovery's value is "did Q ask sensible questions or proceed sensibly?" — a judgment-driven UX that unit tests can't verify; (b) the calibration anchor lives in the prompt, and the only way to prove the prompt holds up under real model behavior is to run against the real model; (c) regression baseline for prompt drift on future model upgrades. Run discovery scenarios in CI on PRs that touch `prompts/discovery.md`, `lib/agents/config.server.ts` (discovery factory), or `lib/run/loop.server.ts` (discovery iteration / canUseTool). Don't run them on every unrelated PR.
 
@@ -672,6 +683,7 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 
 - [ ] Discovery errors write `status: 'stopped'` with `stoppedDuring: 'discovery'`
 - [ ] Budget stop during discovery writes `stopReason: 'budget'` with Continue option
+- [ ] Stopped or budget discovery does **not** trigger planning — only `runDiscoveryIteration` returning `'completed'` proceeds to `runPlanningIteration` (verified by absence of `phase: 'planning'` PhaseRecord in `.run.json`)
 
 **Billing and gating:**
 
@@ -707,7 +719,7 @@ Run loop — discovery mode (`lib/run/loop.server.test.ts`):
 
 - [ ] `startRun` with `mode: 'discovery'` writes `.run.json` with `status: 'discovering'`
 - [ ] Discovery that completes without questions auto-transitions to planning (status becomes `'planning'`)
-- [ ] Discovery that uses AskUserQuestion sets `pending: clarification` on task.md via canUseTool
+- [ ] Discovery that uses AskUserQuestion sets `pending: 'clarification'` on task.md via canUseTool
 - [ ] canUseTool clears `pending` after user answers
 - [ ] canUseTool broadcasts `question` event through `notifyClient` before blocking
 - [ ] canUseTool writes `pendingQuestions` to `.run.json` before blocking, clears after answer
@@ -731,7 +743,7 @@ Agent config (`lib/agents/config.server.test.ts`):
 - [ ] `discoveryAgentOptions` does NOT configure `mcpServers` or `agents` (no custom MCP, no custom subagents)
 - [ ] AskUserQuestion triggers the documented setup ordering: `pendingQuestions` write → `pending: 'clarification'` set → `question` event broadcast → block on `Promise.race`
 - [ ] Setup write failure (mock `updateRunInfoPendingQuestions` to throw) returns `{ result: 'deny' }` without blocking
-- [ ] AskUserQuestion triggers `pending: clarification` set/clear cycle
+- [ ] AskUserQuestion triggers `pending: 'clarification'` set/clear cycle
 - [ ] AskUserQuestion triggers `question` event broadcast via notifyClient
 
 Compat shim (`lib/fs/read.server.test.ts`):
@@ -757,6 +769,7 @@ Client (`components/features/tasks/`):
 - [ ] "Reviewed Ns" completed-state row renders with duration from discovery `PhaseRecord` (compute time)
 - [ ] Clicking "Reviewed Ns" opens the discovery session in the chat-session viewer via discovery phase record's `sessionId`
 
-Not tested:
+Not unit-tested (covered by smoke):
 
-- Discovery-to-planning auto-transition as end-to-end flow (requires real SDK session)
+- Discovery-to-planning auto-transition as end-to-end flow with a real SDK session — exercised by smoke Scenario 1.
+- The actual prompt's ask-vs-proceed judgment under real model behavior — exercised by smoke Scenarios 1 and 2.

--- a/happyhq/specs/discovery.md
+++ b/happyhq/specs/discovery.md
@@ -279,6 +279,21 @@ If step 1 or 2 throws, the callback returns `{ result: 'deny', message: 'Discove
 
 **Cleanup on resolution or abort** (in `finally`): clear `pendingQuestions` and `pending` in the same order as setup, both with `.catch(() => {})` since the callback is exiting and the disk state will be reconciled by the loop's next status write.
 
+**Implementation note: `updateRunInfoPendingQuestions` is a new helper.** The existing `writeRunInfo` (private in `lib/run/loop.server.ts`) takes a full `RunInfo`, not a partial. The simplest implementation is a thin read-merge-write wrapper:
+
+```typescript
+async function updateRunInfoPendingQuestions(
+  taskName: string,
+  questions: AskUserQuestionInput['questions'] | undefined,
+): Promise<void> {
+  const info = await readRunInfo(taskName)
+  if (!info) return
+  await writeRunInfo(taskName, { ...info, pendingQuestions: questions })
+}
+```
+
+Live alongside `writeRunInfo` in `lib/run/loop.server.ts` (private), or hoist both to `lib/fs/run-json.server.ts` if `parseRunInfo` lands there too. The spec doesn't prescribe — implementer's call. `updateTaskMdPending` is the parallel pattern, already in `lib/fs/task-md.server.ts`.
+
 ### System Prompt
 
 New file: `prompts/discovery.md`. The prompt tells Q:
@@ -389,7 +404,7 @@ if (mode === 'discovery') {
 }
 ```
 
-`runDiscoveryIteration` follows the same structure as `runPlanningIteration`: create a session, run `query()`, handle abort/budget/error, return `'completed' | 'stopped' | 'budget'`. The key difference: discovery uses `canUseTool` with AskUserQuestion blocking and question broadcasting, while planning uses `createAutomatedCanUseTool()` (fully automated). Only `'completed'` continues to the planning iteration; both `'stopped'` and `'budget'` halt the run.
+`runDiscoveryIteration` follows the same structure as `runPlanningIteration`: create a session, run `query()`, handle abort/budget/error, return `Promise<RunInfo['status']>`. The key difference: discovery uses `canUseTool` with AskUserQuestion blocking and question broadcasting, while planning uses `createAutomatedCanUseTool()` (fully automated). In practice, discovery returns `'completed'` on success and `'stopped'` for any abort/error/budget case (with the corresponding `stopReason` and `stoppedDuring` written to `.run.json` before returning). The dispatcher only continues to planning on `=== 'completed'`.
 
 **Type changes required.** Add `'discovery'` to every `mode` union and `'discovering'` to every `RunInfo.status` union. The concrete sites:
 
@@ -405,6 +420,62 @@ After updating the unions, run `pnpm check-types` from `happyhq/`. TypeScript wi
 Discovery cost is tracked within the same billing task run record that spans the full run lifecycle. The `runLoop` function starts a billing record at the top (`startTaskRun`) and finalizes at the bottom (`finalizeTaskRun`). When `mode: 'discovery'`, the loop runs discovery then planning sequentially — the billing record naturally spans both.
 
 After discovery completes, a `PhaseRecord` with `phase: 'discovery'` is appended to the `phases` array on `.run.json`, recording cost and duration. The `costUsd` field on RunInfo tracks the cumulative total (discovery + planning + working). `updateUsage` calls happen after each phase.
+
+### Config schema additions
+
+The `discoveryAgentOptions()` factory needs `config.models.discovery` and `config.limits.discoveryBudgetUsd` to exist. These fields don't exist today — the schemas at `happyhq/lib/config/types.ts` only list learning/planning/working. Add:
+
+- `AppConfig.models.discovery?: ModelConfig` (optional — user override).
+- `AppConfig.limits.discoveryBudgetUsd?: number` (optional — user override).
+- `ResolvedConfig.models.discovery: Required<ModelConfig>` (required in resolved form).
+- `ResolvedConfig.limits.discoveryBudgetUsd: number` (required in resolved form).
+
+Add corresponding defaults in `happyhq/lib/config/defaults.ts`. Mirror the existing `models.planning` / `limits.planningBudgetUsd` defaults — Opus model with adaptive thinking, conservative budget.
+
+The factory then reads them the same way the other factories do today:
+
+```typescript
+// happyhq/lib/agents/config.server.ts — discoveryAgentOptions
+model: MODEL_IDS[config.models.discovery.model],
+maxBudgetUsd: config.limits.discoveryBudgetUsd,
+```
+
+### PostToolUse hook for Write
+
+Discovery's factory needs a `PostToolUse` hook that fires after `Write` to emit `task_content_changed` — same pattern as planning/working at [`happyhq/lib/agents/config.server.ts:507-515`](happyhq/lib/agents/config.server.ts#L507-L515). Without this, the user won't see the `## Discovery` section appear in the panel until they manually refresh.
+
+```typescript
+hooks: {
+  PostToolUse: [
+    {
+      hooks: [
+        async (input) => {
+          if (input.hook_event_name !== 'PostToolUse') return { continue: true }
+          if (input.tool_name === 'Write' || input.tool_name === 'Edit') {
+            opts?.notifyClient?.({ type: 'task_content_changed' })
+          }
+          return { continue: true }
+        },
+      ],
+    },
+  ],
+}
+```
+
+Same shape as planning's hook; only the agent factory it's wired to differs.
+
+### Logging
+
+Discovery emits the existing `run.*` structured-log events ([`happyhq/lib/log.server.ts`](happyhq/lib/log.server.ts)). No new event namespace.
+
+- `run.started` already includes a `mode` field — when `mode: 'discovery'`, that's discovery starting.
+- `run.stopped` with `stoppedDuring: 'discovery'` for user/error/budget aborts.
+- `run.error` for fatal errors during discovery (e.g., setup-write failure in `canUseTool`).
+- `run.completed` for the run as a whole (after planning + working finish).
+
+PhaseRecord on `.run.json` captures success metrics (cost, duration, sessionId) — no separate per-phase log event needed. The mode and stoppedDuring fields are sufficient to grep discovery activity.
+
+**`canUseTool` setup-write failure** specifically should emit `run.error` with an explanatory message before returning `{ result: 'deny', message: 'Discovery state write failed' }` — silent denials are bad ops.
 
 ## Git Commits and Restart
 
@@ -636,7 +707,8 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 - [ ] Start button triggers discovery (not planning directly) — v0 always runs discovery on Start
 - [ ] `discoveryAgentOptions()` factory exists in `lib/agents/config.server.ts`: Opus (resolved via `config.models.discovery` against `MODEL_IDS`), adaptive thinking, no `mcpServers`, no `agents`, `persistSession: true`, `settingSources: []`, `disallowedTools: ['EnterPlanMode', 'ExitPlanMode']`
 - [ ] Discovery agent reads task inputs, stream playbook, specs, and samples (read-first rule from prompt)
-- [ ] `runDiscoveryIteration()` exists in `lib/run/loop.server.ts`, mirroring `runPlanningIteration` shape; returns `'completed' | 'stopped' | 'budget'`
+- [ ] `runDiscoveryIteration()` exists in `lib/run/loop.server.ts`, mirroring `runPlanningIteration` shape; signature returns `Promise<RunInfo['status']>`. In practice returns `'completed'` on success and `'stopped'` for any abort/error/budget case (with `stoppedDuring: 'discovery'` and any `stopReason` written to `.run.json` before returning)
+- [ ] Loop dispatcher's `if (mode === 'discovery')` branch only proceeds to `runPlanningIteration` when `runDiscoveryIteration` returns `'completed'`; any other return value is propagated as the final status without running planning
 - [ ] When Q has enough context, discovery auto-transitions to planning without user action
 - [ ] Loop commits `[stream/task] Discovery complete` after successful discovery, before planning
 - [ ] Discovery appends a `PhaseRecord` with `phase: 'discovery'` to `phases` on `.run.json`, then flips status to `'planning'` (single write where possible)
@@ -659,6 +731,19 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 - [ ] `parseRunInfo(raw): RunInfo` introduced in `lib/fs/read.server.ts`; both existing `JSON.parse(runJson) as RunInfo` sites switch to `parseRunInfo(JSON.parse(runJson))`; shim handles old shape (see [Working](working.md) migration)
 - [ ] `clearStaleRun` clears `pendingQuestions` along with flipping `'discovering'` status to `'stopped'`
 - [ ] Q synthesizes what it learned and appends a `## Discovery` section to task.md (or writes nothing when there's nothing useful to add)
+
+**Config schema:**
+
+- [ ] `AppConfig.models.discovery?: ModelConfig` and `ResolvedConfig.models.discovery: Required<ModelConfig>` added to `happyhq/lib/config/types.ts`
+- [ ] `AppConfig.limits.discoveryBudgetUsd?: number` and `ResolvedConfig.limits.discoveryBudgetUsd: number` added to `happyhq/lib/config/types.ts`
+- [ ] Defaults added to `happyhq/lib/config/defaults.ts` — Opus + adaptive thinking, conservative budget (mirror the planning defaults pattern)
+- [ ] `discoveryAgentOptions()` reads `config.models.discovery.model` (mapped via `MODEL_IDS`) and `config.limits.discoveryBudgetUsd` — same pattern as planning/working factories
+
+**Hooks and logging:**
+
+- [ ] `discoveryAgentOptions()` configures a `PostToolUse` hook that emits `notifyClient({ type: 'task_content_changed' })` after `Write` / `Edit` calls — mirrors the planning/working hook in `lib/agents/config.server.ts`
+- [ ] Discovery emits the existing `run.*` log events (`run.started`, `run.stopped`, `run.error`, `run.completed`) with `mode: 'discovery'` and `stoppedDuring: 'discovery'` discriminating the phase — no new event namespace
+- [ ] `canUseTool` setup-write failure emits `run.error` with an explanatory message before returning `{ result: 'deny' }` (no silent failures)
 
 **Restart:**
 
@@ -739,12 +824,19 @@ Restart (`lib/run/loop.server.test.ts`):
 
 Agent config (`lib/agents/config.server.test.ts`):
 
-- [ ] `discoveryAgentOptions` returns Opus model (via `MODEL_IDS`) with AskUserQuestion blocking via canUseTool
+- [ ] `discoveryAgentOptions` returns Opus model (resolved via `config.models.discovery` + `MODEL_IDS`) with AskUserQuestion blocking via canUseTool
+- [ ] `discoveryAgentOptions` reads `maxBudgetUsd` from `config.limits.discoveryBudgetUsd`
 - [ ] `discoveryAgentOptions` does NOT configure `mcpServers` or `agents` (no custom MCP, no custom subagents)
+- [ ] `discoveryAgentOptions` configures a `PostToolUse` hook for `Write` / `Edit` that calls `notifyClient({ type: 'task_content_changed' })`
 - [ ] AskUserQuestion triggers the documented setup ordering: `pendingQuestions` write → `pending: 'clarification'` set → `question` event broadcast → block on `Promise.race`
-- [ ] Setup write failure (mock `updateRunInfoPendingQuestions` to throw) returns `{ result: 'deny' }` without blocking
+- [ ] Setup write failure (mock `updateRunInfoPendingQuestions` to throw) returns `{ result: 'deny' }` and emits a `run.error` log event (no silent failure)
 - [ ] AskUserQuestion triggers `pending: 'clarification'` set/clear cycle
 - [ ] AskUserQuestion triggers `question` event broadcast via notifyClient
+
+Config defaults (`lib/config/defaults.test.ts`):
+
+- [ ] `models.discovery` resolves to a default `Required<ModelConfig>` (Opus + adaptive)
+- [ ] `limits.discoveryBudgetUsd` resolves to a default number
 
 Compat shim (`lib/fs/read.server.test.ts`):
 

--- a/happyhq/specs/discovery.md
+++ b/happyhq/specs/discovery.md
@@ -1,12 +1,25 @@
 # Discovery
 
-How Q assesses a task before planning.
+The gut check Q does before planning a task.
 
 ## Purpose
 
-When tasks were created from learning conversations, Q naturally gathered context and asked questions before calling CreateTask. Tasks created outside of chat (quick-add, task panel, command menu) skip that conversation and jump straight to planning. The result: planning runs that produce a plan saying "I'm missing X, Y, and Z" — wasting a run and frustrating the user.
+Discovery is the same gut check a human would do before starting any task: _do I have what I need to do this work well?_ Q sits down with the task, reviews what's there (the description, the inputs, the stream's playbook and specs and samples), and decides whether anything is missing that would force planning to guess or come back asking later.
 
-Discovery formalizes the pre-planning assessment. Q reads the task, evaluates whether it has enough to plan well, asks structured questions if not, and enriches the task description with what it learns. It's the first phase of the run lifecycle — between Start and Planning.
+If everything's in hand, discovery proceeds quietly and planning starts. If something's genuinely missing that would change the plan, Q asks the user a tight set of questions and writes the answers into the task description. Either way, planning starts from a task that's been reviewed, not assumed.
+
+This phase exists because today, every task entry point that isn't a learning conversation jumps straight to planning. The result is the planning run that comes back saying "I'm missing X, Y, and Z" — wasted compute, wasted time, frustrated user. Tasks created inside a learning conversation didn't have that problem because Q naturally gathered context and asked questions before calling CreateTask. Discovery formalizes that gut check as an explicit phase, available to _every_ entry point — quick-add, task panel, command menu, and future Slack/email.
+
+## Discovery vs. learning
+
+Both modes interview the user. They are not the same.
+
+- **Learning mutates the stream.** A learning conversation accrues knowledge into `playbook.md`, `specs/`, and `samples/` — how Q approaches a _class_ of work. Persistent across all future tasks.
+- **Discovery enriches one task.** A discovery session writes a `## Discovery` section to _this_ task's `task.md` — does this specific task have what's needed to plan well? The stream is unchanged.
+
+A task created right after a learning conversation still benefits from discovery: the stream got smarter, but this specific task hasn't been triaged. The questions can rhyme ("what's the deadline?"), but the artifact each produces is different.
+
+Architecturally, discovery is a **heads-up** mode that joins learning. See [Agent Configuration → Mode Orientation](agent-config.md#mode-orientation-heads-up-vs-heads-down) for the heads-up vs. heads-down axis and the infrastructure each orientation inherits. Discovery's only true deltas from learning's heads-up plumbing are the SSE stream it broadcasts on (run vs. chat) and the prompt — everything else is reuse.
 
 ## Related Specs
 
@@ -15,9 +28,9 @@ Discovery formalizes the pre-planning assessment. Q reads the task, evaluates wh
 - Run lifecycle, `.run.json`, and `PhaseRecord` / `RunInfo` types → [Working](working.md)
 - Agent modes and orchestration → [Agent Configuration](agent-config.md)
 
-## Prerequisites
+## Type refactor (ships in this same change)
 
-- **RunInfo refactor:** Discovery depends on the `phases: PhaseRecord[]` structure on `RunInfo` (see [Working](working.md)). This replaces the current ad-hoc `planningCostUsd`, `planningSessionId`, `workingSessionIds`, and positional `iterations` array. The refactor is a separate task that should land before discovery.
+Discovery's `PhaseRecord` write is the forcing function for the `phases: PhaseRecord[]` structure on `RunInfo` described in [Working](working.md). The two ship together as one PR. Splitting them would mean the refactor lands without a forcing function (and rots) or discovery adds yet another flat field set (`discoveryCostUsd`, `discoverySessionId`, ...) to the structure the refactor is trying to replace. See [Working](working.md) for the new shape and the read-time compat shim that handles existing `.run.json` files.
 
 ## Trigger
 
@@ -27,7 +40,9 @@ Current flow: Start → Planning → (approval) → Working → (review) → Don
 
 New flow: Start → Discovery → Planning → (approval) → Working → (review) → Done
 
-Discovery is not a separate user action. The user clicks one button. Internally, the system runs discovery first, then planning. If Q has no questions, the transition is seamless — the user sees "Discovering..." briefly, then "Planning..." begins. If Q has questions, the run pauses and the ball returns to the user.
+Discovery is not a separate user action. The user clicks one button. Internally, the system runs discovery first, then planning. If Q has no questions, the transition is seamless — the user sees "Reviewing the task..." briefly, then "Planning..." begins. If Q has questions, the run pauses and the ball returns to the user.
+
+**Naming.** "Discovery" is the architectural name (used in mode names, status values, file paths, and code). The user-facing label is "Reviewing the task..." (active) and "Reviewed Ns" (completed). Keeping the internal term and the user-facing term distinct lets us tighten the user-facing language without churning the codebase.
 
 ## What Q Does
 
@@ -87,10 +102,29 @@ When Q has no questions and nothing useful to add (e.g., the task already has ri
 
 The discovery prompt should be tuned for speed and judgment, not depth. Q is not researching — it's triaging.
 
+- **Read what's there first; ask only about gaps.** Q reads the materials at hand (task description, inputs, playbook, specs, samples) before deciding whether to ask anything. Questions are about what those materials don't cover — never about things the playbook or specs already answer. Web research (`WebFetch`, `WebSearch`) is for filling specific gaps when needed (e.g., looking up a person or company mentioned in the task), not a default exploration mode.
 - **Bias toward proceeding.** If Q can plan with what it has, even imperfectly, it should proceed. Don't ask questions just because you could. The worst failure mode isn't "Q planned with incomplete info" (the user catches this at plan review) — it's "Q asks annoying questions on every task."
 - **Few, focused questions.** 1–3 questions max per round. High-leverage questions that would materially change the plan. Not a laundry list.
 - **Structured answers.** Use AskUserQuestion with multiple-choice options. Easier for the user, more useful for planning, and translates cleanly to future channels (Slack buttons, email reply templates).
 - **Fast.** Discovery should complete in seconds, not minutes.
+
+### Calibration: when to ask vs. proceed
+
+The bias-to-proceed heuristic is the entire UX. Ship the prompt with worked examples baked in. Three patterns that calibrate the line:
+
+**Ask when the playbook lists a required input that's missing AND it would change the plan.**
+
+- Stream playbook lists pricing as a required section. Task: "Draft Q4 proposal." Inputs: a pitch deck, no rate information. The deck doesn't carry pricing. Pricing materially shapes the plan. → **Ask** ("What's the budget range for this engagement?") with structured options spanning realistic ranges.
+
+**Proceed when missing fields have reasonable defaults from the playbook or specs.**
+
+- Stream playbook says "default engagement length is 6 months unless specified." Task: "Draft Q4 proposal" missing duration. Defaults are reliable; the user catches deviations at plan review. → **Proceed.** Optionally append a `## Discovery` note: "Assuming standard 6-month engagement per playbook default."
+
+**Proceed when a thin task description maps cleanly onto a samples-rich stream.**
+
+- Task: "Update onboarding checklist" with no inputs and only a one-line title. Stream has 5 samples of past onboarding checklists and a spec listing the standard sections. The plan can clearly mirror prior work. → **Proceed** without writing to `task.md`. Discovery's job is to triage, not to add ceremony.
+
+The pattern: **ASK** when (a) the playbook or spec lists something as required AND (b) Q can't derive it from inputs/specs/samples AND (c) it would change the plan. **PROCEED** otherwise. Over time, specs may say "if X is missing, assume Y" — that further reduces unnecessary questions and is a separate stream-level investment.
 
 ## Interactive Q&A Plumbing
 
@@ -118,6 +152,16 @@ The client receives the question event via `GET /api/run/stream` (same SSE conne
 If the client disconnects and reconnects while discovery is waiting for answers, it needs to recover the pending questions. The `pendingQuestions` field on `RunInfo` stores the current AskUserQuestion input when discovery is blocking. The task content API (`GET /api/fs/task`) returns this as part of `.run.json`, so on reconnect the client sees `status: 'discovering'` + `pendingQuestions` and re-renders the question UI. This also serves the multi-channel case — a Slack adapter reads `pendingQuestions` from `.run.json` to know what to relay.
 
 The `canUseTool` callback writes `pendingQuestions` to `.run.json` before blocking and clears it after the user answers (same write that sets/clears `pending: clarification`).
+
+### Event vs. disk precedence (rule)
+
+The disk is authoritative; the SSE `question` event is a fast path. Concretely:
+
+- The client's render rule is **"if `pendingQuestions` is set on `.run.json`, show the question UI"** — regardless of whether the SSE event fired.
+- The SSE `question` event is fire-and-forget (the run stream uses `writer.write(...).catch(() => {})` — see [Working](working.md) on stream writes). A client mid-reconnect can miss it; the disk write closes that race.
+- Multi-channel adapters (future Slack, email) read `pendingQuestions` from `.run.json` directly. They never depend on the SSE event existing.
+
+This means: if discovery has questions but the SSE event was dropped, the client still renders correctly on next read of the task content API. The event is an optimization for in-app liveness, not a correctness mechanism.
 
 ### How Answers Get Back
 
@@ -207,14 +251,17 @@ Same structure as the learning agent's `canUseTool`, with additions: (1) broadca
 
 New file: `prompts/discovery.md`. The prompt tells Q:
 
-- Your job is to assess whether this task has enough context for planning
-- Read the task description, inputs, playbook, and specs
-- If you have enough, write your synthesis to task.md under `## Discovery` and exit
-- If you need clarification, use AskUserQuestion with structured options
-- Bias toward proceeding — only ask when the gap would materially change the plan
-- 1–3 questions max per round, structured multiple-choice
+- Your job is the gut check before planning: does this task have what's needed to plan well?
+- **Read first, ask second.** Read the task description, inputs, playbook, specs, and samples _before_ deciding whether to ask anything. Questions are about what those materials don't cover.
+- If everything's there, write a brief `## Discovery` synthesis to `task.md` (or nothing if there's nothing useful to add) and exit.
+- If something's genuinely missing that would change the plan, use `AskUserQuestion` with structured multiple-choice options.
+- Bias toward proceeding. Don't ask just because you can.
+- 1–3 focused questions max per round.
+- Web research (`WebFetch`, `WebSearch`) is for filling specific gaps when needed — not a default exploration mode.
 
 The reading list is built the same way as planning: `buildReadingList()` from `prompts.server.ts` injects specs, samples, inputs, and playbook paths.
+
+Worked calibration examples ship in the prompt itself (see [Calibration: when to ask vs. proceed](#calibration-when-to-ask-vs-proceed) above). Without them, the prompt iterates by vibe.
 
 ## Run State
 
@@ -358,35 +405,51 @@ if (mode === 'discovery') {
 
 The existing `mode === 'planning'` cleanup handles deleting `plan.md` and clearing directories. The existing `mode === 'working'` cleanup handles `restorePlanFromGit`. Discovery adds the `restoreTaskMdFromGit` call.
 
+**Single commit for cleanup.** All restart-from-discovery operations — `restoreTaskMdFromGit`, deleting `plan.md`, clearing `working/` and `outputs/` — must land in the _same_ `commitGitState('Task restarted from scratch')` commit. If they land as multiple commits, the next discovery's `git log --grep='Discovery complete' -1 -- task.md` lookup can hit a stale or unrelated commit (the restart sequence interleaves with prior history). Mirror the ordering in the existing `mode === 'working'` block, which already follows this pattern for `restorePlanFromGit`.
+
 **First run:** `restoreTaskMdFromGit` is a graceful no-op when there's no "Discovery complete" commit (same as `restorePlanFromGit` on first planning run). No special-casing needed.
 
 ## Task Panel UI
 
-Discovery follows the same pattern as planning: activity header during the phase, duration label after. Questions render in the island (bottom of canvas), not in the task card.
+Discovery follows the same shape as planning and working: a phase header in the task card, sub-rows beneath it for items that exist during the phase, and a duration label after.
 
-### During Discovery — Q Working
+### The phase header is stable
 
-```
- Discovering...                               [Stop]
-```
-
-ActivityHeader with the latest step label, same as Planning uses today. The run stream delivers activity step events exactly as it does during planning.
-
-### During Discovery — Questions Waiting
-
-**Island (canvas bottom):** Full AskUserQuestion UI appears in the island, replacing the composer — same structured question blocks the user already knows from learning mode. This is the primary interaction surface. The user selects answers and submits. Same visual treatment, same components, different rendering context (island during a run vs. island during a chat).
-
-**Task card:** A `QuestionRow` shows a hint — e.g., "2 questions from Q" or the first question's header. Clicking it focuses the island. This mirrors how `PlanFileRow` shows the plan and clicking opens it. The full question experience lives in the island, not the task card.
-
-When the user submits answers (`POST /api/run/answer`), the island clears and the activity header resumes ("Discovering...") as Q processes the answers. If Q asks follow-ups, the island shows new questions.
-
-### After Discovery
+The header label does **not** swap when questions surface. The header is the phase indicator; what's _happening within_ the phase is shown as sub-rows beneath it.
 
 ```
- Discovered                                      18s
+ Reviewing the task...                         [Stop]
 ```
 
-SectionHeader with duration (from `phases.find(p => p.phase === 'discovery')?.durationMs`). Clicking the label opens the discovery session transcript in a chat window (via the phase record's `sessionId`), same as clicking "Planned" opens the planning session.
+- **While Q is reviewing (no questions):** "Reviewing the task..." with the activity stream beneath it (same activity-step events that Planning uses today, just on the discovery session).
+- **While Q has questions pending:** The header text stays "Reviewing the task..." A question sub-row appears beneath it (see below). The activity stream pauses; the sub-row is what tells the user the ball is in their court.
+- **After completion:** The header transitions to the completed-state row "Reviewed Ns" — same shape and weight as "Planned 3m" and "Worked 4m" elsewhere in the panel.
+
+### Sub-rows beneath the header
+
+While discovery is running, sub-rows appear beneath "Reviewing the task..." for items that exist during the phase — same pattern as file rows, attachment rows, or the plan row beneath other phase headers.
+
+The one sub-row discovery uses in v0:
+
+- **Question row** — appears whenever Q has open questions waiting on the user. The row indicates that questions exist and points the user at the island, where the actual answer UI lives. No question count, no first-question-header — keep the row simple. Whether answered question rows persist (with a check) or vanish is intentionally TBD; decide at build time by feel.
+
+### Where the user actually answers
+
+Questions render in the **island** as full `AskUserQuestion` blocks — the same component the learning chat already uses, just rendered in the island during a run instead of in the chat composer. The user selects answers and submits. Same visual treatment, same components, different rendering context.
+
+When the user submits answers (`POST /api/run/answer`), the question block clears from the island, the question sub-row in the task card updates (per the persist/vanish decision above), and the activity stream resumes as Q processes the answers. If Q asks follow-ups, a new question block appears.
+
+### Completed-state row: clicking opens the session
+
+```
+ Reviewed                                       2m 10s
+```
+
+Clicking the row opens the discovery session in the chat-session viewer — the same component used for clicking "Planned" or for opening any learning chat. The transcript shows what Q read, what it considered, and the inline question/answer rounds (`AskUserQuestion` calls render in the transcript exactly as they would in any chat session — there is no second display path).
+
+The duration shown is **compute time**, recorded as `durationMs` on the discovery `PhaseRecord`. It does _not_ include time spent waiting for the user to answer questions. A discovery run that took 90 seconds of compute but waited 20 minutes for an answer reads as "Reviewed 1m 30s," not "Reviewed 21m 30s." The row is honest about what Q actually did.
+
+> **Implementation note (transcript display).** Discovery sessions are SDK sessions associated with a run, accessed via `phase.sessionId`. They do not live in `.chats/{sessionId}/` like learning chats. The transcript-display component reads from the SDK journal regardless of which session-creation path produced it — to the user, the experience is identical. Don't fork into a second display component.
 
 ### Restart Options
 
@@ -398,19 +461,21 @@ When a task is stopped or finished, the user can restart from any completed phas
 
 These map to `POST /api/run/start` with `mode: 'discovery'`, `'planning'`, or `'working'`.
 
-### Clarification Indicator
+### Clarification Indicator (task list)
 
-The task list item shows a clarification indicator when Q is waiting for answers:
+Separate from the in-card sub-row above, the task list item — anywhere a task title appears in a list (sidebar, home, search results) — shows a clarification badge when Q is waiting for answers:
 
 ```
   Draft Q4 Proposal              · Needs clarification
 ```
 
-This uses the existing `pending: clarification` indicator pattern — same visual treatment as other pending states.
+This uses the existing `pending: 'clarification'` indicator pattern — same visual treatment as other pending states. Together with the in-card question sub-row, this gives the user two ways to find a discovery session that needs them: the badge wherever they encounter the task in a list, and the sub-row when they're already viewing the task.
 
 ## Skip Mechanisms
 
-### Per-Stream Auto-Skip
+### Per-Stream Auto-Skip (deferred to v1 — design held for later)
+
+This subsection documents the design held for v1; it is **not in v0 scope** (see [v0 vs. v1 scope](#v0-vs-v1-scope)). v0 runs discovery on every Start.
 
 Playbook frontmatter gains an optional `skipDiscovery` field:
 
@@ -421,9 +486,9 @@ skipDiscovery: true
 ---
 ```
 
-When `skipDiscovery: true`, the Start button sends `mode: 'planning'` instead of `mode: 'discovery'` — discovery is bypassed entirely. No "Discovered" row appears in the panel. The server also enforces this: if `mode: 'discovery'` arrives but the playbook says `skipDiscovery: true`, the server redirects to `mode: 'planning'`.
+When `skipDiscovery: true`, the Start button sends `mode: 'planning'` instead of `mode: 'discovery'` — discovery is bypassed entirely. No "Reviewed" row appears in the panel. The server also enforces this: if `mode: 'discovery'` arrives but the playbook says `skipDiscovery: true`, the server redirects to `mode: 'planning'`.
 
-This lives in the playbook because it's the right granularity — "I trust Q to plan SOWs without asking, but for research tasks it should always check." It's human-editable, requires no new schema, and is already read by the system during prompt construction.
+This lives in the playbook because it's the right granularity — "I trust Q to plan SOWs without asking, but for research tasks it should always check." It's human-editable and is already read by the system during prompt construction. Adding it requires extending `PlaybookFrontmatter` (currently a closed schema) at v1 implementation time.
 
 ### Stopping During Discovery
 
@@ -460,7 +525,7 @@ Today, Start requires a stream assignment. A natural extension: tasks created wi
 
 **Git-based restore, not string-stripping.** On restart from discovery, `task.md` is restored from git (parent of the "Discovery complete" commit) rather than parsing and stripping the `## Discovery` section. This follows the `restorePlanFromGit` pattern already used for `plan.md` during working restarts. Reliable, no markdown parsing, and handles any content Q might have written.
 
-**No `discovered` status.** It would exist for ~0ms between discovery completing and planning starting. Nothing would render it. The task panel's "Discovered 18s" comes from the discovery `PhaseRecord` in the `phases` array, not the status field.
+**No `discovered` status.** It would exist for ~0ms between discovery completing and planning starting. Nothing would render it. The task panel's "Reviewed 2m 10s" comes from the discovery `PhaseRecord` in the `phases` array, not the status field.
 
 **Sonnet, not Opus.** Discovery is read-and-assess, not synthesize-and-create. Sonnet is fast, cheap, and sufficient. The cost delta matters because discovery runs on every task start. Configurable if needed.
 
@@ -468,7 +533,24 @@ Today, Start requires a stream assignment. A natural extension: tasks created wi
 
 **Stop replaces skip.** No dedicated "skip discovery" button during the session. The Stop button already exists and does the right thing — abort the session, then the user chooses where to restart (including "Restart from plan" which skips discovery). This avoids a second button alongside Stop that does nearly the same thing.
 
-**Server-driven transitions.** The run loop handles discovery → planning sequentially, same as how it handles planning → `plan_ready`. No client orchestration needed. The user can close the tab after answering Q's last question and come back to find planning done. If Q had no questions, the transition is instant — the user sees "Discovering..." briefly then "Planning..." with no gap.
+**Server-driven transitions.** The run loop handles discovery → planning sequentially, same as how it handles planning → `plan_ready`. No client orchestration needed. The user can close the tab after answering Q's last question and come back to find planning done. If Q had no questions, the transition is instant — the user sees "Reviewing the task..." briefly then "Planning..." with no gap.
+
+**Header stays stable across question state.** When questions surface, the header text doesn't change to something like "Q has questions for you" — the header is the _phase_ indicator, not the _state_ indicator. State (questions pending, files attached, plan ready) lives in sub-rows beneath the header. Swapping the header text would be jarring and would conflict with the sub-row pattern other phases already use. One header per phase, sub-rows for what's happening inside it.
+
+## v0 vs. v1 scope
+
+Everything documented in this spec is in v0 _unless_ listed below. The deferred items are not abandoned — they're held for v1 once we see how v0 lands in the wild.
+
+**Deferred from v0 (revisit after v0 ships):**
+
+- **`skipDiscovery` playbook frontmatter flag.** v0 runs discovery on every Start. Bias-to-proceed in the prompt should be enough — if a stream's playbook is rich and a task is well-formed, discovery transitions to planning in seconds without writing anything. Add the flag once we observe ask-rates that warrant a stream-level opt-out. Requires extending `PlaybookFrontmatter` (currently a closed schema) when added.
+- **Stream selection during discovery.** Tasks created with just a title would let Q suggest which stream to assign. Out of v0 scope; the architecture supports it.
+- **Channel adapters (Slack, email).** This spec keeps the architecture channel-ready (`pendingQuestions` on `.run.json`, `pending: 'clarification'` as a notification trigger, `AskUserQuestion` as the abstraction), but no adapter ships in v0. See [Multi-Channel Awareness](#multi-channel-awareness) for the readiness story.
+- **Concurrency-safe answer routing.** `POST /api/run/answer` resolves against module-level singleton state (same pattern as `getActiveRunInfo()`). When concurrency lands and the singleton becomes a `Map<>` (see [Working](working.md)), the answer endpoint will need a task identifier in the body. Decoupled from this PR.
+
+**Bundled into v0 (despite the spec originally splitting them):**
+
+- **`phases: PhaseRecord[]` migration on `RunInfo`.** Originally listed as a prerequisite; ships together with discovery. See [Type refactor](#type-refactor-ships-in-this-same-change) above and the new shape in [Working](working.md).
 
 ## Acceptance Criteria
 
@@ -477,14 +559,15 @@ Today, Start requires a stream assignment. A natural extension: tasks created wi
 - [ ] When Q has enough context, discovery auto-transitions to planning without user action
 - [ ] When Q has questions, `canUseTool` broadcasts a `question` event through the run stream
 - [ ] `canUseTool` sets `pending: clarification` before blocking and clears it after
-- [ ] Questions render in the island (full AskUserQuestion UI) with a `QuestionRow` hint in the task card
+- [ ] Header in the task card stays "Reviewing the task..." while discovery is active — does NOT swap text when questions surface
+- [ ] When questions are pending, a question sub-row appears beneath the "Reviewing the task..." header in the task card
+- [ ] Questions render in the island as full AskUserQuestion blocks (same component as learning chat), with the task-card sub-row pointing to the island
 - [ ] `POST /api/run/answer` accepts answers and resolves the pending AskUserQuestion promise
 - [ ] Q can ask follow-up questions within the same session (multiple rounds)
 - [ ] Q synthesizes what it learned and appends a `## Discovery` section to task.md
 - [ ] Loop commits `[stream/task] Discovery complete` after successful discovery, before planning
-- [ ] `skipDiscovery` in playbook frontmatter bypasses discovery entirely
-- [ ] Task panel shows "Discovered" section header with duration from discovery `PhaseRecord`
-- [ ] Clicking "Discovered" opens the discovery session transcript via phase record's `sessionId`
+- [ ] Task panel shows "Reviewed Ns" completed-state row with duration from discovery `PhaseRecord` (compute time, not wall-clock)
+- [ ] Clicking "Reviewed Ns" opens the discovery session in the chat-session viewer via phase record's `sessionId` (same display component as Planned and learning chats)
 - [ ] Planning reads the enriched task.md (no changes to planning's reading list needed)
 - [ ] Discovery appends a `PhaseRecord` with `phase: 'discovery'` to the `phases` array in `.run.json`
 - [ ] `pendingQuestions` written to `.run.json` while blocking, cleared after answer
@@ -494,7 +577,6 @@ Today, Start requires a stream assignment. A natural extension: tasks created wi
 - [ ] Discovery errors write `status: 'stopped'` with `stoppedDuring: 'discovery'`
 - [ ] Budget stop during discovery writes `stopReason: 'budget'` with Continue option
 - [ ] `clearStaleRun` handles `'discovering'` status
-- [ ] `PlaybookFrontmatter` includes optional `skipDiscovery?: boolean`
 - [ ] `canStart` gate relaxed: title + stream is sufficient when discovery is enabled (no description/inputs required)
 
 ## Edge Cases
@@ -546,17 +628,17 @@ Agent config (`lib/agents/config.server.test.ts`):
 API routes:
 
 - [ ] POST `/api/run/start` with `mode: 'discovery'` returns `{ status: 'discovering' }`
-- [ ] POST `/api/run/start` with `mode: 'discovery'` redirects to planning when `skipDiscovery: true`
 - [ ] POST `/api/run/answer` resolves the pending AskUserQuestion promise
 
 Client (`components/features/tasks/`):
 
-- [ ] Task card renders `QuestionRow` when a `question` event is received from the run stream
-- [ ] Island renders full AskUserQuestion UI during discovery Q&A
-- [ ] Submitting answers calls `POST /api/run/answer` and clears the question UI
-- [ ] On reconnect, client reads `pendingQuestions` from task content and re-renders question UI
-- [ ] "Discovered" section header renders with duration from discovery `PhaseRecord`
-- [ ] Clicking "Discovered" opens session transcript via discovery phase record's `sessionId`
+- [ ] Header stays "Reviewing the task..." while discovery is active, including when questions are pending (no header swap)
+- [ ] Question sub-row appears beneath the "Reviewing the task..." header when `pendingQuestions` is set on `.run.json` (regardless of whether the SSE `question` event fired — disk is authoritative)
+- [ ] Island renders full AskUserQuestion UI during discovery Q&A using the same component as learning chat
+- [ ] Submitting answers calls `POST /api/run/answer` and clears the question UI from the island
+- [ ] On reconnect, client reads `pendingQuestions` from task content and re-renders the question UI
+- [ ] "Reviewed Ns" completed-state row renders with duration from discovery `PhaseRecord` (compute time)
+- [ ] Clicking "Reviewed Ns" opens the discovery session in the chat-session viewer via discovery phase record's `sessionId`
 
 Not tested:
 

--- a/happyhq/specs/discovery.md
+++ b/happyhq/specs/discovery.md
@@ -399,62 +399,28 @@ After discovery completes, a `PhaseRecord` with `phase: 'discovery'` is appended
 
 ### Discovery Commits
 
-When discovery completes successfully (with or without questions), the loop commits: `[stream/task] Discovery complete`. This commit captures the `## Discovery` section added to `task.md`. The commit happens before planning begins.
+When discovery completes successfully and writes anything to `task.md`, the loop commits: `[stream/task] Discovery complete`. This commit is a chronological marker in git history showing what Q contributed. Nothing in v0 reads this commit programmatically — restart paths don't use it as an anchor. Its only role is auditability (git log + diff show what discovery added to `task.md`).
 
-### Restart From Any Phase
+If Q wrote nothing (clean tree), no commit happens. That's fine — the PhaseRecord on `.run.json` still records that discovery ran.
 
-The user controls where they restart from. The three restart points are:
+### Restart From a Phase
 
-| Restart from | `mode` sent   | What happens                                                                                                           |
-| ------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Discovery    | `'discovery'` | `task.md` restored to pre-discovery state via git, `plan.md` deleted, `working/` and `outputs/` cleared. Full restart. |
-| Planning     | `'planning'`  | `plan.md` deleted, `working/` and `outputs/` cleared. `## Discovery` section in `task.md` preserved.                   |
-| Working      | `'working'`   | `working/` and `outputs/` cleared, `plan.md` restored from "Plan accepted" commit. Everything else preserved.          |
+Discovery is a heads-up preamble, not a savepoint to "restart from." It just runs whenever a fresh run starts (or resumes from a stopped-during-discovery state — naturally, by sending `mode: 'discovery'`). The user is in control of `task.md` directly: they can edit it freely between runs to remove a stale `## Discovery` section, change the description, or anything else. There's no "restore task.md to pre-discovery state" affordance because the user is the one in charge of task.md.
 
-### Restoring task.md via Git
+The two visible restart paths after a stopped or completed run:
 
-Same pattern as `restorePlanFromGit`. A new `restoreTaskMdFromGit` helper:
+| Restart from | `mode` sent  | What happens                                                                                                  |
+| ------------ | ------------ | ------------------------------------------------------------------------------------------------------------- |
+| Planning     | `'planning'` | `plan.md` deleted, `working/` and `outputs/` cleared. `task.md` (including any `## Discovery`) is untouched.  |
+| Working      | `'working'`  | `working/` and `outputs/` cleared, `plan.md` restored from "Plan accepted" commit. Everything else preserved. |
 
-```typescript
-function restoreTaskMdFromGit(taskName: string): void {
-  const taskRelPath = `tasks/${taskName}/task.md`
-  // Find the "Discovery complete" commit and restore task.md from its parent
-  const hash = execSync(
-    `git log --format='%H' --grep='Discovery complete' -1 -- ${taskRelPath}`,
-    { cwd: HAPPYHQ_ROOT, encoding: 'utf8', stdio: 'pipe' },
-  ).trim()
-  if (!hash) return
-  execSync(`git restore --source=${hash}~1 -- ${taskRelPath}`, {
-    cwd: HAPPYHQ_ROOT,
-    stdio: 'pipe',
-  })
-}
-```
-
-This restores `task.md` to the version _before_ discovery enriched it — the user's original text. Uses `{hash}~1` (parent of the discovery commit) as the restore source.
+There is no "Restart from discovery" button. The mode `'discovery'` exists in the API for fresh starts and for resuming a stopped-during-discovery run, but it isn't surfaced as a restart button — completed runs don't offer "redo from discovery." If a user wants Q to look at the task fresh, they edit `task.md` to remove the prior `## Discovery` section (and/or change the description) and click Restart from plan; planning will read whatever's there. For a fully clean slate, duplicate the task as a new task.
 
 ### startRun Cleanup Updates
 
-The `startRun` function's fresh-run cleanup block gains a discovery case:
+The `startRun` function's fresh-run cleanup block does **not** gain a discovery case. Discovery has nothing to clean up before running — `task.md` is the user's, and the `## Discovery` section (if any from a prior run) is just text in the file. Q's prompt handles the "task already has a `## Discovery` section" case by deciding whether to update or leave it (judgment in the prompt; not enforced by code).
 
-```typescript
-if (mode === 'discovery') {
-  // Full restart — restore task.md to pre-discovery state
-  restoreTaskMdFromGit(taskName)
-  clearDirectory(path.join(taskDir, 'working'))
-  clearDirectory(path.join(taskDir, 'outputs'))
-  fs.rm(path.join(taskDir, 'plan.md'), { force: true })
-  commitGitState(`[${streamName}/${taskName}] Task restarted from scratch`)
-}
-```
-
-The existing `mode === 'planning'` cleanup handles deleting `plan.md` and clearing directories. The existing `mode === 'working'` cleanup handles `restorePlanFromGit`. Discovery adds the `restoreTaskMdFromGit` call.
-
-**Single commit for cleanup.** All restart-from-discovery operations — `restoreTaskMdFromGit`, deleting `plan.md`, clearing `working/` and `outputs/` — must land in the _same_ `commitGitState('Task restarted from scratch')` commit. If they land as multiple commits, the next discovery's `git log --grep='Discovery complete' -1 -- task.md` lookup can hit a stale or unrelated commit (the restart sequence interleaves with prior history). Mirror the ordering in the existing `mode === 'working'` block, which already follows this pattern for `restorePlanFromGit`.
-
-**First run:** `restoreTaskMdFromGit` is a graceful no-op when there's no "Discovery complete" commit (same as `restorePlanFromGit` on first planning run). No special-casing needed.
-
-**Destructive-restore guard: gate `task.md` description editing during a run.** `restoreTaskMdFromGit` does `git restore --source=...` which overwrites uncommitted edits to `task.md`. As of today, the description textarea in the panel ([happyhq/components/features/tasks/panel/index.tsx](happyhq/components/features/tasks/panel/index.tsx) — search for the `<textarea>` used for description editing) has no run-state gate, so a user _can_ type into the description while a run is active. Combined with restart-from-discovery, that means a user could lose mid-run edits silently. **Fix as part of this PR:** disable the description textarea while `isRunning` (the same pattern the panel uses elsewhere — see the many `disabled={runActions.isLoading || isRunning}` sites in the same file). One-line fix; closes the destructive-restore exposure.
+The existing `mode === 'planning'` cleanup handles deleting `plan.md` and clearing `working/`/`outputs/`. The existing `mode === 'working'` cleanup handles `restorePlanFromGit`. Discovery adds nothing.
 
 ## Task Panel UI
 
@@ -530,13 +496,12 @@ The duration shown is **compute time**, recorded as `durationMs` on the discover
 
 ### Restart Options
 
-When a task is stopped or finished, the user can restart from any completed phase:
+When a task is stopped or finished, the user has two restart affordances:
 
-- **Start over** — restarts from discovery (full restart, restores task.md)
-- **Restart from plan** — restarts from planning (preserves discovery)
-- **Restart from work** — restarts from working (preserves discovery + plan)
+- **Restart from plan** — `mode: 'planning'`. `task.md` (including any `## Discovery`) is preserved; `plan.md` deleted; `working/` and `outputs/` cleared. Planning runs.
+- **Restart from work** — `mode: 'working'`. Working/outputs cleared; `plan.md` restored from "Plan accepted" commit; everything else preserved. Working runs.
 
-These map to `POST /api/run/start` with `mode: 'discovery'`, `'planning'`, or `'working'`.
+There is no "Restart from discovery" button by design (see [Restart From a Phase](#restart-from-a-phase)). For a stopped-during-discovery run, clicking the resume affordance (Continue / Start) sends `mode: 'discovery'` naturally and the loop picks up where it stopped. For a completed run that the user wants Q to look at fresh, they edit `task.md` and click Restart from plan, or duplicate the task.
 
 ### Clarification Indicator (task list)
 
@@ -598,9 +563,9 @@ Today, Start requires a stream assignment. A natural extension: tasks created wi
 
 **Questions render in the island, not inline in the task card.** The island is the established surface for structured interactions during task work (plan approval uses it today). The task card shows a question sub-row beneath the "Reviewing the task..." header that points to the island. This avoids bloating the task card with interactive UI and keeps the question experience focused — same large, clear question blocks the user knows from learning mode.
 
-**Discovery enriches task.md, not a separate directory.** The task is the canonical object. After discovery, the task description should be self-contained. A separate `discovery/` directory would add surface area for limited benefit — the session log (via `discoverySessionId`) is the audit trail, and `task.md` is what planning reads. Git-based restore handles restart cleanly.
+**Discovery enriches task.md, not a separate directory.** The task is the canonical object. After discovery, the task description should be self-contained. A separate `discovery/` directory would add surface area for limited benefit — the session log (via the discovery `PhaseRecord.sessionId`) is the audit trail, and `task.md` is what planning reads.
 
-**Git-based restore, not string-stripping.** On restart from discovery, `task.md` is restored from git (parent of the "Discovery complete" commit) rather than parsing and stripping the `## Discovery` section. This follows the `restorePlanFromGit` pattern already used for `plan.md` during working restarts. Reliable, no markdown parsing, and handles any content Q might have written.
+**`task.md` is the user's; no destructive restore.** When a run is restarted, `task.md` is left untouched. The user controls its content between runs — they can keep, edit, or delete a prior `## Discovery` section as they wish. There is no `restoreTaskMdFromGit` helper, no commit-message-grep restore path, and no "Restart from discovery" button. Earlier drafts of this spec proposed those; they were dropped because (a) discovery is a heads-up preamble, not a savepoint to "restore to," and (b) handing the user a button that silently rewrites `task.md` makes the destructive case (overwriting their edits) too easy to hit. If a future "wipe plan/working but keep task.md" affordance is needed, it's a thin extension of the existing planning-mode cleanup — not a new restore mechanism.
 
 **No `discovered` status.** It would exist for ~0ms between discovery completing and planning starting. Nothing would render it. The task panel's "Reviewed 2m 10s" comes from the discovery `PhaseRecord` in the `phases` array, not the status field.
 
@@ -645,13 +610,9 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 
 **Scenario 1 — Silent proceed (extends the existing golden path).** Use the rich task fixture. Click Start. Assert: header shows "Reviewing the task..." briefly; transitions to "Planning..." without surfacing any question UI; no `## Discovery` section appended (or appended with non-question synthesis only); planning produces `plan.md`; PhaseRecord `{ phase: 'discovery', durationMs > 0, sessionId }` exists in `.run.json`.
 
-**Scenario 2 — Asks questions and integrates answers.** Use the thin task fixture. Click Start. Assert: header reads "Reviewing the task..."; question sub-row appears beneath the header; full `AskUserQuestion` block renders in the island. Take a screenshot for visual regression. Programmatically submit answers via `POST /api/run/answer` with reasonable values (e.g., `{ "What's the goal of this intro?": "Collaboration on a project", "Do you have a personal anecdote?": "Met them at a charity dinner — Bugs stole Tom's bread roll, Tom played along, table laughed" }`). Assert: question UI clears; activity stream resumes; eventually transitions to "Planning..."; `task.md` now contains a `## Discovery` section reflecting the answers; planning produces a `plan.md` that references the anecdote.
+**Scenario 2 — Asks questions and integrates answers.** Use the thin task fixture. Click Start. Assert: question sub-row appears beneath the header; full `AskUserQuestion` block renders in the island. Take a screenshot for visual regression. Programmatically submit answers via `POST /api/run/answer` with reasonable values. Assert: question UI clears; activity stream resumes; eventually transitions to "Planning..."; `task.md` now contains a `## Discovery` section reflecting the answers; planning produces a `plan.md` that references what was learned in discovery.
 
-**Scenario 3 — Header stays stable across question state.** During Scenario 2, capture the header's text content at three points: (a) before questions surface, (b) while questions are pending, (c) after answers submitted but before planning starts. Assert all three read "Reviewing the task..." — no swap to "Q has questions for you" or anything else.
-
-**Scenario 4 — Restart from discovery restores `task.md`.** After Scenario 2 completes (or partway through, after the `## Discovery` section is written), click "Start over." Assert: `task.md` reverts to the user's original (no `## Discovery` section); discovery runs again; PhaseRecord history shows two discovery entries (the first one's commit is preserved in git but `task.md` content is rewound).
-
-**Scenario 5 — Restart from plan preserves `## Discovery`.** After Scenario 2 reaches `plan_ready`, click "Restart from plan." Assert: `task.md` still contains the `## Discovery` section from Scenario 2; `plan.md` is regenerated; planning runs without re-running discovery.
+**Scenario 3 — Restart from plan preserves `## Discovery`.** After Scenario 2 reaches `plan_ready`, click "Restart from plan." Assert: `task.md` still contains the `## Discovery` section from Scenario 2; `plan.md` is regenerated; planning runs.
 
 **Where the scenarios live.** Scenario 1 extends `scripts/smoke-e2e.ts` (the golden path). Scenarios 2–5 can live in the same script as additional test functions or split into `scripts/smoke-discovery.ts` with a sibling `smoke:discovery` package.json script — implementer's call. The harness pattern (boot a fresh dev server pointed at a per-run `/tmp/happyhq-smoke-<uuid>`, pre-seed the fixture stream, drive Chromium, assert filesystem + DOM state) is established; reuse it.
 
@@ -690,10 +651,9 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 
 **Restart:**
 
-- [ ] Restart from discovery restores task.md to pre-discovery state via `restoreTaskMdFromGit`
-- [ ] Restart-from-discovery cleanup (`restoreTaskMdFromGit`, delete `plan.md`, clear `working/`/`outputs/`) lands in a single `commitGitState('Task restarted from scratch')` commit
-- [ ] Restart from planning preserves `## Discovery` section, only deletes plan.md
-- [ ] Description textarea in the task panel is disabled while `isRunning` (closes the destructive-restore exposure on `task.md`)
+- [ ] Restart from planning preserves `task.md` (including any `## Discovery` section), only deletes plan.md, clears `working/`/`outputs/`
+- [ ] No "Restart from discovery" button surfaced in v0; the `mode: 'discovery'` API path remains for fresh starts and stopped-during-discovery resume
+- [ ] No `restoreTaskMdFromGit` helper (`task.md` is the user's; the user controls its content between runs)
 
 **UI (task card / island / list):**
 
@@ -724,9 +684,7 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 - [ ] Two task fixtures: `thin-intro.md` (title only) and `rich-intro.md` (full description with anecdote)
 - [ ] Scenario 1 (silent proceed) extends the existing golden path in `scripts/smoke-e2e.ts` — discovery runs and transitions to planning without surfacing question UI
 - [ ] Scenario 2 (asks questions and integrates answers) — discovery on the thin task surfaces question UI, programmatic answers submit, `## Discovery` section reflects answers, planning runs against enriched task.md
-- [ ] Scenario 3 (header stable) — header text is "Reviewing the task..." before, during, and after question state; verified via DOM inspection
-- [ ] Scenario 4 (restart from discovery) — Start over restores task.md to pre-discovery state
-- [ ] Scenario 5 (restart from plan) — Restart from plan preserves `## Discovery` section, regenerates plan.md only
+- [ ] Scenario 3 (restart from plan preserves `## Discovery`) — Restart from plan keeps `## Discovery` in task.md, regenerates plan.md only
 - [ ] Discovery smoke scenarios run in CI on PRs touching `prompts/discovery.md`, `lib/agents/config.server.ts`, or `lib/run/loop.server.ts` (not on every unrelated PR — they cost real Opus dollars)
 
 ## Edge Cases
@@ -735,14 +693,13 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 - **Task has only a title**: Q almost certainly asks questions. This is the primary use case — quick-added tasks that need fleshing out.
 - **User navigates away during discovery Q&A**: The `canUseTool` callback is blocking server-side. The run stream disconnects but the session stays alive. On return, the client reads `pendingQuestions` from `.run.json` (via the task content API) and re-renders the question UI. If the user never returns, the session eventually times out via budget limit.
 - **User closes the app after answering last question**: Server-driven transition means planning starts regardless. User returns to find planning done or `plan_ready`.
-- **Discovery fails or errors**: Same pattern as planning errors. Write `status: 'stopped'`, `stoppedDuring: 'discovery'`. UI shows restart options. User can restart from discovery or skip to planning.
-- **Discovery times out (budget)**: Write `status: 'stopped'`, `stopReason: 'budget'`, `stoppedDuring: 'discovery'`. Continue button resumes discovery.
-- **Server restart during discovery Q&A**: Session is lost. `clearStaleRun` writes `status: 'stopped'`, `stoppedDuring: 'discovery'`. User restarts. The `## Discovery` section is only written when Q completes successfully, so a partial run leaves task.md unchanged.
+- **Discovery fails or errors**: Same pattern as planning errors. Write `status: 'stopped'`, `stoppedDuring: 'discovery'`. UI shows the standard stopped affordances (Continue / Restart from plan).
+- **Discovery times out (budget)**: Write `status: 'stopped'`, `stopReason: 'budget'`, `stoppedDuring: 'discovery'`. Continue resumes discovery.
+- **Server restart during discovery Q&A**: Session is lost. `clearStaleRun` writes `status: 'stopped'`, `stoppedDuring: 'discovery'` and clears `pendingQuestions`. User clicks Continue (resumes from `mode: 'discovery'`) or Restart from plan.
 - **Stream has no playbook or specs**: Discovery is especially useful here — Q recognizes it has little context and asks questions the playbook would normally answer. But if the task description is detailed enough, Q should still proceed.
-- **User stops mid-conversation**: Session is aborted. Answers from prior rounds are lost (session context is gone). task.md is unchanged (Q hadn't written yet). User can restart from discovery (try again) or from planning (skip).
-- **Restart with no discovery commit**: `restoreTaskMdFromGit` is a graceful no-op when there's no "Discovery complete" commit in history. No special-casing needed.
-- **Discovery writes nothing to task.md**: Possible when Q has enough context. `commitGitState` is a no-op on clean tree. No "Discovery complete" commit exists, so future `restoreTaskMdFromGit` is a no-op. Clean.
-- **Multiple runs on the same task**: Each restart from discovery restores task.md to before the _latest_ "Discovery complete" commit. Since restart clears previous state before re-running, this always finds the right commit.
+- **User stops mid-conversation**: Session is aborted. Answers from prior rounds are lost (session context is gone). `task.md` may have been updated already by an earlier successful `## Discovery` write — that content is preserved. The user can Continue (resumes discovery; Q may re-ask or update what's there) or Restart from plan (uses task.md as-is).
+- **Discovery writes nothing to `task.md`**: Possible when Q has enough context. `commitGitState` is a no-op on clean tree. No "Discovery complete" commit exists; the PhaseRecord on `.run.json` still records that discovery ran.
+- **Multiple runs on the same task**: Each run reads whatever `task.md` is at the moment Q starts. If a prior `## Discovery` section is present, Q's prompt judgment decides whether to update it, replace it, or leave it. The user can also delete it manually between runs.
 
 ## Testing
 
@@ -765,10 +722,8 @@ Run loop — discovery mode (`lib/run/loop.server.test.ts`):
 
 Restart (`lib/run/loop.server.test.ts`):
 
-- [ ] Restart from discovery (`mode: 'discovery'`) calls `restoreTaskMdFromGit`, deletes plan.md, clears working/ and outputs/
-- [ ] Restart-from-discovery cleanup operations land in a single git commit (verify `git log` after restart shows one "Task restarted from scratch" commit)
-- [ ] Restart from planning (`mode: 'planning'`) preserves task.md (including `## Discovery`), deletes plan.md
-- [ ] `restoreTaskMdFromGit` is no-op when no "Discovery complete" commit exists
+- [ ] Restart from planning (`mode: 'planning'`) preserves `task.md` (including any `## Discovery` section), deletes plan.md, clears `working/`/`outputs/`
+- [ ] Restart from working (`mode: 'working'`) — no change from existing behavior
 
 Agent config (`lib/agents/config.server.test.ts`):
 

--- a/happyhq/specs/discovery.md
+++ b/happyhq/specs/discovery.md
@@ -170,8 +170,16 @@ New endpoint: `POST /api/run/answer` — thin wrapper that calls `submitAnswer(s
 ```typescript
 // POST /api/run/answer
 // Body: { answers: Record<string, string> }
-// Resolves the pending AskUserQuestion promise, SDK continues
+// Returns 200 { status: 'answered' } on success
+// Returns 400 { error: string } on schema validation failure
+// Returns 404 { error: 'No pending question' } when no session is blocked
 ```
+
+**Validation:** parse the body via a zod schema (`{ answers: z.record(z.string()) }`). Reject malformed bodies with 400.
+
+**No-pending-question case:** `submitAnswer(sessionId, answers)` returns `false` when there's no resolved promise to consume (no active session, or the session was just aborted). Return 404 in that case — never pretend the answer was accepted, since the SDK doesn't get the answer and Q won't continue.
+
+**Race with Stop:** the user could submit answers while a Stop request is in flight (or vice versa). The Promise.race in `canUseTool` already handles the SDK side — abort wins, the answer is dropped harmlessly. The endpoint side: if `submitAnswer` returns false because the session was just aborted, surface 404 — the client renders the run as stopped on its next state read.
 
 When the promise resolves, `canUseTool` clears `pending: clarification` on `task.md` and returns the answers to the SDK. Q continues within the same `query()` call — more activity events stream through the existing connection.
 
@@ -210,7 +218,13 @@ allowedTools: [
 ]
 ```
 
-No subagents. No `EnterPlanMode` / `ExitPlanMode`. `persistSession: true` (enables session resume on budget stop, same as planning/working).
+**Explicit non-configuration** (so the implementer doesn't copy from learning by reflex):
+
+- No `mcpServers` — discovery uses no custom MCP tools (no `ProcessSample`, no `CreateTask`, etc.).
+- No `agents` — no custom subagents (no Drafting). Built-in subagent types are also unused.
+- No `EnterPlanMode` / `ExitPlanMode` (in `disallowedTools`).
+- `persistSession: true` (enables session resume on budget stop, same as planning/working).
+- `settingSources: []` (SDK isolation mode, same as other modes).
 
 ### canUseTool Callback
 
@@ -245,7 +259,18 @@ canUseTool: async (toolName, input, { signal }) => {
 }
 ```
 
-Same structure as the learning agent's `canUseTool`, with additions: (1) broadcasts the question event through the run stream, (2) sets `pending: clarification` + writes `pendingQuestions` to `.run.json` before blocking, (3) clears both after.
+Same structure as the learning agent's `canUseTool`, with additions specific to running inside the run loop.
+
+**Setup ordering before blocking** (the canUseTool callback runs these in order; the disk write is most critical for reconnect, so it goes first):
+
+1. Write `pendingQuestions` to `.run.json` via `updateRunInfoPendingQuestions(taskName, input.questions)`.
+2. Set `pending: 'clarification'` on `task.md` via `updateTaskMdPending(...)`.
+3. Broadcast the `question` event via `notifyClient` — fire-and-forget.
+4. Block on `Promise.race([waitForAnswer(sessionId), abortPromise])`.
+
+If step 1 or 2 throws, the callback returns `{ result: 'deny', message: 'Discovery state write failed' }` — Q falls back without blocking, and discovery proceeds to write whatever `## Discovery` section it has and exit. We never block on user input we can't reliably surface.
+
+**Cleanup on resolution or abort** (in `finally`): clear `pendingQuestions` and `pending` in the same order as setup, both with `.catch(() => {})` since the callback is exiting and the disk state will be reconciled by the loop's next status write.
 
 ### System Prompt
 
@@ -287,6 +312,8 @@ Discovery uses the `phases` array on `RunInfo` (see [Working](working.md) for th
 
 When discovery is blocking on AskUserQuestion, the `pendingQuestions` field on `RunInfo` stores the current question input. Cleared when the user answers. This enables client reconnect and multi-channel adapters to read the pending questions from the task content API.
 
+**Stale-run cleanup must clear `pendingQuestions`.** When `clearStaleRun()` flips a leftover `'discovering'` status to `'stopped'` (server restart, HMR, etc.), it also clears `pendingQuestions`. Otherwise the client could read a stopped run with `pendingQuestions` still set and incorrectly render the question UI. The render rule is "if `pendingQuestions` is present, show the question UI" — so the disk write must keep status and pendingQuestions consistent.
+
 ### Lifecycle
 
 ```
@@ -311,12 +338,23 @@ startRun(stream, task, 'discovery')
   ├── commits: [stream/task] Discovery complete
   │
   └── transitions to planning (server-driven, no client round-trip)
-      ├── appends PhaseRecord { phase: 'discovery' } to phases array
+      ├── appends PhaseRecord { phase: 'discovery', sessionId, costUsd, durationMs, ... }
+      │   to phases array on .run.json
       ├── writes .run.json { status: 'planning' }
       └── runs planning agent (same as today)
 ```
 
 The auto-transition from discovery to planning happens inside the server process. There is no conditional — planning always follows discovery. The only branching is if discovery errors or is stopped, in which case planning doesn't run. The user can close the tab after answering Q's last question and come back to find planning done (or `plan_ready`).
+
+**Canonical write order between discovery and planning** (matters for crash recovery):
+
+1. Discovery `query()` resolves successfully. Q has already written any `## Discovery` section to `task.md` and exited.
+2. `commitGitState('[stream/task] Discovery complete')` — the commit captures the `## Discovery` diff (or is a no-op if Q wrote nothing).
+3. Append `PhaseRecord { phase: 'discovery', ... }` to `phases` on `.run.json` — single atomic write.
+4. Flip `.run.json.status` to `'planning'` — single atomic write (can be combined with step 3).
+5. Run the planning agent.
+
+A crash between step 2 and step 3 leaves a "Discovery complete" commit on disk but no `PhaseRecord` for it. On the next read, `clearStaleRun` flips status to `'stopped'` and the user sees Restart options. The commit remains in history; the next discovery will append a fresh PhaseRecord. No data loss; no inconsistency that requires manual recovery.
 
 ### Loop Implementation
 
@@ -342,7 +380,14 @@ if (mode === 'discovery') {
 
 `runDiscoveryIteration` follows the same structure as `runPlanningIteration`: create a session, run `query()`, handle abort/budget/error, return status. The key difference: discovery uses `canUseTool` with AskUserQuestion blocking and question broadcasting, while planning uses `createAutomatedCanUseTool()` (fully automated).
 
-**Type changes required:** The `mode` parameter in `startRun()` signature, the `POST /api/run/start` route body validation, and `use-run-actions.ts` on the client all need `'discovery'` added to the mode union. See [Working](working.md) for the updated API contract.
+**Type changes required.** Add `'discovery'` to every `mode` union and `'discovering'` to every `RunInfo.status` union. The concrete sites:
+
+- `app/api/run/start/route.ts` — request body schema (currently `'planning' | 'working'`).
+- `lib/run/loop.server.ts` — `startRun()` and `runLoop()` signatures + dispatch.
+- `lib/fs/types.ts` — `RunInfo.status` and `RunInfo.stoppedDuring` unions (see [Working](working.md) for the full new shape).
+- Client run-actions hook (find via `grep -rn '"planning" | "working"' happyhq/components` — look for the `useRunActions` / `use-run-actions` file).
+
+After updating the unions, run `pnpm check-types` from `happyhq/`. TypeScript will surface every site that switches on `status` or `mode` without a default — add a `'discovering'` arm to each. Don't suppress with `as any`; an unhandled status arm is the kind of bug that goes silent in production.
 
 ### Billing
 
@@ -409,6 +454,8 @@ The existing `mode === 'planning'` cleanup handles deleting `plan.md` and cleari
 
 **First run:** `restoreTaskMdFromGit` is a graceful no-op when there's no "Discovery complete" commit (same as `restorePlanFromGit` on first planning run). No special-casing needed.
 
+**Destructive-restore guard: gate `task.md` description editing during a run.** `restoreTaskMdFromGit` does `git restore --source=...` which overwrites uncommitted edits to `task.md`. As of today, the description textarea in the panel ([happyhq/components/features/tasks/panel/index.tsx](happyhq/components/features/tasks/panel/index.tsx) — search for the `<textarea>` used for description editing) has no run-state gate, so a user _can_ type into the description while a run is active. Combined with restart-from-discovery, that means a user could lose mid-run edits silently. **Fix as part of this PR:** disable the description textarea while `isRunning` (the same pattern the panel uses elsewhere — see the many `disabled={runActions.isLoading || isRunning}` sites in the same file). One-line fix; closes the destructive-restore exposure.
+
 ## Task Panel UI
 
 Discovery follows the same shape as planning and working: a phase header in the task card, sub-rows beneath it for items that exist during the phase, and a duration label after.
@@ -439,6 +486,12 @@ Questions render in the **island** as full `AskUserQuestion` blocks — the same
 
 When the user submits answers (`POST /api/run/answer`), the question block clears from the island, the question sub-row in the task card updates (per the persist/vanish decision above), and the activity stream resumes as Q processes the answers. If Q asks follow-ups, a new question block appears.
 
+**Activity stream behavior while questions are open.** When `pendingQuestions` is set, `query()` is blocked in `canUseTool` — the SDK is not generating events. The activity area beneath the "Reviewing the task..." header has nothing live to render, so the question sub-row is what fills that area. Don't show a generic spinner alongside the question — it would imply Q is doing something when really Q is waiting on the user. The sub-row alone makes the wait state legible.
+
+### Transition to planning
+
+When discovery completes and the loop flips status to `'planning'`, the user sees the header text change from "Reviewing the task..." to "Planning..." and the activity stream restart with planning's events. There's no flicker, no spinner reset, no empty intermediate state — same shape as the existing `planning → plan_ready` transition. The brief gap (write status + append PhaseRecord + start planning's `query()`) is invisible at human timescales. The Stop button persists across the transition.
+
 ### Completed-state row: clicking opens the session
 
 ```
@@ -446,6 +499,30 @@ When the user submits answers (`POST /api/run/answer`), the question block clear
 ```
 
 Clicking the row opens the discovery session in the chat-session viewer — the same component used for clicking "Planned" or for opening any learning chat. The transcript shows what Q read, what it considered, and the inline question/answer rounds (`AskUserQuestion` calls render in the transcript exactly as they would in any chat session — there is no second display path).
+
+**Concretely: reuse `openChatSessionWindow`.** The Planned-row handler today is at `happyhq/components/features/tasks/panel/index.tsx` (search for `planningSessionId`):
+
+```typescript
+openChatSessionWindow(
+  streamSlug,
+  [taskContent.run!.planningSessionId!],
+  'Planning Session',
+  `chat-${taskSlug}-planning`,
+)
+```
+
+Discovery's "Reviewed Ns" handler calls the same helper with the discovery phase record's `sessionId` and a discovery-flavored label/key:
+
+```typescript
+openChatSessionWindow(
+  streamSlug,
+  [discoveryPhase.sessionId],
+  'Discovery Session',
+  `chat-${taskSlug}-discovery`,
+)
+```
+
+`openChatSessionWindow` lives at `happyhq/components/features/desktop/windows/chat/open-chat-window.ts`. No new viewer to build.
 
 The duration shown is **compute time**, recorded as `durationMs` on the discovery `PhaseRecord`. It does _not_ include time spent waiting for the user to answer questions. A discovery run that took 90 seconds of compute but waited 20 minutes for an answer reads as "Reviewed 1m 30s," not "Reviewed 21m 30s." The row is honest about what Q actually did.
 
@@ -519,7 +596,7 @@ Today, Start requires a stream assignment. A natural extension: tasks created wi
 
 **Discovery runs in the run loop, not as a chat session.** Discovery could use the chat infrastructure (`POST /api/chat`), which already handles AskUserQuestion rendering and answer submission. But this splits the lifecycle: the client would have to orchestrate the transition from discovery chat to planning run, billing would span two systems, and `.run.json` management would be divided between chat and run code. Keeping discovery in the run loop means the server owns the full lifecycle — `discovering` → `planning` → `plan_ready` → working → `completed`. One billing record. One state machine. The new plumbing (question event in run stream + answer endpoint) is small and contained.
 
-**Questions render in the island, not inline in the task card.** The island is the established surface for structured interactions during task work (plan approval uses it today). The task card shows a hint (`QuestionRow`) that points to the island. This avoids bloating the task card with interactive UI and keeps the question experience focused — same large, clear question blocks the user knows from learning mode.
+**Questions render in the island, not inline in the task card.** The island is the established surface for structured interactions during task work (plan approval uses it today). The task card shows a question sub-row beneath the "Reviewing the task..." header that points to the island. This avoids bloating the task card with interactive UI and keeps the question experience focused — same large, clear question blocks the user knows from learning mode.
 
 **Discovery enriches task.md, not a separate directory.** The task is the canonical object. After discovery, the task description should be self-contained. A separate `discovery/` directory would add surface area for limited benefit — the session log (via `discoverySessionId`) is the audit trail, and `task.md` is what planning reads. Git-based restore handles restart cleanly.
 
@@ -554,29 +631,63 @@ Everything documented in this spec is in v0 _unless_ listed below. The deferred 
 
 ## Acceptance Criteria
 
-- [ ] Start button triggers discovery (not planning directly) when `skipDiscovery` is not set
-- [ ] Discovery agent reads task inputs, stream playbook, specs, and samples
+**Run loop and agent:**
+
+- [ ] Start button triggers discovery (not planning directly) — v0 always runs discovery on Start
+- [ ] `discoveryAgentOptions()` factory exists in `lib/agents/config.server.ts`: Sonnet, adaptive thinking, no `mcpServers`, no `agents`, `persistSession: true`, `settingSources: []`, `disallowedTools: ['EnterPlanMode', 'ExitPlanMode']`
+- [ ] Discovery agent reads task inputs, stream playbook, specs, and samples (read-first rule from prompt)
+- [ ] `runDiscoveryIteration()` exists in `lib/run/loop.server.ts`, mirroring `runPlanningIteration` shape; returns `'completed' | 'stopped' | 'budget'`
 - [ ] When Q has enough context, discovery auto-transitions to planning without user action
-- [ ] When Q has questions, `canUseTool` broadcasts a `question` event through the run stream
-- [ ] `canUseTool` sets `pending: clarification` before blocking and clears it after
+- [ ] Loop commits `[stream/task] Discovery complete` after successful discovery, before planning
+- [ ] Discovery appends a `PhaseRecord` with `phase: 'discovery'` to `phases` on `.run.json`, then flips status to `'planning'` (single write where possible)
+- [ ] Planning reads the enriched task.md (no changes to planning's reading list needed)
+
+**`canUseTool` and answers:**
+
+- [ ] `canUseTool` setup ordering: write `pendingQuestions` to `.run.json`, set `pending: 'clarification'` on task.md, broadcast `question` event, then block on `Promise.race([waitForAnswer, abort])`
+- [ ] Setup write failure (steps 1 or 2) returns `{ result: 'deny', message: ... }` — never blocks on input we can't surface
+- [ ] Cleanup in `finally` clears both `pendingQuestions` and `pending: 'clarification'`, both with `.catch(() => {})`
+- [ ] Q can ask follow-up questions within the same session (multiple rounds)
+- [ ] `POST /api/run/answer` validates body via zod (`{ answers: Record<string, string> }`), returns 400 on schema fail, 404 on no-pending-question, 200 `{ status: 'answered' }` on success
+- [ ] When `submitAnswer()` returns `false` (no active session, race with abort), endpoint returns 404 — never silently swallows
+
+**State and types:**
+
+- [ ] `'discovery'` added to `mode` union in: `app/api/run/start/route.ts`, `lib/run/loop.server.ts` (`startRun` + `runLoop`), and the client run-actions hook
+- [ ] `'discovering'` added to `RunInfo.status` union; `'discovery'` added to `RunInfo.stoppedDuring` union (in `lib/fs/types.ts`)
+- [ ] `pnpm check-types` passes — every existing exhaustive `switch` on `status` or `mode` has a `'discovering'` / `'discovery'` arm
+- [ ] `parseRunInfo(raw): RunInfo` introduced in `lib/fs/read.server.ts`; both existing `JSON.parse(runJson) as RunInfo` sites switch to `parseRunInfo(JSON.parse(runJson))`; shim handles old shape (see [Working](working.md) migration)
+- [ ] `clearStaleRun` clears `pendingQuestions` along with flipping `'discovering'` status to `'stopped'`
+- [ ] Q synthesizes what it learned and appends a `## Discovery` section to task.md (or writes nothing when there's nothing useful to add)
+
+**Restart:**
+
+- [ ] Restart from discovery restores task.md to pre-discovery state via `restoreTaskMdFromGit`
+- [ ] Restart-from-discovery cleanup (`restoreTaskMdFromGit`, delete `plan.md`, clear `working/`/`outputs/`) lands in a single `commitGitState('Task restarted from scratch')` commit
+- [ ] Restart from planning preserves `## Discovery` section, only deletes plan.md
+- [ ] Description textarea in the task panel is disabled while `isRunning` (closes the destructive-restore exposure on `task.md`)
+
+**UI (task card / island / list):**
+
 - [ ] Header in the task card stays "Reviewing the task..." while discovery is active — does NOT swap text when questions surface
 - [ ] When questions are pending, a question sub-row appears beneath the "Reviewing the task..." header in the task card
-- [ ] Questions render in the island as full AskUserQuestion blocks (same component as learning chat), with the task-card sub-row pointing to the island
-- [ ] `POST /api/run/answer` accepts answers and resolves the pending AskUserQuestion promise
-- [ ] Q can ask follow-up questions within the same session (multiple rounds)
-- [ ] Q synthesizes what it learned and appends a `## Discovery` section to task.md
-- [ ] Loop commits `[stream/task] Discovery complete` after successful discovery, before planning
+- [ ] Questions render in the island as full `AskUserQuestion` blocks (same component as learning chat), with the task-card sub-row pointing to the island
+- [ ] Submitting answers calls `POST /api/run/answer` and clears the question UI from the island
+- [ ] On reconnect, client reads `pendingQuestions` from task content and re-renders the question UI (disk authoritative; SSE event is fast path)
+- [ ] Activity area beneath the header shows the question sub-row when questions are open — no concurrent spinner suggesting Q is "doing something"
 - [ ] Task panel shows "Reviewed Ns" completed-state row with duration from discovery `PhaseRecord` (compute time, not wall-clock)
-- [ ] Clicking "Reviewed Ns" opens the discovery session in the chat-session viewer via phase record's `sessionId` (same display component as Planned and learning chats)
-- [ ] Planning reads the enriched task.md (no changes to planning's reading list needed)
-- [ ] Discovery appends a `PhaseRecord` with `phase: 'discovery'` to the `phases` array in `.run.json`
-- [ ] `pendingQuestions` written to `.run.json` while blocking, cleared after answer
-- [ ] Billing record spans discovery + planning (single `startTaskRun` / `finalizeTaskRun` lifecycle)
-- [ ] Restart from discovery restores task.md to pre-discovery state via `restoreTaskMdFromGit`
-- [ ] Restart from planning preserves `## Discovery` section, only deletes plan.md
+- [ ] Clicking "Reviewed Ns" calls `openChatSessionWindow(streamSlug, [discoveryPhase.sessionId], 'Discovery Session', chat-${taskSlug}-discovery)` — same helper as the existing Planned-row handler
+- [ ] Discovery → Planning transition is seamless: header text changes from "Reviewing the task..." to "Planning...", activity stream restarts with planning's events, no spinner reset, Stop button persists
+- [ ] Task list "Needs clarification" badge appears when a task's `pending` is `'clarification'`
+
+**Errors and budget:**
+
 - [ ] Discovery errors write `status: 'stopped'` with `stoppedDuring: 'discovery'`
 - [ ] Budget stop during discovery writes `stopReason: 'budget'` with Continue option
-- [ ] `clearStaleRun` handles `'discovering'` status
+
+**Billing and gating:**
+
+- [ ] Billing record spans discovery + planning (single `startTaskRun` / `finalizeTaskRun` lifecycle)
 - [ ] `canStart` gate relaxed: title + stream is sufficient when discovery is enabled (no description/inputs required)
 
 ## Edge Cases
@@ -616,19 +727,31 @@ Run loop — discovery mode (`lib/run/loop.server.test.ts`):
 Restart (`lib/run/loop.server.test.ts`):
 
 - [ ] Restart from discovery (`mode: 'discovery'`) calls `restoreTaskMdFromGit`, deletes plan.md, clears working/ and outputs/
+- [ ] Restart-from-discovery cleanup operations land in a single git commit (verify `git log` after restart shows one "Task restarted from scratch" commit)
 - [ ] Restart from planning (`mode: 'planning'`) preserves task.md (including `## Discovery`), deletes plan.md
 - [ ] `restoreTaskMdFromGit` is no-op when no "Discovery complete" commit exists
 
 Agent config (`lib/agents/config.server.test.ts`):
 
 - [ ] `discoveryAgentOptions` returns Sonnet model with AskUserQuestion blocking via canUseTool
+- [ ] `discoveryAgentOptions` does NOT configure `mcpServers` or `agents` (no custom MCP, no custom subagents)
+- [ ] AskUserQuestion triggers the documented setup ordering: `pendingQuestions` write → `pending: 'clarification'` set → `question` event broadcast → block on `Promise.race`
+- [ ] Setup write failure (mock `updateRunInfoPendingQuestions` to throw) returns `{ result: 'deny' }` without blocking
 - [ ] AskUserQuestion triggers `pending: clarification` set/clear cycle
 - [ ] AskUserQuestion triggers `question` event broadcast via notifyClient
+
+Compat shim (`lib/fs/read.server.test.ts`):
+
+- [ ] `parseRunInfo` synthesizes `phases: PhaseRecord[]` from old shape with `planningCostUsd` + `workingSessionIds` + `iterations`
+- [ ] `parseRunInfo` returns input unchanged when `phases` is already present (new shape pass-through)
+- [ ] Three fixtures: planning-only, planning + N working iterations, never-run task (no old fields) — all parse without error
 
 API routes:
 
 - [ ] POST `/api/run/start` with `mode: 'discovery'` returns `{ status: 'discovering' }`
-- [ ] POST `/api/run/answer` resolves the pending AskUserQuestion promise
+- [ ] POST `/api/run/answer` with valid body resolves the pending AskUserQuestion promise (200 `{ status: 'answered' }`)
+- [ ] POST `/api/run/answer` with malformed body returns 400
+- [ ] POST `/api/run/answer` when no session is blocked returns 404 `{ error: 'No pending question' }`
 
 Client (`components/features/tasks/`):
 

--- a/happyhq/specs/discovery.md
+++ b/happyhq/specs/discovery.md
@@ -28,10 +28,6 @@ Architecturally, discovery is a **heads-up** mode that joins learning. See [Agen
 - Run lifecycle, `.run.json`, and `PhaseRecord` / `RunInfo` types → [Working](working.md)
 - Agent modes and orchestration → [Agent Configuration](agent-config.md)
 
-## Type refactor (ships in this same change)
-
-Discovery's `PhaseRecord` write is the forcing function for the `phases: PhaseRecord[]` structure on `RunInfo` described in [Working](working.md). The two ship together as one PR. Splitting them would mean the refactor lands without a forcing function (and rots) or discovery adds yet another flat field set (`discoveryCostUsd`, `discoverySessionId`, ...) to the structure the refactor is trying to replace. See [Working](working.md) for the new shape and the read-time compat shim that handles existing `.run.json` files.
-
 ## Trigger
 
 The user clicks Start on a task. Discovery runs immediately — it is the first phase of every run. Planning always follows discovery.
@@ -126,33 +122,177 @@ The bias-to-proceed heuristic is the entire UX. Ship the prompt with worked exam
 
 The pattern: **ASK** when (a) the playbook or spec lists something as required AND (b) Q can't derive it from inputs/specs/samples AND (c) it would change the plan. **PROCEED** otherwise. Over time, specs may say "if X is missing, assume Y" — that further reduces unnecessary questions and is a separate stream-level investment.
 
-## Interactive Q&A Plumbing
+## Lifecycle and Run State
 
-Discovery runs inside the run loop (like planning and working) but adds one new capability: the run stream can emit question events, and the client can submit answers back. This keeps the server in control of transitions and billing while enabling interactivity.
+Discovery adds one new status to `.run.json`:
 
-### How Questions Reach the Client
+| Status        | Meaning                                                         |
+| ------------- | --------------------------------------------------------------- |
+| `discovering` | Discovery agent is running (including waiting for user answers) |
+
+No `discovered` status. When discovery completes, the loop writes `status: 'planning'` immediately. The `discovering` → `planning` transition is instantaneous — nothing renders between them.
+
+The full `RunInfo.status` union becomes:
+
+```
+'discovering' | 'planning' | 'plan_ready' | 'working' | 'completed' | 'stopped'
+```
+
+The `stoppedDuring` union gets `'discovery'` alongside `'planning'` and `'working'`.
+
+### Phase Records and pendingQuestions
+
+Discovery uses the `phases` array on `RunInfo` (see [Working](working.md) for the full `PhaseRecord` and `RunInfo` type definitions). When discovery completes, a `PhaseRecord` with `phase: 'discovery'` is appended — recording `costUsd`, `durationMs`, and `sessionId`. The panel reads `phases.find(p => p.phase === 'discovery')` for duration, cost, and session transcript link.
+
+When discovery is blocking on AskUserQuestion, the `pendingQuestions` field on `RunInfo` stores the current question input. Cleared when the user answers. This enables client reconnect and multi-channel adapters to read the pending questions from the task content API.
+
+**Stale-run cleanup must clear `pendingQuestions`.** When `clearStaleRun()` flips a leftover `'discovering'` status to `'stopped'` (server restart, HMR, etc.), it also clears `pendingQuestions`. Otherwise the client could read a stopped run with `pendingQuestions` still set and incorrectly render the question UI. The render rule is "if `pendingQuestions` is present, show the question UI" — so the disk write must keep status and pendingQuestions consistent.
+
+### Canonical write order between discovery and planning
+
+Order matters for crash recovery:
+
+1. Discovery `query()` resolves successfully. Q has already written any `## Discovery` section to `task.md` and exited.
+2. `commitGitState('[stream/task] Discovery complete')` — captures the `## Discovery` diff (no-op if Q wrote nothing, since `commitGitState` is a no-op on a clean tree).
+3. Append `PhaseRecord { phase: 'discovery', sessionId, costUsd, durationMs, ... }` to `phases` on `.run.json`.
+4. Flip `.run.json.status` to `'planning'` (combine with step 3 in a single atomic write where possible).
+5. Run the planning agent.
+
+A crash between step 2 and step 3 leaves a "Discovery complete" commit on disk but no `PhaseRecord` for it. On the next read, `clearStaleRun` flips status to `'stopped'` and the user sees Restart options. The commit remains in history; the next discovery will append a fresh `PhaseRecord`. No data loss; no inconsistency that requires manual recovery.
+
+### Loop dispatch
+
+In `loop.server.ts`, the `runLoop` function dispatches based on mode:
+
+```typescript
+if (mode === 'discovery') {
+  // Run discovery, then planning sequentially
+  const discoveryStatus = await runDiscoveryIteration(...)
+  if (discoveryStatus !== 'completed') {
+    // 'stopped' (user/error/budget) — don't continue to planning
+    finalStatus = discoveryStatus
+  } else {
+    // Discovery succeeded — commit and continue to planning.
+    // commitGitState is a no-op on a clean tree, so this only creates a
+    // commit if Q wrote a ## Discovery section to task.md.
+    commitGitState(`[${streamName}/${taskName}] Discovery complete`)
+    finalStatus = await runPlanningIteration(...)
+  }
+} else if (mode === 'planning') {
+  finalStatus = await runPlanningIteration(...)
+} else {
+  finalStatus = await runWorkingLoop(...)
+}
+```
+
+`runDiscoveryIteration` follows the same structure as `runPlanningIteration`: create a session, run `query()`, handle abort/budget/error, return `Promise<RunInfo['status']>`. The key difference: discovery uses `canUseTool` with AskUserQuestion blocking and question broadcasting, while planning uses `createAutomatedCanUseTool()` (fully automated). In practice, discovery returns `'completed'` on success and `'stopped'` for any abort/error/budget case (with `stopReason` and `stoppedDuring` written to `.run.json` before returning). The dispatcher only proceeds to planning on `=== 'completed'`.
+
+### Type changes required
+
+Add `'discovery'` to every `mode` union and `'discovering'` to every `RunInfo.status` union. Concrete sites:
+
+- `app/api/run/start/route.ts` — request body schema (currently `'planning' | 'working'`).
+- `lib/run/loop.server.ts` — `startRun()` and `runLoop()` signatures + dispatch.
+- `lib/fs/types.ts` — `RunInfo.status` and `RunInfo.stoppedDuring` unions (see [Working](working.md) for the full new shape).
+- Client run-actions hook (find via `grep -rn '"planning" | "working"' happyhq/components` — look for the `useRunActions` / `use-run-actions` file).
+
+After updating the unions, run `pnpm check-types` from `happyhq/`. TypeScript will surface every site that switches on `status` or `mode` without a default — add a `'discovering'` arm to each. Don't suppress with `as any`; an unhandled status arm is the kind of bug that goes silent in production.
+
+### Billing
+
+Discovery cost is tracked within the same billing task run record that spans the full run lifecycle. The `runLoop` function starts a billing record at the top (`startTaskRun`) and finalizes at the bottom (`finalizeTaskRun`). When `mode: 'discovery'`, the loop runs discovery then planning sequentially — the billing record naturally spans both.
+
+After discovery completes, a `PhaseRecord` with `phase: 'discovery'` is appended to the `phases` array on `.run.json`, recording cost and duration. The `costUsd` field on RunInfo tracks the cumulative total (discovery + planning + working). `updateUsage` calls happen after each phase.
+
+## Plumbing
+
+### Question event on the run stream
 
 The run stream already broadcasts activity events via `notifyClient` in the run loop. Discovery adds a new event type:
 
 ```typescript
-// New event type in ChatStreamEvent
+// New variant in ChatStreamEvent
 | { type: 'question'; sessionId: string; questions: AskUserQuestionInput['questions'] }
 ```
 
-When the discovery agent calls AskUserQuestion, the `canUseTool` callback runs the setup sequence (see [canUseTool Callback](#canusetool-callback) for the canonical ordering — disk write first, then task.md pending, then broadcast, then block). The summary:
+`notifyClient` in the run loop is `(event) => broadcast(encodeEvent(event))`. Adding the new variant to `ChatStreamEvent` is sufficient — no new transport is needed. This uses the same callback pattern that PostToolUse hooks already use to emit activity step events; it does not go through `filterMessage` (which converts SDK messages into events, a separate path).
 
-1. Write `pendingQuestions` to `.run.json`.
-2. Set `pending: 'clarification'` on `task.md`.
-3. Broadcast `{ type: 'question', sessionId, questions }` through `notifyClient`.
-4. Block on `Promise.race([waitForAnswer(sessionId), abortPromise])`.
+### canUseTool callback
 
-The client receives the question event via `GET /api/run/stream` (same SSE connection it's already using for activity steps) and renders the question UI. This uses the same `notifyClient` callback pattern that PostToolUse hooks already use to emit activity step events — it does not go through `filterMessage` (which converts SDK messages into events, a separate path).
+```typescript
+canUseTool: async (toolName, input, { signal }) => {
+  if (toolName === 'AskUserQuestion') {
+    // Setup ordering: disk first (most critical for reconnect), then
+    // task.md pending, then broadcast, then block.
+    try {
+      await updateRunInfoPendingQuestions(taskName, input.questions)
+      await updateTaskMdPending(taskPath(taskName), 'clarification')
+    } catch (err) {
+      // Setup-write failure: log, then deny rather than block on
+      // input we can't surface.
+      log('run.error', {
+        stream: streamName,
+        task: taskName,
+        error: 'Discovery state write failed',
+      })
+      return { result: 'deny', message: 'Discovery state write failed' }
+    }
+    notifyClient({ type: 'question', sessionId, questions: input.questions })
+    try {
+      const answers = await Promise.race([
+        waitForAnswer(sessionId),
+        new Promise<never>((_, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('Aborted')), {
+            once: true,
+          })
+        }),
+      ])
+      return { result: 'allow', updatedInput: { ...input, answers } }
+    } finally {
+      // Clear pendingQuestions + pending whether answered or aborted.
+      // Fire-and-forget — the loop's next status write reconciles disk state.
+      await updateRunInfoPendingQuestions(taskName, undefined).catch(() => {})
+      await updateTaskMdPending(taskPath(taskName), undefined).catch(() => {})
+    }
+  }
+  return {
+    result: 'deny',
+    message: `Tool ${toolName} not available in discovery mode`,
+  }
+}
+```
 
-### Client Reconnect
+Same structure as the learning agent's `canUseTool`, with three additions specific to running inside the run loop:
 
-If the client disconnects and reconnects while discovery is waiting for answers, it needs to recover the pending questions. The `pendingQuestions` field on `RunInfo` stores the current AskUserQuestion input when discovery is blocking. The task content API (`GET /api/fs/task`) returns this as part of `.run.json`, so on reconnect the client sees `status: 'discovering'` + `pendingQuestions` and re-renders the question UI. This also serves the multi-channel case — a Slack adapter reads `pendingQuestions` from `.run.json` to know what to relay.
+1. Broadcasts a `question` event through the **run** SSE stream via `notifyClient` (learning broadcasts on the chat stream).
+2. Writes `pendingQuestions` to `.run.json` before blocking, clears it after.
+3. Sets `pending: 'clarification'` on `task.md` before blocking, clears it after.
 
-The `canUseTool` callback writes `pendingQuestions` to `.run.json` before blocking and clears it after the user answers. `pendingQuestions` (on `.run.json`) and `pending: 'clarification'` (on `task.md`) are two separate writes that the callback keeps in sync — see [canUseTool Callback](#canusetool-callback) for the exact setup and cleanup ordering.
+**Setup ordering before blocking** (disk write first because it's the only correctness mechanism for reconnect; the SSE event is a fast path):
+
+1. `updateRunInfoPendingQuestions(taskName, input.questions)` — disk first.
+2. `updateTaskMdPending(taskPath(taskName), 'clarification')` — drives the task-list badge.
+3. `notifyClient({ type: 'question', ... })` — fire-and-forget.
+4. `Promise.race([waitForAnswer(sessionId), abortPromise])` — block.
+
+If step 1 or 2 throws, the callback logs `run.error`, returns `{ result: 'deny', message: 'Discovery state write failed' }`. Q falls back without blocking; we never block on user input we can't reliably surface. **No silent denials.**
+
+**Cleanup** (in `finally`): clear `pendingQuestions` and `pending` in the same order as setup, both with `.catch(() => {})` since the callback is exiting and the loop's next status write will reconcile disk state.
+
+**Implementation note: `updateRunInfoPendingQuestions` is a new helper.** The existing `writeRunInfo` (private in `lib/run/loop.server.ts`) takes a full `RunInfo`, not a partial. The simplest implementation is a thin read-merge-write wrapper:
+
+```typescript
+async function updateRunInfoPendingQuestions(
+  taskName: string,
+  questions: AskUserQuestionInput['questions'] | undefined,
+): Promise<void> {
+  const info = await readRunInfo(taskName)
+  if (!info) return
+  await writeRunInfo(taskName, { ...info, pendingQuestions: questions })
+}
+```
+
+Live alongside `writeRunInfo` in `lib/run/loop.server.ts`, or hoist both to `lib/fs/run-json.server.ts` if `parseRunInfo` lands there too. The spec doesn't prescribe — implementer's call. `updateTaskMdPending` is the parallel pattern, already in `lib/fs/task-md.server.ts`.
 
 ### Event vs. disk precedence (rule)
 
@@ -162,11 +302,13 @@ The disk is authoritative; the SSE `question` event is a fast path. Concretely:
 - The SSE `question` event is fire-and-forget (the run stream uses `writer.write(...).catch(() => {})` — see [Working](working.md) on stream writes). A client mid-reconnect can miss it; the disk write closes that race.
 - Multi-channel adapters (future Slack, email) read `pendingQuestions` from `.run.json` directly. They never depend on the SSE event existing.
 
-This means: if discovery has questions but the SSE event was dropped, the client still renders correctly on next read of the task content API. The event is an optimization for in-app liveness, not a correctness mechanism.
+If discovery has questions but the SSE event was dropped, the client still renders correctly on next read of the task content API. The event is an optimization for in-app liveness, not a correctness mechanism.
 
-### How Answers Get Back
+### Client reconnect
 
-New endpoint: `POST /api/run/answer` — thin wrapper that calls `submitAnswer(sessionId, answers)` on the pending-questions store. The client doesn't need to know the sessionId — the server knows which discovery session is active (module-level state, same as `getActiveRunInfo()`).
+If the client disconnects and reconnects while discovery is waiting for answers, the task content API (`GET /api/fs/task`) returns `.run.json` including `pendingQuestions`. The client sees `status: 'discovering'` + `pendingQuestions` and re-renders the question UI. This also serves the multi-channel case — a Slack adapter reads `pendingQuestions` from `.run.json` to know what to relay.
+
+### POST /api/run/answer
 
 ```typescript
 // POST /api/run/answer
@@ -184,19 +326,11 @@ New endpoint: `POST /api/run/answer` — thin wrapper that calls `submitAnswer(s
 
 When the promise resolves, `canUseTool` clears `pending: 'clarification'` on `task.md` and returns the answers to the SDK. Q continues within the same `query()` call — more activity events stream through the existing connection.
 
-### Why Not a Chat Session
+The client doesn't need to know the sessionId — the server knows which discovery session is active (module-level state, same as `getActiveRunInfo()`).
 
-Discovery could use the chat infrastructure (`POST /api/chat`) which already handles AskUserQuestion. But this would mean:
+## Agent and Wiring
 
-- The client has to orchestrate the transition from discovery chat → planning run (fragile — what if user navigates away?)
-- Billing spans two separate systems (chat session cost + run cost)
-- `.run.json` status management is split between chat and run code
-
-Keeping discovery in the run loop means the server owns the full lifecycle: `discovering` → planning → `plan_ready` → working → `completed`. One billing record. One state machine. The new plumbing (question event + answer endpoint) is small and contained.
-
-## Agent Configuration
-
-Discovery is a new agent mode alongside learning, planning, and working. The `discoveryAgentOptions()` factory in `config.server.ts` defines it.
+Discovery is a new agent mode alongside learning, planning, and working. The `discoveryAgentOptions()` factory in `lib/agents/config.server.ts` defines it.
 
 ### Model and Budget
 
@@ -227,219 +361,6 @@ allowedTools: [
 - `persistSession: true` (enables session resume on budget stop, same as planning/working).
 - `settingSources: []` (SDK isolation mode, same as other modes).
 
-### canUseTool Callback
-
-```typescript
-canUseTool: async (toolName, input, { signal }) => {
-  if (toolName === 'AskUserQuestion') {
-    // Setup ordering: disk first (most critical for reconnect), then
-    // task.md pending, then broadcast, then block.
-    try {
-      await updateRunInfoPendingQuestions(taskName, input.questions)
-      await updateTaskMdPending(taskPath(taskName), 'clarification')
-    } catch (err) {
-      // Setup-write failure: deny rather than block on input we can't surface.
-      return { result: 'deny', message: 'Discovery state write failed' }
-    }
-    notifyClient({ type: 'question', sessionId, questions: input.questions })
-    try {
-      const answers = await Promise.race([
-        waitForAnswer(sessionId),
-        new Promise<never>((_, reject) => {
-          signal.addEventListener('abort', () => reject(new Error('Aborted')), {
-            once: true,
-          })
-        }),
-      ])
-      return { result: 'allow', updatedInput: { ...input, answers } }
-    } finally {
-      // Clear pendingQuestions + pending whether answered or aborted.
-      // Fire-and-forget — the loop's next status write reconciles disk state.
-      await updateRunInfoPendingQuestions(taskName, undefined).catch(() => {})
-      await updateTaskMdPending(taskPath(taskName), undefined).catch(() => {})
-    }
-  }
-  return {
-    result: 'deny',
-    message: `Tool ${toolName} not available in discovery mode`,
-  }
-}
-```
-
-Same structure as the learning agent's `canUseTool`, with additions specific to running inside the run loop.
-
-**Setup ordering before blocking** (the canUseTool callback runs these in order; the disk write is most critical for reconnect, so it goes first):
-
-1. Write `pendingQuestions` to `.run.json` via `updateRunInfoPendingQuestions(taskName, input.questions)`.
-2. Set `pending: 'clarification'` on `task.md` via `updateTaskMdPending(...)`.
-3. Broadcast the `question` event via `notifyClient` — fire-and-forget.
-4. Block on `Promise.race([waitForAnswer(sessionId), abortPromise])`.
-
-If step 1 or 2 throws, the callback returns `{ result: 'deny', message: 'Discovery state write failed' }` — Q falls back without blocking, and discovery proceeds to write whatever `## Discovery` section it has and exit. We never block on user input we can't reliably surface.
-
-**Cleanup on resolution or abort** (in `finally`): clear `pendingQuestions` and `pending` in the same order as setup, both with `.catch(() => {})` since the callback is exiting and the disk state will be reconciled by the loop's next status write.
-
-**Implementation note: `updateRunInfoPendingQuestions` is a new helper.** The existing `writeRunInfo` (private in `lib/run/loop.server.ts`) takes a full `RunInfo`, not a partial. The simplest implementation is a thin read-merge-write wrapper:
-
-```typescript
-async function updateRunInfoPendingQuestions(
-  taskName: string,
-  questions: AskUserQuestionInput['questions'] | undefined,
-): Promise<void> {
-  const info = await readRunInfo(taskName)
-  if (!info) return
-  await writeRunInfo(taskName, { ...info, pendingQuestions: questions })
-}
-```
-
-Live alongside `writeRunInfo` in `lib/run/loop.server.ts` (private), or hoist both to `lib/fs/run-json.server.ts` if `parseRunInfo` lands there too. The spec doesn't prescribe — implementer's call. `updateTaskMdPending` is the parallel pattern, already in `lib/fs/task-md.server.ts`.
-
-### System Prompt
-
-New file: `prompts/discovery.md`. The prompt tells Q:
-
-- Your job is the gut check before planning: does this task have what's needed to plan well?
-- **Read first, ask second.** Read the task description, inputs, playbook, specs, and samples _before_ deciding whether to ask anything. Questions are about what those materials don't cover.
-- If everything's there, write a brief `## Discovery` synthesis to `task.md` (or nothing if there's nothing useful to add) and exit.
-- If something's genuinely missing that would change the plan, use `AskUserQuestion` with structured multiple-choice options.
-- Bias toward proceeding. Don't ask just because you can.
-- 1–3 focused questions max per round.
-- Web research (`WebFetch`, `WebSearch`) is for filling specific gaps when needed — not a default exploration mode.
-
-The reading list is built the same way as planning: `buildReadingList()` from `prompts.server.ts` injects specs, samples, inputs, and playbook paths.
-
-Worked calibration examples ship in the prompt itself (see [Calibration: when to ask vs. proceed](#calibration-when-to-ask-vs-proceed) above). Without them, the prompt iterates by vibe.
-
-## Run State
-
-Discovery adds one new status to `.run.json`:
-
-| Status        | Meaning                                                         |
-| ------------- | --------------------------------------------------------------- |
-| `discovering` | Discovery agent is running (including waiting for user answers) |
-
-No `discovered` status. When discovery completes, the loop writes `status: 'planning'` immediately. The `discovering` → `planning` transition is instantaneous — nothing renders between them.
-
-The full `RunInfo.status` union becomes:
-
-```
-'discovering' | 'planning' | 'plan_ready' | 'working' | 'completed' | 'stopped'
-```
-
-The `stoppedDuring` union gets `'discovery'` alongside `'planning'` and `'working'`.
-
-### Phase Records
-
-Discovery uses the `phases` array on `RunInfo` (see [Working](working.md) for the full `PhaseRecord` and `RunInfo` type definitions). When discovery completes, a `PhaseRecord` with `phase: 'discovery'` is appended — recording `costUsd`, `durationMs`, and `sessionId`. The panel reads `phases.find(p => p.phase === 'discovery')` for duration, cost, and session transcript link.
-
-When discovery is blocking on AskUserQuestion, the `pendingQuestions` field on `RunInfo` stores the current question input. Cleared when the user answers. This enables client reconnect and multi-channel adapters to read the pending questions from the task content API.
-
-**Stale-run cleanup must clear `pendingQuestions`.** When `clearStaleRun()` flips a leftover `'discovering'` status to `'stopped'` (server restart, HMR, etc.), it also clears `pendingQuestions`. Otherwise the client could read a stopped run with `pendingQuestions` still set and incorrectly render the question UI. The render rule is "if `pendingQuestions` is present, show the question UI" — so the disk write must keep status and pendingQuestions consistent.
-
-### Lifecycle
-
-```
-startRun(stream, task, 'discovery')
-  │
-  ├── writes .run.json { status: 'discovering' }
-  │
-  ├── runs discovery agent (single session via query())
-  │     │
-  │     ├── Q reads task, inputs, playbook, specs
-  │     ├── Q evaluates sufficiency
-  │     │
-  │     ├── has questions → AskUserQuestion
-  │     │     ├── canUseTool broadcasts question event to run stream
-  │     │     ├── canUseTool sets pending: 'clarification'
-  │     │     ├── user answers via POST /api/run/answer → canUseTool clears pending → Q continues
-  │     │     └── user stops run → abort signal → session ends
-  │     │
-  │     ├── Q synthesizes → appends ## Discovery to task.md
-  │     └── session ends
-  │
-  ├── commits: [stream/task] Discovery complete (no-op if Q wrote nothing)
-  │
-  ├── appends PhaseRecord { phase: 'discovery', sessionId, costUsd, durationMs, ... }
-  │   to phases array on .run.json
-  │
-  ├── flips .run.json { status: 'planning' }   (single write where possible)
-  │
-  └── runs planning agent (same as today)
-```
-
-The auto-transition from discovery to planning happens inside the server process. There is no conditional — planning always follows discovery. The only branching is if discovery errors or is stopped, in which case planning doesn't run. The user can close the tab after answering Q's last question and come back to find planning done (or `plan_ready`).
-
-**Canonical write order between discovery and planning** (matters for crash recovery):
-
-1. Discovery `query()` resolves successfully. Q has already written any `## Discovery` section to `task.md` and exited.
-2. `commitGitState('[stream/task] Discovery complete')` — the commit captures the `## Discovery` diff (or is a no-op if Q wrote nothing).
-3. Append `PhaseRecord { phase: 'discovery', ... }` to `phases` on `.run.json` — single atomic write.
-4. Flip `.run.json.status` to `'planning'` — single atomic write (can be combined with step 3).
-5. Run the planning agent.
-
-A crash between step 2 and step 3 leaves a "Discovery complete" commit on disk but no `PhaseRecord` for it. On the next read, `clearStaleRun` flips status to `'stopped'` and the user sees Restart options. The commit remains in history; the next discovery will append a fresh PhaseRecord. No data loss; no inconsistency that requires manual recovery.
-
-### Loop Implementation
-
-In `loop.server.ts`, the `runLoop` function dispatches based on mode:
-
-```typescript
-if (mode === 'discovery') {
-  // Run discovery, then planning sequentially
-  const discoveryStatus = await runDiscoveryIteration(...)
-  if (discoveryStatus !== 'completed') {
-    // 'stopped' (user/error) or 'budget' — don't continue to planning
-    finalStatus = discoveryStatus
-  } else {
-    // Discovery succeeded — commit and continue to planning.
-    // commitGitState is a no-op on a clean tree, so this only creates a
-    // commit if Q wrote a ## Discovery section to task.md.
-    commitGitState(`[${streamName}/${taskName}] Discovery complete`)
-    finalStatus = await runPlanningIteration(...)
-  }
-} else if (mode === 'planning') {
-  finalStatus = await runPlanningIteration(...)
-} else {
-  finalStatus = await runWorkingLoop(...)
-}
-```
-
-`runDiscoveryIteration` follows the same structure as `runPlanningIteration`: create a session, run `query()`, handle abort/budget/error, return `Promise<RunInfo['status']>`. The key difference: discovery uses `canUseTool` with AskUserQuestion blocking and question broadcasting, while planning uses `createAutomatedCanUseTool()` (fully automated). In practice, discovery returns `'completed'` on success and `'stopped'` for any abort/error/budget case (with the corresponding `stopReason` and `stoppedDuring` written to `.run.json` before returning). The dispatcher only continues to planning on `=== 'completed'`.
-
-**Type changes required.** Add `'discovery'` to every `mode` union and `'discovering'` to every `RunInfo.status` union. The concrete sites:
-
-- `app/api/run/start/route.ts` — request body schema (currently `'planning' | 'working'`).
-- `lib/run/loop.server.ts` — `startRun()` and `runLoop()` signatures + dispatch.
-- `lib/fs/types.ts` — `RunInfo.status` and `RunInfo.stoppedDuring` unions (see [Working](working.md) for the full new shape).
-- Client run-actions hook (find via `grep -rn '"planning" | "working"' happyhq/components` — look for the `useRunActions` / `use-run-actions` file).
-
-After updating the unions, run `pnpm check-types` from `happyhq/`. TypeScript will surface every site that switches on `status` or `mode` without a default — add a `'discovering'` arm to each. Don't suppress with `as any`; an unhandled status arm is the kind of bug that goes silent in production.
-
-### Billing
-
-Discovery cost is tracked within the same billing task run record that spans the full run lifecycle. The `runLoop` function starts a billing record at the top (`startTaskRun`) and finalizes at the bottom (`finalizeTaskRun`). When `mode: 'discovery'`, the loop runs discovery then planning sequentially — the billing record naturally spans both.
-
-After discovery completes, a `PhaseRecord` with `phase: 'discovery'` is appended to the `phases` array on `.run.json`, recording cost and duration. The `costUsd` field on RunInfo tracks the cumulative total (discovery + planning + working). `updateUsage` calls happen after each phase.
-
-### Config schema additions
-
-The `discoveryAgentOptions()` factory needs `config.models.discovery` and `config.limits.discoveryBudgetUsd` to exist. These fields don't exist today — the schemas at `happyhq/lib/config/types.ts` only list learning/planning/working. Add:
-
-- `AppConfig.models.discovery?: ModelConfig` (optional — user override).
-- `AppConfig.limits.discoveryBudgetUsd?: number` (optional — user override).
-- `ResolvedConfig.models.discovery: Required<ModelConfig>` (required in resolved form).
-- `ResolvedConfig.limits.discoveryBudgetUsd: number` (required in resolved form).
-
-Add corresponding defaults in `happyhq/lib/config/defaults.ts`. Mirror the existing `models.planning` / `limits.planningBudgetUsd` defaults — Opus model with adaptive thinking, conservative budget.
-
-The factory then reads them the same way the other factories do today:
-
-```typescript
-// happyhq/lib/agents/config.server.ts — discoveryAgentOptions
-model: MODEL_IDS[config.models.discovery.model],
-maxBudgetUsd: config.limits.discoveryBudgetUsd,
-```
-
 ### PostToolUse hook for Write
 
 Discovery's factory needs a `PostToolUse` hook that fires after `Write` to emit `task_content_changed` — same pattern as planning/working at [`happyhq/lib/agents/config.server.ts:507-515`](happyhq/lib/agents/config.server.ts#L507-L515). Without this, the user won't see the `## Discovery` section appear in the panel until they manually refresh.
@@ -464,30 +385,55 @@ hooks: {
 
 Same shape as planning's hook; only the agent factory it's wired to differs.
 
+### Config schema additions
+
+The factory needs `config.models.discovery` and `config.limits.discoveryBudgetUsd` to exist. These fields don't exist today — the schemas at `happyhq/lib/config/types.ts` only list learning/planning/working. Add:
+
+- `AppConfig.models.discovery?: ModelConfig` (optional — user override).
+- `AppConfig.limits.discoveryBudgetUsd?: number` (optional — user override).
+- `ResolvedConfig.models.discovery: Required<ModelConfig>` (required in resolved form).
+- `ResolvedConfig.limits.discoveryBudgetUsd: number` (required in resolved form).
+
+Add corresponding defaults in `happyhq/lib/config/defaults.ts`. Mirror the existing `models.planning` / `limits.planningBudgetUsd` defaults — Opus model with adaptive thinking, conservative budget.
+
+The factory then reads them the same way the other factories do today:
+
+```typescript
+// happyhq/lib/agents/config.server.ts — discoveryAgentOptions
+model: MODEL_IDS[config.models.discovery.model],
+maxBudgetUsd: config.limits.discoveryBudgetUsd,
+```
+
+### System prompt
+
+New file: `prompts/discovery.md`. The prompt tells Q:
+
+- Your job is the gut check before planning: does this task have what's needed to plan well?
+- **Read first, ask second.** Read the task description, inputs, playbook, specs, and samples _before_ deciding whether to ask anything. Questions are about what those materials don't cover.
+- If everything's there, write a brief `## Discovery` synthesis to `task.md` (or nothing if there's nothing useful to add) and exit.
+- If something's genuinely missing that would change the plan, use `AskUserQuestion` with structured multiple-choice options.
+- Bias toward proceeding. Don't ask just because you can.
+- 1–3 focused questions max per round.
+- Web research (`WebFetch`, `WebSearch`) is for filling specific gaps when needed — not a default exploration mode.
+
+The reading list is built the same way as planning: `buildReadingList()` from `prompts.server.ts` injects specs, samples, inputs, and playbook paths. Worked calibration examples ship in the prompt itself (see [Calibration: when to ask vs. proceed](#calibration-when-to-ask-vs-proceed)). Without them, the prompt iterates by vibe.
+
 ### Logging
 
-Discovery emits the existing `run.*` structured-log events ([`happyhq/lib/log.server.ts`](happyhq/lib/log.server.ts)). No new event namespace.
+Discovery emits the existing `run.*` structured-log events (`lib/log.server.ts`). No new event namespace.
 
 - `run.started` already includes a `mode` field — when `mode: 'discovery'`, that's discovery starting.
 - `run.stopped` with `stoppedDuring: 'discovery'` for user/error/budget aborts.
-- `run.error` for fatal errors during discovery (e.g., setup-write failure in `canUseTool`).
+- `run.error` for fatal errors during discovery (including the `canUseTool` setup-write failure described above).
 - `run.completed` for the run as a whole (after planning + working finish).
 
-PhaseRecord on `.run.json` captures success metrics (cost, duration, sessionId) — no separate per-phase log event needed. The mode and stoppedDuring fields are sufficient to grep discovery activity.
+PhaseRecord on `.run.json` captures success metrics (cost, duration, sessionId) — no separate per-phase log event needed. The mode and `stoppedDuring` fields are sufficient to grep discovery activity.
 
-**`canUseTool` setup-write failure** specifically should emit `run.error` with an explanatory message before returning `{ result: 'deny', message: 'Discovery state write failed' }` — silent denials are bad ops.
+## Restart and Cleanup
 
-## Git Commits and Restart
+Discovery is a heads-up preamble, not a savepoint to "restart from." It just runs whenever a fresh run starts (or resumes from a stopped-during-discovery state — naturally, by sending `mode: 'discovery'`). The user is in control of `task.md` directly: they can edit it freely between runs to remove a stale `## Discovery` section, change the description, or anything else.
 
-### Discovery Commits
-
-When discovery completes successfully and writes anything to `task.md`, the loop commits: `[stream/task] Discovery complete`. This commit is a chronological marker in git history showing what Q contributed. Nothing in v0 reads this commit programmatically — restart paths don't use it as an anchor. Its only role is auditability (git log + diff show what discovery added to `task.md`).
-
-If Q wrote nothing (clean tree), no commit happens. That's fine — the PhaseRecord on `.run.json` still records that discovery ran.
-
-### Restart From a Phase
-
-Discovery is a heads-up preamble, not a savepoint to "restart from." It just runs whenever a fresh run starts (or resumes from a stopped-during-discovery state — naturally, by sending `mode: 'discovery'`). The user is in control of `task.md` directly: they can edit it freely between runs to remove a stale `## Discovery` section, change the description, or anything else. There's no "restore task.md to pre-discovery state" affordance because the user is the one in charge of task.md.
+### Restart options
 
 The two visible restart paths after a stopped or completed run:
 
@@ -496,13 +442,29 @@ The two visible restart paths after a stopped or completed run:
 | Planning     | `'planning'` | `plan.md` deleted, `working/` and `outputs/` cleared. `task.md` (including any `## Discovery`) is untouched.  |
 | Working      | `'working'`  | `working/` and `outputs/` cleared, `plan.md` restored from "Plan accepted" commit. Everything else preserved. |
 
-There is no "Restart from discovery" button. The mode `'discovery'` exists in the API for fresh starts and for resuming a stopped-during-discovery run, but it isn't surfaced as a restart button — completed runs don't offer "redo from discovery." If a user wants Q to look at the task fresh, they edit `task.md` to remove the prior `## Discovery` section (and/or change the description) and click Restart from plan; planning will read whatever's there. For a fully clean slate, duplicate the task as a new task.
+There is no "Restart from discovery" button. The mode `'discovery'` exists in the API for fresh starts and for resuming a stopped-during-discovery run, but it isn't surfaced as a restart button — completed runs don't offer "redo from discovery." If a user wants Q to look at the task fresh, they edit `task.md` to remove the prior `## Discovery` section (and/or change the description) and click Restart from plan; planning will read whatever's there. For a fully clean slate, duplicate the task.
 
-### startRun Cleanup Updates
+### startRun cleanup
 
 The `startRun` function's fresh-run cleanup block does **not** gain a discovery case. Discovery has nothing to clean up before running — `task.md` is the user's, and the `## Discovery` section (if any from a prior run) is just text in the file. Q's prompt handles the "task already has a `## Discovery` section" case by deciding whether to update or leave it (judgment in the prompt; not enforced by code).
 
 The existing `mode === 'planning'` cleanup handles deleting `plan.md` and clearing `working/`/`outputs/`. The existing `mode === 'working'` cleanup handles `restorePlanFromGit`. Discovery adds nothing.
+
+### Discovery git commit
+
+When discovery completes successfully and writes anything to `task.md`, the loop commits: `[stream/task] Discovery complete`. This commit is a chronological marker in git history showing what Q contributed. Nothing in v0 reads this commit programmatically — restart paths don't use it as an anchor. Its only role is auditability (git log + diff show what discovery added to `task.md`).
+
+If Q wrote nothing (clean tree), no commit happens. That's fine — the PhaseRecord on `.run.json` still records that discovery ran.
+
+### Stopping during discovery
+
+There is no dedicated "skip discovery" button during the live Q&A. The Stop button (already present during every run phase) serves this purpose. When the user stops during discovery:
+
+- The session is aborted; `status: 'stopped'`, `stoppedDuring: 'discovery'` is written.
+- The `canUseTool` `finally` clears `pendingQuestions` and `pending: 'clarification'`. The island clears.
+- The task panel shows the standard stopped affordances: **Continue** (resumes discovery — sends `mode: 'discovery'`, picks up where it stopped) and **Restart from plan** (sends `mode: 'planning'`, runs planning against the current `task.md`).
+
+This keeps the UI simple (one Stop button, not Stop + Skip) and gives the user a clear choice between "let Q keep triaging" (Continue) and "I'm done with triage, just plan it" (Restart from plan).
 
 ## Task Panel UI
 
@@ -540,7 +502,7 @@ When the user submits answers (`POST /api/run/answer`), the question block clear
 
 When discovery completes and the loop flips status to `'planning'`, the user sees the header text change from "Reviewing the task..." to "Planning..." and the activity stream restart with planning's events. There's no flicker, no spinner reset, no empty intermediate state — same shape as the existing `planning → plan_ready` transition. The brief gap (write status + append PhaseRecord + start planning's `query()`) is invisible at human timescales. The Stop button persists across the transition.
 
-### Completed-state row: clicking opens the session
+### Completed-state row
 
 ```
  Reviewed                                       2m 10s
@@ -576,18 +538,9 @@ The duration shown is **compute time**, recorded as `durationMs` on the discover
 
 > **Implementation note (transcript display).** Discovery sessions are SDK sessions associated with a run, accessed via `phase.sessionId`. They do not live in `.chats/{sessionId}/` like learning chats. The transcript-display component reads from the SDK journal regardless of which session-creation path produced it — to the user, the experience is identical. Don't fork into a second display component.
 
-### Restart Options
+### Clarification badge (task list)
 
-When a task is stopped or finished, the user has two restart affordances:
-
-- **Restart from plan** — `mode: 'planning'`. `task.md` (including any `## Discovery`) is preserved; `plan.md` deleted; `working/` and `outputs/` cleared. Planning runs.
-- **Restart from work** — `mode: 'working'`. Working/outputs cleared; `plan.md` restored from "Plan accepted" commit; everything else preserved. Working runs.
-
-There is no "Restart from discovery" button by design (see [Restart From a Phase](#restart-from-a-phase)). For a stopped-during-discovery run, clicking the resume affordance (Continue / Start) sends `mode: 'discovery'` naturally and the loop picks up where it stopped. For a completed run that the user wants Q to look at fresh, they edit `task.md` and click Restart from plan, or duplicate the task.
-
-### Clarification Indicator (task list)
-
-Separate from the in-card sub-row above, the task list item — anywhere a task title appears in a list (sidebar, home, search results) — shows a clarification badge when Q is waiting for answers:
+Separate from the in-card sub-row, the task list item — anywhere a task title appears in a list (sidebar, home, search results) — shows a clarification badge when Q is waiting for answers:
 
 ```
   Draft Q4 Proposal              · Needs clarification
@@ -595,11 +548,22 @@ Separate from the in-card sub-row above, the task list item — anywhere a task 
 
 This uses the existing `pending: 'clarification'` indicator pattern — same visual treatment as other pending states. Together with the in-card question sub-row, this gives the user two ways to find a discovery session that needs them: the badge wherever they encounter the task in a list, and the sub-row when they're already viewing the task.
 
-## Skip Mechanisms
+## v0 vs. v1 scope
 
-### Per-Stream Auto-Skip (deferred to v1 — design held for later)
+Everything documented in this spec is in v0 _unless_ listed below. The deferred items are not abandoned — they're held for v1 once we see how v0 lands in the wild.
 
-This subsection documents the design held for v1; it is **not in v0 scope** (see [v0 vs. v1 scope](#v0-vs-v1-scope)). v0 runs discovery on every Start.
+**Deferred from v0 (revisit after v0 ships):**
+
+- **`skipDiscovery` playbook frontmatter flag.** v0 runs discovery on every Start. Bias-to-proceed in the prompt should be enough — if a stream's playbook is rich and a task is well-formed, discovery transitions to planning in seconds without writing anything. Add the flag once we observe ask-rates that warrant a stream-level opt-out. Requires extending `PlaybookFrontmatter` (currently a closed schema) when added. Design held below for reference.
+- **Stream selection during discovery.** Tasks created with just a title would let Q suggest which stream to assign. Out of v0 scope; the architecture supports it.
+- **Channel adapters (Slack, email).** This spec keeps the architecture channel-ready (`pendingQuestions` on `.run.json`, `pending: 'clarification'` as a notification trigger, `AskUserQuestion` as the abstraction), but no adapter ships in v0. See [Multi-Channel Awareness](#multi-channel-awareness) for the readiness story.
+- **Concurrency-safe answer routing.** `POST /api/run/answer` resolves against module-level singleton state (same pattern as `getActiveRunInfo()`). When concurrency lands and the singleton becomes a `Map<>` (see [Working](working.md)), the answer endpoint will need a task identifier in the body. Decoupled from this PR.
+
+**Bundled into v0 (despite the original spec splitting them):**
+
+- **`phases: PhaseRecord[]` migration on `RunInfo`.** Discovery's `PhaseRecord` write is the forcing function for the new shape on `RunInfo` described in [Working](working.md). The two ship together as one PR — splitting them means the refactor lands without a forcing function (and rots) or discovery adds yet another flat field set (`discoveryCostUsd`, `discoverySessionId`, ...) to the structure the refactor is trying to replace. See [Working](working.md) for the new shape and the read-time compat shim that handles existing `.run.json` files.
+
+### v1 design — `skipDiscovery` playbook flag (held for later)
 
 Playbook frontmatter gains an optional `skipDiscovery` field:
 
@@ -614,16 +578,6 @@ When `skipDiscovery: true`, the Start button sends `mode: 'planning'` instead of
 
 This lives in the playbook because it's the right granularity — "I trust Q to plan SOWs without asking, but for research tasks it should always check." It's human-editable and is already read by the system during prompt construction. Adding it requires extending `PlaybookFrontmatter` (currently a closed schema) at v1 implementation time.
 
-### Stopping During Discovery
-
-There is no dedicated "skip discovery" button during the live Q&A. The Stop button (already present during every run phase) serves this purpose. When the user stops during discovery:
-
-- The session is aborted; `status: 'stopped'`, `stoppedDuring: 'discovery'` is written.
-- The `canUseTool` `finally` clears `pendingQuestions` and `pending: 'clarification'`. The island clears.
-- The task panel shows the standard stopped affordances: **Continue** (resumes discovery — sends `mode: 'discovery'`, picks up where it stopped) and **Restart from plan** (sends `mode: 'planning'`, runs planning against the current `task.md`).
-
-This keeps the UI simple (one Stop button, not Stop + Skip) and gives the user a clear choice between "let Q keep triaging" (Continue) and "I'm done with triage, just plan it" (Restart from plan).
-
 ## Multi-Channel Awareness
 
 This spec covers the in-app experience only. The design is channel-agnostic by construction:
@@ -635,53 +589,14 @@ This spec covers the in-app experience only. The design is channel-agnostic by c
 
 A separate spec will cover the channel routing layer, adapters, and the `source`/`notify` fields. The key architectural insight: channels are dumb pipes, Q is the only writer, and task.md is the canonical object.
 
-### Future: Stream Selection During Discovery
-
-Today, Start requires a stream assignment. A natural extension: tasks created with just a title could enter discovery without a stream, and Q could suggest which stream to assign based on the task description — "This looks like an Acme Client task — should I assign it there?" This would make quick-add even faster (title → Start → Q figures out the rest). Deferred from v0 (see [v0 vs. v1 scope](#v0-vs-v1-scope)); the architecture supports it.
-
-## Design Decisions
-
-**Discovery runs in the run loop, not as a chat session.** Discovery could use the chat infrastructure (`POST /api/chat`), which already handles AskUserQuestion rendering and answer submission. But this splits the lifecycle: the client would have to orchestrate the transition from discovery chat to planning run, billing would span two systems, and `.run.json` management would be divided between chat and run code. Keeping discovery in the run loop means the server owns the full lifecycle — `discovering` → `planning` → `plan_ready` → working → `completed`. One billing record. One state machine. The new plumbing (question event in run stream + answer endpoint) is small and contained.
-
-**Questions render in the island, not inline in the task card.** The island is the established surface for structured interactions during task work (plan approval uses it today). The task card shows a question sub-row beneath the "Reviewing the task..." header that points to the island. This avoids bloating the task card with interactive UI and keeps the question experience focused — same large, clear question blocks the user knows from learning mode.
-
-**Discovery enriches task.md, not a separate directory.** The task is the canonical object. After discovery, the task description should be self-contained. A separate `discovery/` directory would add surface area for limited benefit — the session log (via the discovery `PhaseRecord.sessionId`) is the audit trail, and `task.md` is what planning reads.
-
-**`task.md` is the user's; no destructive restore.** When a run is restarted, `task.md` is left untouched. The user controls its content between runs — they can keep, edit, or delete a prior `## Discovery` section as they wish. There is no `restoreTaskMdFromGit` helper, no commit-message-grep restore path, and no "Restart from discovery" button. Earlier drafts of this spec proposed those; they were dropped because (a) discovery is a heads-up preamble, not a savepoint to "restore to," and (b) handing the user a button that silently rewrites `task.md` makes the destructive case (overwriting their edits) too easy to hit. If a future "wipe plan/working but keep task.md" affordance is needed, it's a thin extension of the existing planning-mode cleanup — not a new restore mechanism.
-
-**No `discovered` status.** It would exist for ~0ms between discovery completing and planning starting. Nothing would render it. The task panel's "Reviewed 2m 10s" comes from the discovery `PhaseRecord` in the `phases` array, not the status field.
-
-**Opus, matching the other modes.** Discovery joins learning, planning, and working at Opus for consistency at v0. Sonnet would be cheaper and likely sufficient for read-and-assess work, but mixing models across modes complicates evaluation and prompt tuning early on. Once discovery is shipped and we have a feel for ask-rates and per-Start cost, we can downshift to Sonnet behind `config.models.discovery` without touching the rest of the system.
-
-**Bias toward proceeding.** The prompt should lean toward moving forward, asking only when the gap would materially change the plan. Specs define what's needed — if something is missing that specs call for, ask. But don't over-interrogate. Over time, specs can say "if X is missing, assume Y" to further reduce unnecessary questions.
-
-**Stop replaces skip.** No dedicated "skip discovery" button during the session. The Stop button already exists and does the right thing — abort the session, then the user chooses where to restart (including "Restart from plan" which skips discovery). This avoids a second button alongside Stop that does nearly the same thing.
-
-**Server-driven transitions.** The run loop handles discovery → planning sequentially, same as how it handles planning → `plan_ready`. No client orchestration needed. The user can close the tab after answering Q's last question and come back to find planning done. If Q had no questions, the transition is instant — the user sees "Reviewing the task..." briefly then "Planning..." with no gap.
-
-**Header stays stable across question state.** When questions surface, the header text doesn't change to something like "Q has questions for you" — the header is the _phase_ indicator, not the _state_ indicator. State (questions pending, files attached, plan ready) lives in sub-rows beneath the header. Swapping the header text would be jarring and would conflict with the sub-row pattern other phases already use. One header per phase, sub-rows for what's happening inside it.
-
-## v0 vs. v1 scope
-
-Everything documented in this spec is in v0 _unless_ listed below. The deferred items are not abandoned — they're held for v1 once we see how v0 lands in the wild.
-
-**Deferred from v0 (revisit after v0 ships):**
-
-- **`skipDiscovery` playbook frontmatter flag.** v0 runs discovery on every Start. Bias-to-proceed in the prompt should be enough — if a stream's playbook is rich and a task is well-formed, discovery transitions to planning in seconds without writing anything. Add the flag once we observe ask-rates that warrant a stream-level opt-out. Requires extending `PlaybookFrontmatter` (currently a closed schema) when added.
-- **Stream selection during discovery.** Tasks created with just a title would let Q suggest which stream to assign. Out of v0 scope; the architecture supports it.
-- **Channel adapters (Slack, email).** This spec keeps the architecture channel-ready (`pendingQuestions` on `.run.json`, `pending: 'clarification'` as a notification trigger, `AskUserQuestion` as the abstraction), but no adapter ships in v0. See [Multi-Channel Awareness](#multi-channel-awareness) for the readiness story.
-- **Concurrency-safe answer routing.** `POST /api/run/answer` resolves against module-level singleton state (same pattern as `getActiveRunInfo()`). When concurrency lands and the singleton becomes a `Map<>` (see [Working](working.md)), the answer endpoint will need a task identifier in the body. Decoupled from this PR.
-
-**Bundled into v0 (despite the spec originally splitting them):**
-
-- **`phases: PhaseRecord[]` migration on `RunInfo`.** Originally listed as a prerequisite; ships together with discovery. See [Type refactor](#type-refactor-ships-in-this-same-change) above and the new shape in [Working](working.md).
+**Future: stream selection during discovery.** Today, Start requires a stream assignment. A natural extension: tasks created with just a title could enter discovery without a stream, and Q could suggest which stream to assign based on the task description. This would make quick-add even faster (title → Start → Q figures out the rest). Deferred from v0 (see [v0 vs. v1 scope](#v0-vs-v1-scope)); the architecture supports it.
 
 ## End-to-end smoke scenarios
 
 The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke harness (`pnpm smoke:e2e` → `scripts/smoke-e2e.ts`) proves the _experience_ works — real Chromium driving the real dev server against real Claude SDK calls. Discovery extends this in two ways:
 
 1. The existing golden path (plan → work) runs through discovery as its first phase. The fixture task should be rich enough that discovery proceeds silently. This is a free assertion that the silent-case happy path doesn't break the rest of the loop.
-2. Add discovery-specific scenarios that exercise the heads-up behaviors — questions appearing, answers programmatically submitted, restart paths preserving / restoring state.
+2. Add discovery-specific scenarios that exercise the heads-up behaviors — questions appearing, answers programmatically submitted, restart paths preserving state.
 
 **Fixture stream** under `scripts/smoke-fixtures/discovery/email-intros/` — neutral fictional names (no real customer or user data per project convention):
 
@@ -717,7 +632,7 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 **`canUseTool` and answers:**
 
 - [ ] `canUseTool` setup ordering: write `pendingQuestions` to `.run.json`, set `pending: 'clarification'` on task.md, broadcast `question` event, then block on `Promise.race([waitForAnswer, abort])`
-- [ ] Setup write failure (steps 1 or 2) returns `{ result: 'deny', message: ... }` — never blocks on input we can't surface
+- [ ] Setup write failure (steps 1 or 2) logs `run.error` and returns `{ result: 'deny', message: ... }` — never blocks on input we can't surface
 - [ ] Cleanup in `finally` clears both `pendingQuestions` and `pending: 'clarification'`, both with `.catch(() => {})`
 - [ ] Q can ask follow-up questions within the same session (multiple rounds)
 - [ ] `POST /api/run/answer` validates body via zod (`{ answers: Record<string, string> }`), returns 400 on schema fail, 404 on no-pending-question, 200 `{ status: 'answered' }` on success
@@ -783,20 +698,6 @@ The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke har
 - [ ] Scenario 2 (asks questions and integrates answers) — discovery on the thin task surfaces question UI, programmatic answers submit, `## Discovery` section reflects answers, planning runs against enriched task.md
 - [ ] Scenario 3 (restart from plan preserves `## Discovery`) — Restart from plan keeps `## Discovery` in task.md, regenerates plan.md only
 - [ ] Discovery smoke scenarios run in CI on PRs touching `prompts/discovery.md`, `lib/agents/config.server.ts`, or `lib/run/loop.server.ts` (not on every unrelated PR — they cost real Opus dollars)
-
-## Edge Cases
-
-- **Task has rich description and inputs**: Q says "ready," may not write anything to task.md, and transitions immediately. No "Discovery complete" commit if task.md is unchanged (clean tree = no commit).
-- **Task has only a title**: Q almost certainly asks questions. This is the primary use case — quick-added tasks that need fleshing out.
-- **User navigates away during discovery Q&A**: The `canUseTool` callback is blocking server-side. The run stream disconnects but the session stays alive. On return, the client reads `pendingQuestions` from `.run.json` (via the task content API) and re-renders the question UI. If the user never returns, the session eventually times out via budget limit.
-- **User closes the app after answering last question**: Server-driven transition means planning starts regardless. User returns to find planning done or `plan_ready`.
-- **Discovery fails or errors**: Same pattern as planning errors. Write `status: 'stopped'`, `stoppedDuring: 'discovery'`. UI shows the standard stopped affordances (Continue / Restart from plan).
-- **Discovery times out (budget)**: Write `status: 'stopped'`, `stopReason: 'budget'`, `stoppedDuring: 'discovery'`. Continue resumes discovery.
-- **Server restart during discovery Q&A**: Session is lost. `clearStaleRun` writes `status: 'stopped'`, `stoppedDuring: 'discovery'` and clears `pendingQuestions`. User clicks Continue (resumes from `mode: 'discovery'`) or Restart from plan.
-- **Stream has no playbook or specs**: Discovery is especially useful here — Q recognizes it has little context and asks questions the playbook would normally answer. But if the task description is detailed enough, Q should still proceed.
-- **User stops mid-conversation**: Session is aborted. Answers from prior rounds are lost (session context is gone). `task.md` may have been updated already by an earlier successful `## Discovery` write — that content is preserved. The user can Continue (resumes discovery; Q may re-ask or update what's there) or Restart from plan (uses task.md as-is).
-- **Discovery writes nothing to `task.md`**: Possible when Q has enough context. `commitGitState` is a no-op on clean tree. No "Discovery complete" commit exists; the PhaseRecord on `.run.json` still records that discovery ran.
-- **Multiple runs on the same task**: Each run reads whatever `task.md` is at the moment Q starts. If a prior `## Discovery` section is present, Q's prompt judgment decides whether to update it, replace it, or leave it. The user can also delete it manually between runs.
 
 ## Testing
 
@@ -865,3 +766,31 @@ Not unit-tested (covered by smoke):
 
 - Discovery-to-planning auto-transition as end-to-end flow with a real SDK session — exercised by smoke Scenario 1.
 - The actual prompt's ask-vs-proceed judgment under real model behavior — exercised by smoke Scenarios 1 and 2.
+
+## Edge Cases
+
+- **Task has rich description and inputs**: Q says "ready," may not write anything to task.md, and transitions immediately. No "Discovery complete" commit if task.md is unchanged (clean tree = no commit).
+- **Task has only a title**: Q almost certainly asks questions. This is the primary use case — quick-added tasks that need fleshing out.
+- **User navigates away during discovery Q&A**: The `canUseTool` callback is blocking server-side. The run stream disconnects but the session stays alive. On return, the client reads `pendingQuestions` from `.run.json` (via the task content API) and re-renders the question UI. If the user never returns, the session eventually times out via budget limit.
+- **User closes the app after answering last question**: Server-driven transition means planning starts regardless. User returns to find planning done or `plan_ready`.
+- **Discovery fails or errors**: Same pattern as planning errors. Write `status: 'stopped'`, `stoppedDuring: 'discovery'`. UI shows the standard stopped affordances (Continue / Restart from plan).
+- **Discovery times out (budget)**: Write `status: 'stopped'`, `stopReason: 'budget'`, `stoppedDuring: 'discovery'`. Continue resumes discovery.
+- **Server restart during discovery Q&A**: Session is lost. `clearStaleRun` writes `status: 'stopped'`, `stoppedDuring: 'discovery'` and clears `pendingQuestions`. User clicks Continue (resumes from `mode: 'discovery'`) or Restart from plan.
+- **Stream has no playbook or specs**: Discovery is especially useful here — Q recognizes it has little context and asks questions the playbook would normally answer. But if the task description is detailed enough, Q should still proceed.
+- **User stops mid-conversation**: Session is aborted. Answers from prior rounds are lost (session context is gone). `task.md` may have been updated already by an earlier successful `## Discovery` write — that content is preserved. The user can Continue (resumes discovery; Q may re-ask or update what's there) or Restart from plan (uses task.md as-is).
+- **Discovery writes nothing to `task.md`**: Possible when Q has enough context. `commitGitState` is a no-op on clean tree. No "Discovery complete" commit exists; the PhaseRecord on `.run.json` still records that discovery ran.
+- **Multiple runs on the same task**: Each run reads whatever `task.md` is at the moment Q starts. If a prior `## Discovery` section is present, Q's prompt judgment decides whether to update it, replace it, or leave it. The user can also delete it manually between runs.
+
+## Design Decisions
+
+The architectural calls that aren't obvious from the body. Decisions that purely follow from the body sections (e.g., "questions render in the island," "header stays stable") aren't repeated here — see the relevant section for the reasoning.
+
+**Discovery runs in the run loop, not as a chat session.** Discovery could use the chat infrastructure (`POST /api/chat`), which already handles AskUserQuestion rendering and answer submission. But splitting the lifecycle means the client orchestrates the transition from discovery chat to planning run (fragile), billing spans two systems (chat session cost + run cost), and `.run.json` status management is divided between chat and run code. Keeping discovery in the run loop means the server owns the full lifecycle — `discovering` → `planning` → `plan_ready` → `working` → `completed`. One billing record. One state machine. The new plumbing (question event in run stream + answer endpoint) is small and contained.
+
+**`task.md` is the user's; no destructive restore.** When a run is restarted, `task.md` is left untouched. The user controls its content between runs — they can keep, edit, or delete a prior `## Discovery` section as they wish. There is no `restoreTaskMdFromGit` helper, no commit-message-grep restore path, and no "Restart from discovery" button. Earlier drafts of this spec proposed those; they were dropped because (a) discovery is a heads-up preamble, not a savepoint to "restore to," and (b) handing the user a button that silently rewrites `task.md` makes the destructive case (overwriting their edits) too easy to hit. If a future "wipe plan/working but keep task.md" affordance is needed, it's a thin extension of the existing planning-mode cleanup — not a new restore mechanism.
+
+**Opus, matching the other modes.** Discovery joins learning, planning, and working at Opus for consistency at v0. Sonnet would be cheaper and likely sufficient for read-and-assess work, but mixing models across modes complicates evaluation and prompt tuning early on. Once discovery is shipped and we have a feel for ask-rates and per-Start cost, we can downshift to Sonnet behind `config.models.discovery` without touching the rest of the system.
+
+**Server-driven transitions.** The run loop handles discovery → planning sequentially, same as how it handles planning → `plan_ready`. No client orchestration needed. The user can close the tab after answering Q's last question and come back to find planning done. If Q had no questions, the transition is instant — the user sees "Reviewing the task..." briefly then "Planning..." with no gap.
+
+**No `discovered` status.** It would exist for ~0ms between discovery completing and planning starting. Nothing would render it. The task panel's "Reviewed 2m 10s" comes from the discovery `PhaseRecord` in the `phases` array, not the status field.

--- a/happyhq/specs/discovery.md
+++ b/happyhq/specs/discovery.md
@@ -629,6 +629,34 @@ Everything documented in this spec is in v0 _unless_ listed below. The deferred 
 
 - **`phases: PhaseRecord[]` migration on `RunInfo`.** Originally listed as a prerequisite; ships together with discovery. See [Type refactor](#type-refactor-ships-in-this-same-change) above and the new shape in [Working](working.md).
 
+## End-to-end smoke scenarios
+
+The unit tests in [Testing](#testing) prove the plumbing is wired. The smoke harness (`pnpm smoke:e2e` → `scripts/smoke-e2e.ts`) proves the _experience_ works — real Chromium driving the real dev server against real Claude SDK calls. Discovery extends this in two ways:
+
+1. The existing golden path (plan → work) runs through discovery as its first phase. The fixture task should be rich enough that discovery proceeds silently. This is a free assertion that the silent-case happy path doesn't break the rest of the loop.
+2. Add discovery-specific scenarios that exercise the heads-up behaviors — questions appearing, answers programmatically submitted, restart paths preserving / restoring state.
+
+**Fixture stream** under `scripts/smoke-fixtures/discovery/email-intros/` — neutral fictional names (no real customer or user data per project convention):
+
+- `playbook.md` — the typical email-intros playbook: research both parties, find common ground, draft, review. Notes "always include a personal anecdote about at least one of them" as a required step.
+- `specs/intro-email.md` — the spec: must include salutation, why-introducing, one-line per person, **personal anecdote**, call to action. Tone, length, banned-words list.
+- `samples/intros/intro-1/extracted.md` — one fictional past intro the user wrote (warm tone, anecdote in body).
+- Two task fixtures: a thin one (`scripts/smoke-fixtures/discovery/tasks/thin-intro.md` — title and frontmatter only, no description) and a rich one (`scripts/smoke-fixtures/discovery/tasks/rich-intro.md` — full description with goal, anecdote, parties named).
+
+**Scenario 1 — Silent proceed (extends the existing golden path).** Use the rich task fixture. Click Start. Assert: header shows "Reviewing the task..." briefly; transitions to "Planning..." without surfacing any question UI; no `## Discovery` section appended (or appended with non-question synthesis only); planning produces `plan.md`; PhaseRecord `{ phase: 'discovery', durationMs > 0, sessionId }` exists in `.run.json`.
+
+**Scenario 2 — Asks questions and integrates answers.** Use the thin task fixture. Click Start. Assert: header reads "Reviewing the task..."; question sub-row appears beneath the header; full `AskUserQuestion` block renders in the island. Take a screenshot for visual regression. Programmatically submit answers via `POST /api/run/answer` with reasonable values (e.g., `{ "What's the goal of this intro?": "Collaboration on a project", "Do you have a personal anecdote?": "Met them at a charity dinner — Bugs stole Tom's bread roll, Tom played along, table laughed" }`). Assert: question UI clears; activity stream resumes; eventually transitions to "Planning..."; `task.md` now contains a `## Discovery` section reflecting the answers; planning produces a `plan.md` that references the anecdote.
+
+**Scenario 3 — Header stays stable across question state.** During Scenario 2, capture the header's text content at three points: (a) before questions surface, (b) while questions are pending, (c) after answers submitted but before planning starts. Assert all three read "Reviewing the task..." — no swap to "Q has questions for you" or anything else.
+
+**Scenario 4 — Restart from discovery restores `task.md`.** After Scenario 2 completes (or partway through, after the `## Discovery` section is written), click "Start over." Assert: `task.md` reverts to the user's original (no `## Discovery` section); discovery runs again; PhaseRecord history shows two discovery entries (the first one's commit is preserved in git but `task.md` content is rewound).
+
+**Scenario 5 — Restart from plan preserves `## Discovery`.** After Scenario 2 reaches `plan_ready`, click "Restart from plan." Assert: `task.md` still contains the `## Discovery` section from Scenario 2; `plan.md` is regenerated; planning runs without re-running discovery.
+
+**Where the scenarios live.** Scenario 1 extends `scripts/smoke-e2e.ts` (the golden path). Scenarios 2–5 can live in the same script as additional test functions or split into `scripts/smoke-discovery.ts` with a sibling `smoke:discovery` package.json script — implementer's call. The harness pattern (boot a fresh dev server pointed at a per-run `/tmp/happyhq-smoke-<uuid>`, pre-seed the fixture stream, drive Chromium, assert filesystem + DOM state) is established; reuse it.
+
+**Why this is worth the cost.** Smoke runs against real Opus calls, so each run is several dollars. Worth it because: (a) discovery's value is "did Q ask sensible questions or proceed sensibly?" — a judgment-driven UX that unit tests can't verify; (b) the calibration anchor lives in the prompt, and the only way to prove the prompt holds up under real model behavior is to run against the real model; (c) regression baseline for prompt drift on future model upgrades. Run discovery scenarios in CI on PRs that touch `prompts/discovery.md`, `lib/agents/config.server.ts` (discovery factory), or `lib/run/loop.server.ts` (discovery iteration / canUseTool). Don't run them on every unrelated PR.
+
 ## Acceptance Criteria
 
 **Run loop and agent:**
@@ -689,6 +717,17 @@ Everything documented in this spec is in v0 _unless_ listed below. The deferred 
 
 - [ ] Billing record spans discovery + planning (single `startTaskRun` / `finalizeTaskRun` lifecycle)
 - [ ] `canStart` gate relaxed: title + stream is sufficient when discovery is enabled (no description/inputs required)
+
+**Smoke (end-to-end, real Opus, real Chromium):**
+
+- [ ] Fixture stream `scripts/smoke-fixtures/discovery/email-intros/` exists with playbook, intro-email spec, and one sample (fictional names — no real user data)
+- [ ] Two task fixtures: `thin-intro.md` (title only) and `rich-intro.md` (full description with anecdote)
+- [ ] Scenario 1 (silent proceed) extends the existing golden path in `scripts/smoke-e2e.ts` — discovery runs and transitions to planning without surfacing question UI
+- [ ] Scenario 2 (asks questions and integrates answers) — discovery on the thin task surfaces question UI, programmatic answers submit, `## Discovery` section reflects answers, planning runs against enriched task.md
+- [ ] Scenario 3 (header stable) — header text is "Reviewing the task..." before, during, and after question state; verified via DOM inspection
+- [ ] Scenario 4 (restart from discovery) — Start over restores task.md to pre-discovery state
+- [ ] Scenario 5 (restart from plan) — Restart from plan preserves `## Discovery` section, regenerates plan.md only
+- [ ] Discovery smoke scenarios run in CI on PRs touching `prompts/discovery.md`, `lib/agents/config.server.ts`, or `lib/run/loop.server.ts` (not on every unrelated PR — they cost real Opus dollars)
 
 ## Edge Cases
 

--- a/happyhq/specs/discovery.md
+++ b/happyhq/specs/discovery.md
@@ -199,8 +199,8 @@ Discovery is a new agent mode alongside learning, planning, and working. The `di
 
 ### Model and Budget
 
-- **Model:** Sonnet with adaptive thinking. Discovery is read-and-assess, not synthesize-and-create. Configurable via `config.models.discovery` like other modes.
-- **Budget:** New `config.limits.discoveryBudgetUsd` (default low — discovery should be cheap and fast).
+- **Model:** Opus with adaptive thinking — same as learning, planning, and working. Consistency over cost optimization at v0; revisit if discovery's per-Start cost shows up as a real concern in the wild. Resolve via `config.models.discovery` against `MODEL_IDS` (don't hardcode a model string).
+- **Budget:** New `config.limits.discoveryBudgetUsd`. Default conservative — discovery should still be cheap and fast even on Opus, since it's read-and-assess, not synthesize-and-create.
 
 ### Tools
 
@@ -604,7 +604,7 @@ Today, Start requires a stream assignment. A natural extension: tasks created wi
 
 **No `discovered` status.** It would exist for ~0ms between discovery completing and planning starting. Nothing would render it. The task panel's "Reviewed 2m 10s" comes from the discovery `PhaseRecord` in the `phases` array, not the status field.
 
-**Sonnet, not Opus.** Discovery is read-and-assess, not synthesize-and-create. Sonnet is fast, cheap, and sufficient. The cost delta matters because discovery runs on every task start. Configurable if needed.
+**Opus, matching the other modes.** Discovery joins learning, planning, and working at Opus for consistency at v0. Sonnet would be cheaper and likely sufficient for read-and-assess work, but mixing models across modes complicates evaluation and prompt tuning early on. Once discovery is shipped and we have a feel for ask-rates and per-Start cost, we can downshift to Sonnet behind `config.models.discovery` without touching the rest of the system.
 
 **Bias toward proceeding.** The prompt should lean toward moving forward, asking only when the gap would materially change the plan. Specs define what's needed — if something is missing that specs call for, ask. But don't over-interrogate. Over time, specs can say "if X is missing, assume Y" to further reduce unnecessary questions.
 
@@ -634,7 +634,7 @@ Everything documented in this spec is in v0 _unless_ listed below. The deferred 
 **Run loop and agent:**
 
 - [ ] Start button triggers discovery (not planning directly) — v0 always runs discovery on Start
-- [ ] `discoveryAgentOptions()` factory exists in `lib/agents/config.server.ts`: Sonnet, adaptive thinking, no `mcpServers`, no `agents`, `persistSession: true`, `settingSources: []`, `disallowedTools: ['EnterPlanMode', 'ExitPlanMode']`
+- [ ] `discoveryAgentOptions()` factory exists in `lib/agents/config.server.ts`: Opus (resolved via `config.models.discovery` against `MODEL_IDS`), adaptive thinking, no `mcpServers`, no `agents`, `persistSession: true`, `settingSources: []`, `disallowedTools: ['EnterPlanMode', 'ExitPlanMode']`
 - [ ] Discovery agent reads task inputs, stream playbook, specs, and samples (read-first rule from prompt)
 - [ ] `runDiscoveryIteration()` exists in `lib/run/loop.server.ts`, mirroring `runPlanningIteration` shape; returns `'completed' | 'stopped' | 'budget'`
 - [ ] When Q has enough context, discovery auto-transitions to planning without user action
@@ -733,7 +733,7 @@ Restart (`lib/run/loop.server.test.ts`):
 
 Agent config (`lib/agents/config.server.test.ts`):
 
-- [ ] `discoveryAgentOptions` returns Sonnet model with AskUserQuestion blocking via canUseTool
+- [ ] `discoveryAgentOptions` returns Opus model (via `MODEL_IDS`) with AskUserQuestion blocking via canUseTool
 - [ ] `discoveryAgentOptions` does NOT configure `mcpServers` or `agents` (no custom MCP, no custom subagents)
 - [ ] AskUserQuestion triggers the documented setup ordering: `pendingQuestions` write → `pending: 'clarification'` set → `question` event broadcast → block on `Promise.race`
 - [ ] Setup write failure (mock `updateRunInfoPendingQuestions` to throw) returns `{ result: 'deny' }` without blocking

--- a/happyhq/specs/learning.md
+++ b/happyhq/specs/learning.md
@@ -8,6 +8,8 @@ Define Q's behavior when the user teaches it something new — whether during in
 
 This spec covers behavior, not technical configuration. For Q's model (Opus with adaptive thinking), tools, and permissions in learning mode, see Agent Configuration. For sample lifecycle and metadata, see Samples.
 
+**Orientation:** Learning is a **heads-up** mode — Q interacts with the user, asks structured questions, and may wait on a wall-clock answer. It shares heads-up infrastructure (`AskUserQuestion` via `canUseTool` blocking, the pending-questions store, an answer endpoint, an interactive UI surface) with [Discovery](discovery.md). See [Agent Configuration → Mode Orientation](agent-config.md#mode-orientation-heads-up-vs-heads-down) for the axis. Where they differ: learning mutates the _stream_ (playbook, specs, samples); discovery enriches _one task_ (`task.md`).
+
 **Prompt philosophy**: Q's learning prompt is minimal (~30 lines) — context about the filesystem and artifacts, not conversation instructions. The original spike (see `specs/refs/learning-reference/`) showed that Opus with extended thinking naturally reads samples, asks targeted questions, and synthesizes specs — with no personality prompting or phase management. The prompt tells Claude what exists and where things go, not how to have a conversation.
 
 ## Classification Principle

--- a/happyhq/specs/planning.md
+++ b/happyhq/specs/planning.md
@@ -6,6 +6,8 @@ How Q turns user inputs into a reviewable working plan.
 
 Define how user inputs become a reviewable working plan. The working plan is a key checkpoint for managing the loop — the user sees what Q intends to do and can course-correct before tokens are spent.
 
+**Orientation:** Planning is a **heads-down** mode — Q runs autonomously to a completion signal (`plan.md` written), with no user interaction during the run. `createAutomatedCanUseTool` denies interactive tools; there are no question events on the run stream. Pre-planning user input lives in [Discovery](discovery.md) (the heads-up phase that runs first). See [Agent Configuration → Mode Orientation](agent-config.md#mode-orientation-heads-up-vs-heads-down) for the axis.
+
 ## Preconditions
 
 Q doesn't offer "Start Task" until it has created a playbook. This is prompt behavior, not an app-level gate — by the time the "Start Task" card appears in chat, Q has already written the playbook to disk during the teaching conversation. The sequence is natural: user describes work → Q asks questions → Q creates playbook → Q offers "Start Task." No code-level check needed.

--- a/happyhq/specs/working.md
+++ b/happyhq/specs/working.md
@@ -220,7 +220,54 @@ interface RunInfo {
 
 Each phase appends a `PhaseRecord` when it completes. The panel reads `phases.find(p => p.phase === 'discovery')?.durationMs` for "Reviewed 2m 10s" (the user-facing label for the discovery phase — see [Discovery](discovery.md)), `phases.find(p => p.phase === 'planning')?.durationMs` for "Planned 3m", and `phases.filter(p => p.phase === 'working')` for working iterations. No positional guessing. Session transcripts are opened via `phases[n].sessionId`.
 
-> **Migration:** This replaces the previous `planningCostUsd`, `planningSessionId`, `workingSessionIds`, and positional `iterations` fields. Existing `.run.json` files on users' filesystems have the old shape. The migration is **a read-time compat shim**, not a one-time rewrite or flag day. The `.run.json` reader detects the old fields (`planningCostUsd`, `planningSessionId`, `workingSessionIds`, `iterations`) and synthesizes a `phases: PhaseRecord[]` array on the way out — stale entries get the new shape transparently. Writers always emit the new shape. After a few releases, remove the shim. This ships in the same change as discovery (see [Discovery](discovery.md) — discovery's `PhaseRecord` write is the forcing function for the new shape).
+> **Migration:** This replaces the previous `planningCostUsd`, `planningSessionId`, `workingSessionIds`, and positional `iterations` fields. Existing `.run.json` files on users' filesystems have the old shape. The migration is **a read-time compat shim**, not a one-time rewrite or flag day.
+>
+> **Where the shim lives:** introduce `parseRunInfo(raw: unknown): RunInfo` in `happyhq/lib/fs/read.server.ts` (the file that already does `JSON.parse(runJson) as RunInfo` in two places). All callers replace the bare cast with `parseRunInfo(JSON.parse(runJson))`. One central translation point; one place to remove the shim a few releases later.
+>
+> **What the shim does:** detects old-shape input by the presence of any of `planningCostUsd`, `planningSessionId`, `workingSessionIds`, or `iterations`, and synthesizes a `phases: PhaseRecord[]` array. Writers always emit the new shape, so stored files re-saved by the new code drop the old fields naturally.
+>
+> **Concrete shape mapping (fixture for tests):**
+>
+> ```jsonc
+> // Old shape (input — pre-upgrade .run.json)
+> {
+>   "status": "completed",
+>   "iteration": 4,
+>   "planningCostUsd": 0.12,
+>   "planningSessionId": "sess_planning_abc",
+>   "workingSessionIds": ["sess_work_1", "sess_work_2", "sess_work_3", "sess_work_4"],
+>   "iterations": [
+>     { "costUsd": 0.45, "durationMs": 30000 },
+>     { "costUsd": 0.50, "durationMs": 35000 },
+>     { "costUsd": 0.40, "durationMs": 28000 },
+>     { "costUsd": 0.42, "durationMs": 30000 }
+>   ],
+>   "startedAt": "2026-01-15T10:00:00Z",
+>   "lastIterationAt": "2026-01-15T10:05:00Z",
+>   "error": null
+> }
+>
+> // New shape (output — what parseRunInfo returns)
+> {
+>   "status": "completed",
+>   "phases": [
+>     { "phase": "planning", "sessionId": "sess_planning_abc", "costUsd": 0.12, "durationMs": 0 },
+>     { "phase": "working", "iteration": 1, "sessionId": "sess_work_1", "costUsd": 0.45, "durationMs": 30000 },
+>     { "phase": "working", "iteration": 2, "sessionId": "sess_work_2", "costUsd": 0.50, "durationMs": 35000 },
+>     { "phase": "working", "iteration": 3, "sessionId": "sess_work_3", "costUsd": 0.40, "durationMs": 28000 },
+>     { "phase": "working", "iteration": 4, "sessionId": "sess_work_4", "costUsd": 0.42, "durationMs": 30000 }
+>   ],
+>   "costUsd": 1.89,
+>   "startedAt": "2026-01-15T10:00:00Z",
+>   "lastIterationAt": "2026-01-15T10:05:00Z"
+> }
+> ```
+>
+> Notes on synthesis: planning's `durationMs` is missing from the old shape — emit `0` (renders as "Planned 0s" rather than crashing). Working iterations are paired by index between `workingSessionIds[i]` and `iterations[i]`; if the lengths disagree, prefer `iterations.length` and fill missing sessionIds with empty strings. `error: null` collapses to `error?: undefined` in the new shape (no field).
+>
+> **Test against three fixtures**: planning-only, planning + N working iterations, and a never-run task (no old fields present — pass-through). All in `lib/fs/read.server.test.ts`.
+>
+> After a few releases (no remaining old-shape files in the wild), delete the synthesis branch from `parseRunInfo`. This ships in the same change as discovery (see [Discovery](discovery.md) — discovery's `PhaseRecord` write is the forcing function for the new shape).
 
 The loop writes `.run.json`:
 

--- a/happyhq/specs/working.md
+++ b/happyhq/specs/working.md
@@ -6,6 +6,8 @@ How Q loops through a task.
 
 Define the loop that Q works through to complete a task. Each iteration is a fresh Worker that reads file state, does one piece of work, and exits. The app keeps the loop going — starting iterations and checking for completion. This spec covers the loop mechanics: starting, checking, stopping, and re-running. It does not cover what Q does within each iteration (that's the working prompt — see [Agent Configuration](agent-config.md)) or what the user sees while Q works (see [Desktop](desktop.md)).
 
+**Orientation:** Working is a **heads-down** mode — each iteration runs autonomously to a `[done]` signal (or the loop's safety stops), with no user interaction inside an iteration. `createAutomatedCanUseTool` denies interactive tools; there are no question events on the run stream. Pre-iteration user input lives in [Discovery](discovery.md) (heads-up triage) and plan approval (a brief heads-up moment between [Planning](planning.md) and the working loop). See [Agent Configuration → Mode Orientation](agent-config.md#mode-orientation-heads-up-vs-heads-down) for the axis.
+
 ## Entry Point
 
 The user approves the working plan in the Desktop (see [Planning](planning.md)). Approval triggers the app to start the working loop.
@@ -170,6 +172,8 @@ Response: { stream: string, task: string } | null
 Run state lives on the filesystem at the task root — `{task}/.run.json`. Written by the loop, read by the client via SWR (through the task content API). No in-memory state object, no `lib/run-state.ts`. This is the same `.run.json` written during planning — see [Planning](planning.md) for the planning-phase states and failure contract. The `RunInfo` interface below covers all phases.
 
 ```typescript
+import type { AskUserQuestionInput } from '@anthropic-ai/claude-agent-sdk'
+
 /** Metrics for a single phase invocation (discovery, planning, or one working iteration). */
 interface PhaseRecord {
   phase: 'discovery' | 'planning' | 'working'
@@ -185,6 +189,14 @@ interface PhaseRecord {
   contextWindowUsedPct?: number
 }
 
+// Invariants:
+//   status === 'discovering' ⟺ no record with phase === 'discovery' has been appended yet.
+//   status === 'planning'    ⟺ a discovery PhaseRecord (if any) has been appended,
+//                              but no planning record has yet.
+//   status === 'plan_ready'  ⟺ planning PhaseRecord has been appended.
+//   status === 'working'     ⟺ at least one working PhaseRecord has been appended;
+//                              `phases.filter(p => p.phase === 'working')` is the iteration history.
+// `phases` is append-only — past records never mutate.
 interface RunInfo {
   status:
     | 'queued'
@@ -199,16 +211,16 @@ interface RunInfo {
   stopReason?: 'budget' | 'user' | 'error' | 'iteration_limit' | 'no_progress'
   startedAt: string // ISO 8601 timestamp
   lastIterationAt: string // ISO 8601 timestamp, updated after each phase/iteration
-  error: string | null
+  error?: string // Set when status is 'stopped' with a real error
   costUsd?: number // Cumulative total across all phases
   phases: PhaseRecord[] // Append-only log — one entry per discovery, planning, each working iteration
-  pendingQuestions?: object // Current AskUserQuestion input, if discovery is waiting for answers
+  pendingQuestions?: AskUserQuestionInput['questions'] // Set when a heads-up phase is blocked on AskUserQuestion
 }
 ```
 
-Each phase appends a `PhaseRecord` when it completes. The panel reads `phases.find(p => p.phase === 'discovery')?.durationMs` for "Discovered 18s", `phases.find(p => p.phase === 'planning')?.durationMs` for "Planned 3m", and `phases.filter(p => p.phase === 'working')` for working iterations. No positional guessing. Session transcripts are opened via `phases[n].sessionId`.
+Each phase appends a `PhaseRecord` when it completes. The panel reads `phases.find(p => p.phase === 'discovery')?.durationMs` for "Reviewed 2m 10s" (the user-facing label for the discovery phase — see [Discovery](discovery.md)), `phases.find(p => p.phase === 'planning')?.durationMs` for "Planned 3m", and `phases.filter(p => p.phase === 'working')` for working iterations. No positional guessing. Session transcripts are opened via `phases[n].sessionId`.
 
-> **Migration note:** This replaces the previous `planningCostUsd`, `planningSessionId`, `workingSessionIds`, and `iterations` fields. Existing `.run.json` files with the old shape will need a compatibility shim or one-time migration. This refactor is a prerequisite for discovery — see [Discovery](discovery.md).
+> **Migration:** This replaces the previous `planningCostUsd`, `planningSessionId`, `workingSessionIds`, and positional `iterations` fields. Existing `.run.json` files on users' filesystems have the old shape. The migration is **a read-time compat shim**, not a one-time rewrite or flag day. The `.run.json` reader detects the old fields (`planningCostUsd`, `planningSessionId`, `workingSessionIds`, `iterations`) and synthesizes a `phases: PhaseRecord[]` array on the way out — stale entries get the new shape transparently. Writers always emit the new shape. After a few releases, remove the shim. This ships in the same change as discovery (see [Discovery](discovery.md) — discovery's `PhaseRecord` write is the forcing function for the new shape).
 
 The loop writes `.run.json`:
 


### PR DESCRIPTION
## Summary

Issue #39 asks for a discovery phase before planning so Q can ask clarifying questions when a task is thin. This PR readies the spec so the work can be handed off to a build with minimal interpretation needed — it's a docs-only change; no code touched.

- **Hardens `specs/discovery.md` end-to-end** plus targeted updates to `working.md`, `agent-config.md`, `learning.md`, `planning.md`, `chat-modes.md`. Each implementation choice is pinned to a concrete file path or function name; each UX decision has rationale.
- **Major decisions baked in:** bundle the `phases: PhaseRecord[]` migration with discovery (was originally a separate prerequisite); Opus + adaptive thinking matching the other modes; no destructive `task.md` restore (no "Restart from discovery" button); the `## Discovery` section is the user's to keep/edit/delete; smoke scenarios cover the prompt-driven UX with real Opus calls.
- **Verified against the codebase**, not assumed: `runPlanningIteration` return shape, `MODEL_IDS` lookup pattern, existing `notifyClient` / `PostToolUse` plumbing, `openChatSessionWindow` reuse for the completed-state row, `commitGitState` no-op semantics.
- **Architectural axis introduced:** heads-up vs. heads-down modes (in `agent-config.md`). Discovery joins learning as heads-up; planning and working stay heads-down. Each orientation inherits its plumbing pattern. Future modes classify on this axis first.

The spec went through eight rounds of iteration, then a restructure pass to put the layout on a reader's path rather than the conversation's. 92 acceptance criteria + tests, all cross-references resolve, every concrete file path verified in the codebase.

## Review checklist

- [ ] `specs/discovery.md` reads end-to-end without contradictions
- [ ] Section ordering matches a reader's mental model (Purpose → behavior → state → plumbing → wiring → restart → UI → scope → smoke → ACs/tests → edge cases → design decisions)
- [ ] Acceptance criteria map to concrete, verifiable behaviors
- [ ] Smoke scenarios are concrete enough to implement directly
- [ ] No real customer or user data in any spec example
- [ ] Heads-up vs. heads-down framing in `agent-config.md` reads sensibly when discovery joins the existing modes

## What's NOT in this PR

- Any code, tests, prompts, or fixtures. Pure spec changes.
- The implementation itself — that's the next PR, against this spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)