### PR TITLE
feat(qa): the litmus test, plans on PRs, no more cache file

### DIFF
--- a/happyhq/.dev/PROMPT_qa_execute.md
+++ b/happyhq/.dev/PROMPT_qa_execute.md
@@ -1,18 +1,27 @@
-0a. Read @qa-rubric.md — this is the spec. Apply it literally.
+0a. Read @qa-rubric.md — this is the spec. Apply it literally. Note especially the litmus test (_Are you satisfied with what's been tested?_) and the pitfalls section.
 0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
 0c. Read [@.dev/exercising-the-ui.md](.dev/exercising-the-ui.md) — Playwright knowledge for any verification that involves driving the UI.
-0d. **You are running unit ${UNIT_INDEX} of ${UNIT_TOTAL}.** The triage plan is at `${PLAN_FILE}`. Read it, find the section headed `## Unit ${UNIT_INDEX} — PR #...`, and operate only on that unit. Do not touch any other unit — the wrapper fires a fresh session per unit.
+0d. **You are running QA on PR #${PR_NUMBER}.** Operate only on this PR — the wrapper fires a fresh session per PR.
 
 1. **Pre-flight.** Confirm `git rev-parse --show-toplevel` ends in `happyhq-qa`. Confirm `${BASE_BRANCH}` is set (the wrapper exports it). The wrapper has already snapped to a clean tree at `${BASE_BRANCH}` — don't reset again.
 
-2. **Skip directive?** If your unit's heading is `## Unit ${UNIT_INDEX} — PR #X — skipped: ...`, print the per-unit summary line with `→ skipped` and exit. The wrapper will pick up the PR on the next run.
+2. **Read the triage plan from the PR.** It's a comment body starting with `QA: triage`:
 
-3. **Fork check.** `gh pr view ${PR_NUMBER} --json isCrossRepository --jq '.isCrossRepository'`. If `true`, apply `ralphie:qa-fail` with the v1-fork-limitation comment per the rubric, print the per-unit summary, and exit.
+   ```
+   gh pr view ${PR_NUMBER} --json comments \
+     --jq '.comments[] | select(.body | startswith("QA: triage")) | .body' | head -1
+   ```
+
+   - If empty → print `PR #${PR_NUMBER} → no triage plan, skipping` and exit cleanly. The wrapper will pick this up next run after triage covers it.
+   - If body is `QA: triage — skipped: ...` → print `PR #${PR_NUMBER} → triage skipped (<reason>)` and exit cleanly.
+   - Otherwise: parse the plan's `What changed`, `What could break`, `What's been tested`, `How to verify`, `Backstop` fields.
+
+3. **Fork check.** `gh pr view ${PR_NUMBER} --json isCrossRepository --jq '.isCrossRepository'`. If `true`, apply `ralphie:qa-fail` with the v1-fork-limitation comment per the rubric, print the summary line, and exit.
 
 4. **Check out the PR's branch.** `gh pr checkout ${PR_NUMBER}` from the qa worktree. If `pnpm-lock.yaml` changed in the diff (`gh pr diff ${PR_NUMBER} --name-only | grep pnpm-lock.yaml`): `pnpm install` from the repo root. Else skip.
 
 5. **Run the verification from the plan's "How to verify" section.** Two cases:
-   - **Trust author's evidence.** Re-read the cited evidence in the PR body (`gh pr view ${PR_NUMBER} --comments`). Confirm it actually covers what the plan claimed. If it doesn't (the plan was wrong), write a quick verification yourself — note the deviation in the comment.
+   - **Litmus test passes — author's testing covers it.** Re-read the cited testing in the PR body / artifacts (`gh pr view ${PR_NUMBER} --comments`). Confirm it actually covers what the plan claimed and that the kind of verification matches the kind of risk (per the rubric's pitfalls). If it doesn't (the plan was wrong), write a quick verification yourself — note the deviation in the qa-pass / qa-fail comment.
    - **Explicit verification steps.** Carry out what the plan describes. The means is whatever the plan named:
      - **Driving UI** → use Playwright MCP tools per `.dev/exercising-the-ui.md`. For any artifacts you create (streams, tasks, uploads), use stream slug `qa-bespoke-${PR_NUMBER}`.
      - **API probe** → curl per CLAUDE.md "Using HappyHQ's API for verification".
@@ -24,31 +33,32 @@
 
 6. **Run smoke as backstop** — unless the plan's `Backstop:` is `skip`. From `happyhq/`: `pnpm smoke:e2e`. Capture full output (stdout + stderr) — you'll quote the last 30 lines on failure.
 
-7. **Decide the outcome:**
-   - **Pass:** verification passed AND (smoke passed OR backstop was skipped).
-   - **Fail:** verification failed OR smoke failed.
+7. **Apply the litmus test one final time.** _Are you satisfied with what's been tested?_ If yes → pass. If no (verification failed, smoke failed, or the verification's kind didn't match the risk's kind after all) → fail.
 
 8. **Workspace cleanup** if you used the `qa-bespoke-${PR_NUMBER}` stream slug:
    - `rm -rf ~/HappyHQ/qa-bespoke-${PR_NUMBER}`. Best-effort — note any failure under an "Artifacts" line in the comment, but don't let cleanup failure change the verdict.
 
 9. **Apply the terminal label and post the comment** per the rubric's "Comment shape":
-   - On pass: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-pass"` + `gh pr comment ${PR_NUMBER} --body "..."` using the qa-pass shape. Cite the verification evidence and the smoke result (or "skipped — non-code").
+   - On pass: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-pass"` + `gh pr comment ${PR_NUMBER} --body "..."` using the qa-pass shape. Cite the verification evidence and the smoke result (or `skipped — non-code`).
    - On fail: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-fail"` + qa-fail comment. Quote the failing step (last 30 log lines on smoke fail). Link the preserved smoke root (`/tmp/happyhq-smoke-*`). Embed any failure screenshot via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <dir>`.
 
-10. **Print the per-unit summary and exit:**
+   The triage comment stays untouched. If you deviated from the plan, name the deviation in your own qa-pass / qa-fail comment.
+
+10. **Print the summary line and exit:**
 
     ```
-    Unit ${UNIT_INDEX} of ${UNIT_TOTAL}: PR #${PR_NUMBER} → <qa-pass | qa-fail | skipped>
+    PR #${PR_NUMBER} → <qa-pass | qa-fail | skipped>
     ```
 
-    The wrapper handles inter-unit cleanup (return to `${BASE_BRANCH}`, stop dev server) before firing the next unit.
+    The wrapper handles inter-PR cleanup (return to `${BASE_BRANCH}`, stop dev server) before firing the next PR.
 
 **${OVERRIDE_NOTE}**
 
-**[1]** ONE unit per session. Find unit `${UNIT_INDEX}`, run the verification the plan describes, smoke as backstop, label, comment, summarize, exit.
+**[1]** ONE PR per session. Read its triage plan, run the verification, smoke as backstop, apply the litmus test, label, comment, summarize, exit.
 **[2]** Hard constraints from @qa-rubric.md are non-negotiable: never auto-merge, never push to a PR's branch, never apply both `qa-pass` and `qa-fail` to the same PR, never QA fork PRs (apply `qa-fail` with v1-limitation comment), only operate in the qa worktree.
 **[3]** Cite evidence in every comment — quote smoke output, link the smoke root on failure, embed screenshot URLs (upload via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <dir>`). Comments are the artifact future-readers consume; they need to stand alone.
-**[4]** Don't return to `${BASE_BRANCH}` or stop the dev server before exiting — the wrapper does both before the next unit.
+**[4]** Don't return to `${BASE_BRANCH}` or stop the dev server before exiting — the wrapper does both before the next PR.
 **[5]** Bespoke workspace cleanup (`rm -rf ~/HappyHQ/qa-bespoke-${PR_NUMBER}`) IS your job — the wrapper doesn't know what stream slug you used. Run it after any UI-driving verification, even on failure. Best-effort: cleanup failure doesn't change the verdict.
 **[6]** Preserve the smoke root on failure — never delete `/tmp/happyhq-smoke-*` directories yourself.
-**[7]** AI disclosure not required on QA comments. The PR body's existing AI disclosure stands.
+**[7]** Don't edit the `QA: triage` comment — it's triage's record. Note any deviation in your own `QA: pass` / `QA: fail` comment.
+**[8]** AI disclosure not required on QA comments. The PR body's existing AI disclosure stands.

--- a/happyhq/.dev/PROMPT_qa_triage.md
+++ b/happyhq/.dev/PROMPT_qa_triage.md
@@ -1,7 +1,7 @@
-0a. Read @qa-rubric.md — this is the spec. Apply it literally.
+0a. Read @qa-rubric.md — this is the spec. Apply it literally. Note especially the litmus test (_Are you satisfied with what's been tested?_) and the pitfalls section.
 0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
 
-1. **Get the queue.** PRs that are open, labeled `ralphie:ready-to-merge` OR `needs-qa`, and have neither `ralphie:qa-pass` nor `ralphie:qa-fail`:
+1. **Get the queue.** If `${SINGLE_PR}` is set, skip the query — operate only on PR #${SINGLE_PR} (regardless of its labels). Otherwise, PRs that are open, labeled `ralphie:ready-to-merge` OR `needs-qa`, and have neither `ralphie:qa-pass` nor `ralphie:qa-fail`:
 
    ```
    gh pr list --state open --limit 100 \
@@ -12,51 +12,55 @@
        ] | sort_by(.createdAt)'
    ```
 
-   Empty queue → write a plan with `Queue: 0 PRs.` and exit cleanly. The wrapper handles the no-units case.
+   Empty queue → print `Triaged 0 PRs.` and exit cleanly.
 
-2. **For each PR in the queue, gather context** (parallel where it makes sense — Sonnet subagents for diff reads on larger PRs):
+2. **For each PR, gather context** (parallel where it makes sense — Sonnet subagents for diff reads on larger PRs):
    - `gh pr diff <#>` — the diff. Capture in working memory.
-   - `gh pr view <#> --comments` — body and review comments. Note the embedded Exercise evidence (screenshots, log excerpts, "what was exercised" sentence).
+   - `gh pr view <#> --comments` — body and review comments. Note the artifacts the author shipped showing (screenshots, log excerpts, "what was exercised" sentence).
    - Author signature in the body's AI-disclosure paragraph distinguishes loop-authored PRs from human ones. Don't treat one as more trustworthy — read the diff regardless.
 
-3. **For each PR, walk the four steps from the rubric** and capture the answers:
-   - **What changed?** One sentence describing the diff.
-   - **What could break?** One or two sentences naming the surface, semantic, or data path at risk if the change is wrong.
-   - **How to verify?** Either:
-     - Author's evidence is sufficient (per the rubric's "What counts as sufficient author evidence"). Cite the specific evidence — quote it, link it, or describe it concretely. Triage's verdict for this PR is `trust`.
-     - Author's evidence is thin OR doesn't cover the changed surface. Write the verification: prose describing what execute should do (drive the UI, hit an API, read a changelog, run a targeted unit test, inspect logs — see the rubric's "What 'verify' looks like" for the menu).
-   - **Backstop?**
-     - Pure non-code PRs (docs only, CSS only, string-literal copy in `.tsx` with no logic change, dev-only deps): `skip — non-code, build can't break`.
-     - Otherwise: `smoke`.
+3. **For each PR, answer the litmus test** by walking the rubric's six steps. Compose the answers as the PR's triage comment body:
+   - **What changed?** One sentence.
+   - **What could break?** Surface, behavior, data path, integration — name the real risks.
+   - **What's been tested?** Quote or cite the author's testing concretely (the embedded screenshots, log excerpts, test results). Don't paraphrase claims you can't verify against artifacts.
+   - **How to verify?** Two outcomes:
+     - **Litmus test passes on the author's testing alone** — the testing matches the kind of every risk identified. Body reads: `Litmus test passes — author's testing covers <risk> via <evidence>.`
+     - **There's a gap** — name what's not covered (which risk, why the existing testing doesn't match its kind), then describe what execute should do to close it (drive the UI, hit an API, read the changelog, run a targeted unit test, inspect logs — see the rubric's "What 'verify' looks like" for the menu).
+   - **Backstop?** `smoke` for code PRs. `skip — non-code` for pure non-code (docs only, CSS only, string-literal copy in `.tsx` with no logic change, dev-only deps).
 
-4. **Write the plan** to `~/.cache/qa/triage-$(date +%Y%m%dT%H%M%S).md`. One unit per PR, in queue order (oldest `createdAt` first). Format:
+4. **Post or edit each PR's `QA: triage` comment** with the plan body. One comment per PR, edited if it exists, never accumulated.
 
-   ```markdown
-   # QA triage — <UTC timestamp>
+   Comment body format:
 
-   Queue: <N> PRs.
-
-   ## Unit 1 — PR #<X>: <PR title>
+   ```
+   QA: triage
 
    **What changed:** <one sentence>
 
    **What could break:** <one or two sentences>
 
-   **How to verify:** <"Trust author's evidence: <citation>" OR prose verification steps>
+   **What's been tested:** <author's testing — quoted / cited concretely>
+
+   **How to verify:** <"Litmus test passes — ..." OR prose verification, naming the gap>
 
    **Backstop:** <smoke | skip — non-code>
-
-   ---
-
-   ## Unit 2 — PR #<Y>: ...
    ```
 
-5. Print a one-line summary to stdout: `Triaged N PRs into N units. Plan: ~/.cache/qa/triage-<timestamp>.md`. Exit.
+   Procedure:
+   - Find an existing `QA: triage` comment on the PR:
+     ```
+     EXISTING_ID=$(gh pr view <#> --json comments --jq '.comments[] | select(.body | startswith("QA: triage")) | .id' | head -1)
+     ```
+   - If empty → create: `gh pr comment <#> --body "$BODY"`
+   - If present → edit: `gh api -X PATCH "/repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/issues/comments/$EXISTING_ID" -f body="$BODY"`
+
+   If a PR's diff fetch errored or the diff is empty (e.g., a rebase mid-triage), post / edit its `QA: triage` comment with body `QA: triage — skipped: diff fetch failed, retry next run`. Execute will see the skip directive and exit cleanly.
+
+5. Print a one-line summary: `Triaged N PRs: #X, #Y, #Z`. Exit.
 
 6. ${DRY_RUN_NOTE}
 
-**[1]** Triage is read-only on the repo and write-only on the local plan file. Never label, comment, branch, commit, push, or open a PR in this phase. Execute does all of that.
-**[2]** When in doubt about whether author evidence is sufficient, write the verification. False-positive verification time costs ~90s; a false-negative pass ships a regression.
-**[3]** If a PR's diff is empty or `gh pr diff` errors (e.g., a rebase mid-triage), skip it and note in the plan: `## Unit N — PR #X — skipped: diff fetch failed, retry next run`. The wrapper will count it as a unit but execute will see the skip directive and exit cleanly.
+**[1]** Triage's writes are restricted to `gh pr comment` and `gh api PATCH` for `QA: triage` comments. Never label, never post other comments, never branch / commit / push, never edit a comment that isn't a `QA: triage` comment.
+**[2]** When in doubt, write the verification. The litmus test should err toward dissatisfaction — a false-positive verification costs ~90s of execute time; a false-negative pass ships a regression to main.
+**[3]** Reject these as evidence (per the rubric's pitfalls): contract-level checks of a behavioral risk, smoke as verification, prior `QA: pass` / `QA: fail` comments on this PR (they're previous verdicts, not the author's testing), "I tested it thoroughly" without artifacts.
 **[4]** Do not run smoke or any verification yet — that's execute's job.
-**[5]** Do not write the plan to anywhere other than `~/.cache/qa/triage-<timestamp>.md`. The wrapper reads from there.

--- a/happyhq/.dev/qa-rubric.md
+++ b/happyhq/.dev/qa-rubric.md
@@ -2,61 +2,69 @@
 
 Source of truth for how Ralphie acts as the QA gate on PRs marked `ralphie:ready-to-merge` (loop-driven, e.g. dependency upgrades) or `needs-qa` (maintainer-flagged). Both `PROMPT_qa_triage.md` and `PROMPT_qa_execute.md` load this file. Edit here, not in the prompts.
 
-## What QA does
+## The litmus test
 
-The author has already run unit tests, lint, types, and an Exercise step that drove the user-visible surface and embedded evidence in the PR body. Our job is the second pair of eyes — verify what specifically changed didn't break what could break, and backstop with the smoke harness.
+Approach every PR as a senior QA engineer. Ask one question:
 
-## The four steps
+> **Are you satisfied with what's been tested?**
 
-For every PR:
+Everything else in this rubric is how to answer that honestly. The author has already run unit tests, lint, types, and an exercise step that drove the user-visible surface. We're the second pair of eyes.
 
-1. **Read the diff.** What specifically changed?
-2. **Identify what could break.** What surface, semantic, or data path is at risk if the change is wrong?
-3. **Verify it didn't.** By whatever means makes sense for this change.
-4. **Smoke as backstop.** Run `pnpm smoke:e2e` to catch build / golden-path regressions independent of step 3.
+## How to answer the litmus test
 
-For pure non-code PRs — docs only, CSS only, string-literal copy in `.tsx` (no logic change), dev-only deps — the build can't regress and the author's Exercise evidence covers the user-visible surface. Skip steps 2–4. Trust the embedded evidence and label.
+For every PR, walk these:
 
-For code PRs where the author's Exercise evidence already concretely covers what changed: skip step 3. Step 4 (smoke) still runs — it catches build regressions the author's surface verification doesn't.
+1. **What changed?** Read the diff.
+2. **What could break?** Surface, behavior, data path, integration — name the real risks.
+3. **What's been tested?** Read the PR body and the artifacts the author shipped (screenshots, log excerpts, test results, "what was exercised" sentence). Note what they actually did.
+4. **Does the testing match the risks?** A behavioral risk needs behavioral testing. A contract risk is covered by a unit test asserting the contract. An integration risk needs an integration check. _The kind of verification has to match the kind of risk._
+5. **If there's a gap, close it.** Drive the UI, hit the API, run the right test — whatever the gap calls for.
+6. **Smoke as backstop.** Run `pnpm smoke:e2e` to catch build / golden-path regressions independent of step 5.
 
-Otherwise: triage writes the verification, execute carries it out, then smokes.
+Then ask the litmus test again. Satisfied → label pass. Not satisfied → step 5.
+
+## When to skip steps
+
+- **Pure non-code PRs** (docs only, CSS only, string-literal copy in `.tsx` with no logic change, dev-only deps): the build can't regress and the author's exercise covers the user-visible change. Skip steps 4–6. Label pass and cite the author's testing.
+- **Code PRs where the author's testing already covers what could break** (litmus test answers yes after step 3): skip step 5. Step 6 (smoke) still runs as build backstop — it catches build regressions the author's surface verification doesn't.
+
+Otherwise: write the verification, run it, smoke.
+
+## Pitfalls — things that look like verification but aren't
+
+These are failure modes we've actually seen. Name them when they apply; reject them as evidence.
+
+- **Contract-level verification of a behavioral risk.** "Unit test asserts the function returns X" doesn't cover "the agent still behaves correctly when context arrives via a different channel." A unit test pins a contract; behavior under integration is a separate risk. The kind has to match.
+- **Smoke as verification.** Smoke is the backstop. It runs the golden path with one fixture; it doesn't verify what changed unless the change is on that exact path.
+- **Prior QA comments as proof.** They're previous verdicts, possibly the verdict being re-evaluated. Read them for context, never count them as the author's testing.
+- **"I tested it thoroughly" without artifacts.** The claim has to be verifiable against embedded evidence — screenshots, log excerpts, output. If it isn't, treat the surface as untested.
 
 ## What "verify" looks like
 
-The verification is whatever the change calls for. Examples:
+The verification is whatever the change calls for:
 
 - **UI surface change** → drive it in dev with the Playwright MCP tools (per [.dev/exercising-the-ui.md](exercising-the-ui.md)).
-- **API change** → hit the endpoint with curl, inspect the response (per CLAUDE.md "Using HappyHQ's API for verification").
-- **SDK / framework bump** → read the upstream changelog for what shifted between versions, probe those specific semantics.
-- **Server-side behaviour change** → trigger the code path, read structured logs (per CLAUDE.md "Debugging Q").
+- **API change** → curl the endpoint, inspect the response (per CLAUDE.md "Using HappyHQ's API for verification").
+- **SDK / framework bump** → read the upstream changelog for what shifted, probe those specific semantics.
+- **Server-side behavior** → trigger the code path, read structured logs (per CLAUDE.md "Debugging Q").
 - **Internal-only change** → run the targeted unit test that covers the changed code path.
 - **Combination** as the change demands.
 
-There's no enum to pick from. Triage describes the verification in prose; execute follows it.
-
-## What counts as sufficient author evidence
-
-The author's Exercise step is upstream defense. It's sufficient when:
-
-- The PR body has concrete embedded evidence — screenshots, log excerpts, API responses — for the changed surface.
-- The driven scenario matches what would break if the change is wrong (upload bug fix → exercised an upload; chat composer change → sent a message).
-- The "what was exercised" claim is verifiable against the embedded evidence — not "I tested it thoroughly."
-
-If any of those is missing or thin, author evidence is not sufficient: triage writes an explicit verification.
+There's no enum to dispatch on. Triage describes what to do in prose; execute follows it.
 
 ## Phases
 
-- **Triage.** Walks the queue, reads each PR's diff and body, writes a per-PR verification plan to `~/.cache/qa/triage-<timestamp>.md`. The plan is prose: what changed, what could break, how to verify (or "trust author's evidence"). Triage never labels, never comments, never runs smoke.
-- **Execute.** The wrapper fans out one fresh agent session per unit. Each session reads its assigned unit from the plan, runs the verification, runs smoke if applicable, labels, comments, exits. Inter-unit hygiene — return to base branch, stop dev server — is the wrapper's job.
+- **Triage.** Walks the queue, reads each PR's diff and body, walks the six steps for each, and posts (or edits) a single `QA: triage` comment on each PR with the verification plan. Triage never labels, never posts other comments, never runs smoke. One `QA: triage` comment per PR — edited if it exists, never accumulated.
+- **Execute.** The wrapper queries the queue itself and fans out one fresh agent session per PR. Each session reads its assigned PR's `QA: triage` comment, runs the verification, runs smoke if applicable, applies the litmus test, posts a `QA: pass` or `QA: fail` comment, labels, exits. Inter-PR hygiene — clean tree, dev-server stop — is the wrapper's job.
 
-One unit = one PR. No batching in v1.
+The triage comment is triage's record (the plan); the qa-pass / qa-fail comment is execute's record (the verdict). Execute never edits the triage comment — if it deviates from the plan, it notes the deviation in its own verdict comment.
 
-## Bespoke driving — workspace hygiene
+## Workspace hygiene (when verification drives the UI)
 
-When verification involves driving the actual UI, the agent uses the maintainer's `~/HappyHQ/` workspace. Discipline:
+The agent uses the maintainer's `~/HappyHQ/` workspace. Discipline:
 
-- Use a uniquely-named stream slug for any artifacts created: `qa-bespoke-${PR_NUMBER}` (or similar). Don't write into existing user streams.
-- After verification completes — pass or fail — `rm -rf ~/HappyHQ/qa-bespoke-${PR_NUMBER}`. Best-effort: cleanup failure doesn't change the verdict, but note it in the comment.
+- Use stream slug `qa-bespoke-${PR_NUMBER}` for any artifacts created (streams, tasks, uploads). Don't write into existing user streams.
+- After verification — pass or fail — `rm -rf ~/HappyHQ/qa-bespoke-${PR_NUMBER}`. Best-effort: cleanup failure doesn't change the verdict, but note it in the comment.
 
 ## Comment shapes
 
@@ -65,9 +73,9 @@ When verification involves driving the actual UI, the agent uses the maintainer'
 ```
 QA: pass
 
-What was checked: <one or two sentences — the verification done, or "trusted author's evidence on <surface>">
+What was tested: <one or two sentences — the verification done and how it answered the litmus test>
 
-Evidence: <link to screenshots / log excerpts / smoke output / cited author evidence>
+Evidence: <links / screenshots / log excerpts / what the author tested that we relied on>
 
 Backstop: <smoke PASS in Xs | skipped — non-code PR>
 ```
@@ -77,7 +85,7 @@ Backstop: <smoke PASS in Xs | skipped — non-code PR>
 ```
 QA: fail
 
-What broke: <one or two sentences — failure mode, where it surfaced (verification step or smoke backstop)>
+What broke: <one or two sentences — failure mode, where it surfaced (verification or smoke)>
 
 Evidence: <last 30 lines of relevant log / link to preserved smoke root / screenshots>
 
@@ -99,14 +107,14 @@ These tune _how_ QA runs. Not gates.
 
 **Judgment is load-bearing.** The whole point of having an agent rather than a static GH Action is reasoning per-PR about what could break and how to check. Path-rules can't tell UI copy from logic.
 
-**Verify what changed, not the same thing every time.** Smoke is the backstop, not the verification. If a PR changed the chat composer, drive the chat composer. If a PR bumped the SDK, probe the semantics that shifted.
+**Match the verification to the risk.** Smoke is the backstop, not the verification. If a PR changed the chat composer, drive the chat composer. If a PR bumped the SDK, probe the semantics that shifted. A contract test answers a contract risk; a behavioral test answers a behavioral risk.
 
-**Cite evidence, always.** Every comment links or quotes specific artifacts. "QA: pass — looked fine" is never the comment; "QA: pass — drove learning-mode entry, observed brief ack; smoke PASS in 78s" is.
+**Cite evidence, always.** Every comment links or quotes specific artifacts. "QA: pass — looked fine" is never the comment; "QA: pass — drove learning-mode entry, observed brief ack and agent proceeding to learn; smoke PASS in 78s" is.
 
-**Trust but verify Exercise.** When the author claims Exercise covered the surface, look at the embedded evidence and judge. The Exercise step is upstream defense, not blank trust.
+**Read the author's testing skeptically.** The author's exercise is upstream defense, not blank trust. Look at the embedded evidence and judge whether it covers what could break.
 
-**A pass isn't just the label.** The comment is the artifact a future reader uses to understand what was verified. Write it like that — with enough detail that someone reading the PR a month later understands what evidence the QA loop saw.
+**A pass isn't just the label.** The comment is the artifact a future reader uses to understand what was verified. Write it so someone reading the PR a month later understands what the QA loop saw.
 
 ## Tuning signal
 
-When the QA loop gets it wrong — passes a PR that broke main, fails a PR that was actually fine — that's a rubric-tuning signal, not a one-off correction. Edit this file. The next run picks up the change.
+When the QA loop gets it wrong — passes a PR that broke main, fails a PR that was actually fine — that's a rubric-tuning signal. Edit this file. The next run picks up the change.

--- a/happyhq/.dev/qa.sh
+++ b/happyhq/.dev/qa.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -o pipefail
 # Usage: ./qa.sh [options]
-#   ./qa.sh                    # triage + execute on PRs labeled ralphie:ready-to-merge or needs-qa
-#   ./qa.sh --triage-only      # Phase 1 only — write the cohort plan, don't execute
-#   ./qa.sh --execute-only     # Phase 2 only — read latest plan, run it
-#   ./qa.sh --pr 240           # skip triage; QA one specific PR (treated as smoke-isolated)
-#   ./qa.sh --pr 240 --override # also bypass any soft-skip rules for that PR
-#   ./qa.sh --dry-run          # Phase 1 preview only, no plan file written
+#   ./qa.sh                     # triage + execute on PRs labeled ralphie:ready-to-merge or needs-qa
+#   ./qa.sh --triage-only       # Phase 1 only — post / edit triage comments, don't execute
+#   ./qa.sh --execute-only      # Phase 2 only — fan out execute over current queue (reads existing triage comments)
+#   ./qa.sh --pr 240            # triage + execute one specific PR
+#   ./qa.sh --pr 240 --override # also force explicit verification regardless of author testing
+#   ./qa.sh --dry-run           # Phase 1 preview only, no triage comments posted / edited
 
 DIM='\033[2m'
 BOLD='\033[1m'
@@ -109,9 +109,6 @@ git fetch origin --quiet || { echo -e "  ${RED}git fetch failed${RESET}" >&2; ex
 git reset --hard origin/main >/dev/null || { echo -e "  ${RED}git reset failed${RESET}" >&2; exit 1; }
 (cd "$REPO_ROOT" && (pnpm install --frozen-lockfile || pnpm install)) || { echo -e "  ${RED}pnpm install failed${RESET}" >&2; exit 1; }
 
-# Ensure the triage-plan directory exists.
-mkdir -p ~/.cache/qa
-
 cleanup() {
     echo -e "\n${DIM}Cleaning up child processes...${RESET}"
     pkill -P $$ 2>/dev/null
@@ -124,13 +121,13 @@ cleanup() {
 trap cleanup SIGINT SIGTERM
 
 if [ -n "$DRY_RUN" ]; then
-    export DRY_RUN_NOTE="**DRY RUN MODE**: This is a triage-phase preview. Read the queue, classify each PR, group into test units, but do NOT write the plan file to ~/.cache/qa/. Print the would-be plan to stdout instead. Do not invoke any 'gh pr edit', 'gh pr comment', 'git commit', 'git push', or filesystem write."
+    export DRY_RUN_NOTE="**DRY RUN MODE**: This is a triage-phase preview. Read the queue, walk the litmus test for each PR, but do NOT post or edit any QA: triage comments. Print the would-be comment bodies to stdout instead. Do not invoke any 'gh pr edit', 'gh pr comment', 'gh api PATCH', 'git commit', or 'git push'."
 else
     export DRY_RUN_NOTE=""
 fi
 
 if [ -n "$OVERRIDE" ]; then
-    export OVERRIDE_NOTE="**OVERRIDE MODE**: The maintainer invoked --override on this single-PR session. Don't trust author evidence regardless of how thick it looks — write an explicit verification at execute time and run it. Smoke runs unconditionally as backstop. Hard constraints (no auto-merge, no push to PR branch, only operate in qa worktree) remain non-negotiable. Note the override in the qa-pass / qa-fail comment: 'Maintainer invoked --override; explicit verification was performed regardless of author evidence.'"
+    export OVERRIDE_NOTE="**OVERRIDE MODE**: The maintainer invoked --override on this single-PR session. Don't trust author testing regardless of how thick it looks — write an explicit verification at execute time and run it. Smoke runs unconditionally as backstop. Hard constraints (no auto-merge, no push to PR branch, only operate in qa worktree) remain non-negotiable. Note the override in the qa-pass / qa-fail comment: 'Maintainer invoked --override; explicit verification was performed regardless of author testing.'"
 else
     export OVERRIDE_NOTE=""
 fi
@@ -159,30 +156,31 @@ run_session() {
     return ${PIPESTATUS[1]}
 }
 
-# ── Single-PR mode: synthesise a one-unit plan, then run execute against it ──
+# ── Single-PR mode: triage one PR, then execute it ──
 if [ -n "$SINGLE_PR" ]; then
-    PLAN_FILE=~/.cache/qa/triage-$(date +%Y%m%dT%H%M%S).md
-    cat > "$PLAN_FILE" <<EOF
-# QA triage — single-PR mode
+    export SINGLE_PR
+    run_session "PROMPT_qa_triage.md" "Triage · PR #${SINGLE_PR}"
+    TRIAGE_EXIT=$?
+    if [ $TRIAGE_EXIT -ne 0 ]; then
+        echo -e "  ${RED}Triage exited with status $TRIAGE_EXIT — stopping${RESET}"
+        exit $TRIAGE_EXIT
+    fi
 
-Queue: 1 PR (forced via --pr ${SINGLE_PR}).
+    if [ -n "$DRY_RUN" ]; then
+        echo -e "\n  ${GREEN}✓${RESET} Phase 1 preview complete (DRY RUN). Skipping execute."
+        exit 0
+    fi
 
-## Unit 1 — PR #${SINGLE_PR}: <single-PR mode>
+    # Snap to clean state before execute (in case triage left state).
+    git -C "$REPO_ROOT" checkout "$BASE_BRANCH" >/dev/null 2>&1 || true
+    git -C "$REPO_ROOT" reset --hard origin/main >/dev/null 2>&1 || true
+    (cd "$REPO_ROOT" && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install)) >/dev/null 2>&1 || true
+    (cd "$REPO_ROOT/happyhq" && npx tsx scripts/dev-server.ts stop 2>/dev/null) || true
 
-**What changed:** (single-PR mode — execute reads the diff fresh)
-
-**What could break:** (single-PR mode — execute reads the diff fresh)
-
-**How to verify:** Read the diff at execute time and write a verification on the fly. Drive what the change actually touches. ${OVERRIDE:+Override mode active — don't trust author evidence regardless.}
-
-**Backstop:** smoke
-EOF
-    echo -e "  ${DIM}Wrote single-PR plan to ${PLAN_FILE}${RESET}"
-    export PLAN_FILE
-    export UNIT_INDEX=1
-    export UNIT_TOTAL=1
-    run_session "PROMPT_qa_execute.md" "Unit 1 of 1 · PR #${SINGLE_PR}"
+    export PR_NUMBER="$SINGLE_PR"
+    run_session "PROMPT_qa_execute.md" "Execute · PR #${SINGLE_PR}"
     EXECUTE_EXIT=$?
+
     (cd "$REPO_ROOT/happyhq" && npx tsx scripts/dev-server.ts stop 2>/dev/null) || true
     exit $EXECUTE_EXIT
 fi
@@ -197,48 +195,50 @@ if [ $EXECUTE_ONLY -eq 0 ]; then
     fi
 
     if [ $TRIAGE_ONLY -eq 1 ]; then
-        echo -e "\n  ${GREEN}✓${RESET} Triage complete (--triage-only). Plan: ~/.cache/qa/triage-*.md"
+        echo -e "\n  ${GREEN}✓${RESET} Triage complete (--triage-only). Plans posted as QA: triage comments on each PR."
         exit 0
     fi
 
     if [ -n "$DRY_RUN" ]; then
-        echo -e "\n  ${GREEN}✓${RESET} Phase 1 preview complete. Skipping Phase 2 in --dry-run (no plan file written, execute would have nothing to read)."
+        echo -e "\n  ${GREEN}✓${RESET} Phase 1 preview complete (DRY RUN). Skipping Phase 2."
         exit 0
     fi
 fi
 
-# ── Phase 2: Execute (per-unit fanout) ──
-PLAN_FILE=$(ls -t ~/.cache/qa/triage-*.md 2>/dev/null | head -1)
-if [ -z "$PLAN_FILE" ]; then
-    echo -e "  ${RED}Error: no triage plan found at ~/.cache/qa/triage-*.md${RESET}" >&2
-    exit 1
-fi
-export PLAN_FILE
+# ── Phase 2: query queue, fan out execute one-per-PR ──
+echo -e "\n  ${DIM}Querying queue for execute fanout…${RESET}"
+QUEUE_PRS=$(gh pr list --state open --limit 100 \
+    --json number,labels \
+    --jq '[.[]
+      | select(.labels | map(.name) | any(. == "ralphie:ready-to-merge" or . == "needs-qa"))
+      | select(.labels | map(.name) | any(. == "ralphie:qa-pass" or . == "ralphie:qa-fail") | not)
+      ] | sort_by(.number) | .[] | .number')
 
-UNIT_TOTAL=$(grep -c '^## Unit ' "$PLAN_FILE" 2>/dev/null || echo 0)
-if [ "$UNIT_TOTAL" -eq 0 ]; then
-    echo -e "\n  ${GREEN}✓${RESET} Triage found 0 PRs in queue. Nothing to execute."
+if [ -z "$QUEUE_PRS" ]; then
+    echo -e "  ${GREEN}✓${RESET} No PRs in queue. Nothing to execute."
     exit 0
 fi
-export UNIT_TOTAL
 
-echo -e "\n  ${DIM}Plan: ${PLAN_FILE}${RESET}"
-echo -e "  ${DIM}Fanning out ${UNIT_TOTAL} unit$([ "$UNIT_TOTAL" -ne 1 ] && echo s)…${RESET}"
+QUEUE_COUNT=$(echo "$QUEUE_PRS" | wc -l | tr -d ' ')
+echo -e "  ${DIM}Fanning out ${QUEUE_COUNT} PR$([ "$QUEUE_COUNT" -ne 1 ] && echo s)…${RESET}"
 
+i=0
 ERROR_COUNT=0
-for i in $(seq 1 "$UNIT_TOTAL"); do
-    # Snap to clean state before each unit (the previous unit may have left a PR branch checked out).
+for PR in $QUEUE_PRS; do
+    i=$((i+1))
+
+    # Snap to clean state before each PR (the previous PR may have left a branch checked out).
     git -C "$REPO_ROOT" checkout "$BASE_BRANCH" >/dev/null 2>&1 || true
     git -C "$REPO_ROOT" reset --hard origin/main >/dev/null 2>&1 || true
     (cd "$REPO_ROOT" && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install)) >/dev/null 2>&1 || true
     (cd "$REPO_ROOT/happyhq" && npx tsx scripts/dev-server.ts stop 2>/dev/null) || true
 
-    export UNIT_INDEX=$i
-    run_session "PROMPT_qa_execute.md" "Unit $i of $UNIT_TOTAL"
+    export PR_NUMBER="$PR"
+    run_session "PROMPT_qa_execute.md" "PR #${PR} (${i} of ${QUEUE_COUNT})"
     UNIT_EXIT=$?
     if [ $UNIT_EXIT -ne 0 ]; then
-        echo -e "  ${YELLOW}⚠ Unit $i exited with status $UNIT_EXIT — continuing to next unit${RESET}"
-        ((ERROR_COUNT++))
+        echo -e "  ${YELLOW}⚠ PR #${PR} session exited with status $UNIT_EXIT — continuing${RESET}"
+        ERROR_COUNT=$((ERROR_COUNT+1))
     fi
 done
 
@@ -248,5 +248,5 @@ git -C "$REPO_ROOT" reset --hard origin/main >/dev/null 2>&1 || true
 (cd "$REPO_ROOT/happyhq" && npx tsx scripts/dev-server.ts stop 2>/dev/null) || true
 pkill -f "next dev" 2>/dev/null || true
 
-echo -e "\n  ${GREEN}✓${RESET} QA pass complete. Units: ${UNIT_TOTAL}$([ $ERROR_COUNT -gt 0 ] && echo " (${ERROR_COUNT} errors)")"
-echo -e "  ${DIM}Per-unit outcomes posted as labels on the PRs themselves.${RESET}"
+echo -e "\n  ${GREEN}✓${RESET} QA pass complete. PRs processed: ${QUEUE_COUNT}$([ $ERROR_COUNT -gt 0 ] && echo " (${ERROR_COUNT} errors)")"
+echo -e "  ${DIM}Per-PR outcomes posted as labels and comments on each PR.${RESET}"


### PR DESCRIPTION
## Summary

Two real flaws surfaced when we re-ran QA on #250 with the previous rewrite:

1. **The verification kind didn't match the risk kind.** The plan named integration risks (agent behaviour with the manifest moved to a reminder); execute accepted contract-level evidence (a unit test pinning a function return). A senior QA engineer wouldn't have been satisfied with that, and the rubric had no rule that would have caught it.
2. **Triage trusted its own prior QA comment as author evidence.** Circular validation — we re-validated #250 by reading the verdict we'd just removed in order to re-evaluate it.

This PR reframes the rubric around one question — the litmus test — and moves the triage→execute handoff from a hidden local cache file onto the PR itself.

## The litmus test

Approach every PR as a senior QA engineer. Ask one question:

> **Are you satisfied with what's been tested?**

Everything else in the rubric is how to answer it honestly: read the diff, name the risks, look at what's been tested, check the *kind* of verification matches the *kind* of risk, close any gap, smoke as backstop, ask again.

## Pitfalls section (new)

Things that look like verification but aren't, encoded so future runs reject them:

- **Contract-level verification of a behavioral risk.** A unit test asserting a function return doesn't cover behaviour under integration.
- **Smoke as verification.** Smoke is the backstop. It runs the golden path with one fixture; it doesn't verify what changed.
- **Prior QA comments as proof.** Previous verdicts, possibly the verdict being re-evaluated. Context, not evidence.
- **"I tested it thoroughly" without artifacts.** The claim has to be verifiable against embedded evidence.

## Triage plan moves to the PR

`~/.cache/qa/triage-*.md` and the `PLAN_FILE` / `UNIT_INDEX` / `UNIT_TOTAL` env-var dance are gone. Triage now posts (or edits) a single `QA: triage` comment per PR with the plan body. Execute reads the comment via `gh pr view --comments`, runs the verification, posts its own `QA: pass` / `QA: fail` comment, labels.

Two comments per QA cycle, both visible on the PR, both inspectable. Triage owns the plan record; execute owns the verdict record. Execute never edits the triage comment — if it deviates from the plan, it notes the deviation in its own verdict comment.

One `QA: triage` comment per PR, edited if it exists, never accumulated.

## Language sweep

- "author evidence" → "what the author tested" / "the author's testing"
- "trust the author's evidence" → "the author's testing covers it"

Plain English the maintainer reads in PR comments shouldn't need a glossary.

## Test plan

- [ ] Remove `ralphie:qa-pass` from #250 to re-queue
- [ ] Run `./qa.sh --pr 250` against the new model
- [ ] Confirm a `QA: triage` comment appears on the PR with the new format
- [ ] Confirm execute reads it, runs the verification (this time the agent should detect the integration risk and *not* accept the prior contract-level argument), and posts a verdict
- [ ] Apply the litmus test ourselves to the result: would a senior QA engineer be satisfied this time?

🤖 Generated with [Claude Code](https://claude.com/claude-code)