### PR TITLE
fix: unify Start Task gate across card and panel

### DIFF
--- a/happyhq/components/features/tasks/card/attachments-section.tsx
+++ b/happyhq/components/features/tasks/card/attachments-section.tsx
@@ -1,26 +1,30 @@
 'use client'
 
-import { useOptimisticUploads } from '@/components/features/tasks/hooks/use-optimistic-uploads'
+import type { PendingFile } from '@/components/features/tasks/hooks/use-optimistic-uploads'
 import { deleteTaskInput } from '@/lib/actions'
 import { ALLOWED_INPUT_ACCEPT } from '@/lib/file-types'
+import type { FileItem } from '@/lib/fs/types'
 import { useTaskStore } from '@/stores/taskStore'
+import type { RefObject } from 'react'
 import { useCallback } from 'react'
 import { AttachmentList } from '../atoms/attachment-list'
-import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
+import { useTaskMutate } from '../hooks/use-task-swr'
 
-export function AttachmentsSection() {
-  const content = useTaskContentData()
+interface AttachmentsSectionProps {
+  visibleInputs: FileItem[]
+  pendingFiles: PendingFile[]
+  handleFiles: (files: FileList) => void
+  fileInputRef: RefObject<HTMLInputElement | null>
+}
+
+export function AttachmentsSection({
+  visibleInputs,
+  pendingFiles,
+  handleFiles,
+  fileInputRef,
+}: AttachmentsSectionProps) {
   const taskSlug = useTaskStore((s) => s.taskSlug)
   const refresh = useTaskMutate()
-
-  const visibleInputs =
-    content?.inputs.filter((i) => i.name !== 'context') ?? []
-
-  const { pendingFiles, handleFiles, fileInputRef } = useOptimisticUploads({
-    taskSlug,
-    refresh,
-    resolvedNames: visibleInputs.map((i) => i.name),
-  })
 
   const handleDeleteInput = useCallback(
     async (inputName: string) => {

--- a/happyhq/components/features/tasks/card/index.tsx
+++ b/happyhq/components/features/tasks/card/index.tsx
@@ -1,15 +1,13 @@
 'use client'
 
-import { toastError, toastWarning } from '@/components/common/ui/sonner'
 import { UpgradePrompt } from '@/components/features/billing/upgrade-prompt'
 import { useFileDrop } from '@/components/features/desktop/windows/shared/use-file-drop'
-import { useCurrentUser } from '@/lib/accounts/hooks'
-import { ingestTaskInput } from '@/lib/actions'
 import type { TaskItem } from '@/lib/fs/types'
 import { useTaskStore } from '@/stores/taskStore'
-import { useCallback } from 'react'
+import { useOptimisticUploads } from '../hooks/use-optimistic-uploads'
 import { useTaskData } from '../hooks/use-task-data'
 import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
+import { canStartIdleTask } from '../start-gate'
 import { AttachmentsSection } from './attachments-section'
 import { DescriptionSection } from './description-section'
 import { OutputsSection } from './outputs-section'
@@ -46,8 +44,6 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
   const taskSlug = useTaskStore((s) => s.taskSlug)
   const streamSlug = useTaskStore((s) => s.streamSlug)
 
-  const { token } = useCurrentUser()
-
   // Derive status from TaskItem first (instant), SWR content second (may be delayed).
   const runStatus = content?.run?.status ?? taskItem.run?.status ?? null
   const isIdle = !runStatus
@@ -68,42 +64,27 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
   const hasDescription = !!(
     content?.description ?? taskItem.description
   )?.trim()
-  const canStart =
-    streamSlug != null &&
-    !!taskTitle.trim() &&
-    (hasDescription || visibleInputs.length > 0)
 
   // ── Drag-and-drop file upload ─────────────────────────────────────
-  const handleFiles = useCallback(
-    async (files: FileList) => {
-      const fileList = Array.from(files)
-      if (fileList.length === 0) return
-      try {
-        for (const file of fileList) {
-          const formData = new FormData()
-          formData.append('file', file)
-          const result = await ingestTaskInput(
-            taskSlug!,
-            formData,
-            token ?? undefined,
-          )
-          if (result.quality === 'poor' || result.quality === 'empty') {
-            toastWarning(
-              `"${file.name.length > 20 ? file.name.slice(0, 20) + '…' : file.name}" not optimized for AI comprehension`,
-            )
-          }
-        }
-        refresh?.()
-      } catch {
-        toastError(
-          'Something went wrong adding this file. Files must be under 100MB.',
-        )
-      }
-    },
-    [taskSlug, token, refresh],
-  )
-  const { isDragOver, dragHandlers } = useFileDrop(handleFiles, {
+  // Single useOptimisticUploads instance shared with AttachmentsSection so the
+  // start-task gate can observe upload state from drops on the whole card.
+  const uploads = useOptimisticUploads({
+    taskSlug,
+    refresh,
+    resolvedNames: visibleInputs.map((i) => i.name),
+  })
+  const { isDragOver, dragHandlers } = useFileDrop(uploads.handleFiles, {
     enabled: isIdle,
+  })
+
+  const canStart = canStartIdleTask({
+    streamSlug,
+    title: taskTitle,
+    hasDescription,
+    hasInputs: visibleInputs.length > 0,
+    isUploading: uploads.isUploading,
+    runActionsLoading,
+    runActionsUpgradeNeeded,
   })
 
   // ── Sections ──────────────────────────────────────────────────────
@@ -113,7 +94,12 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
   sections.push(
     <div key="context">
       <DescriptionSection />
-      <AttachmentsSection />
+      <AttachmentsSection
+        visibleInputs={visibleInputs}
+        pendingFiles={uploads.pendingFiles}
+        handleFiles={uploads.handleFiles}
+        fileInputRef={uploads.fileInputRef}
+      />
     </div>,
   )
 
@@ -198,9 +184,7 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
             <button
               type="button"
               onClick={() => runStart?.()}
-              disabled={
-                !canStart || runActionsLoading || runActionsUpgradeNeeded
-              }
+              disabled={!canStart}
               title={
                 streamSlug == null
                   ? 'Assign a stream to run this task'

--- a/happyhq/components/features/tasks/panel/index.tsx
+++ b/happyhq/components/features/tasks/panel/index.tsx
@@ -39,6 +39,7 @@ import {
 import { WorkingRow } from '@/components/features/tasks/atoms/working-row'
 import { useOptimisticUploads } from '@/components/features/tasks/hooks/use-optimistic-uploads'
 import { shouldShowWorkSection } from '@/components/features/tasks/panel/work-gate'
+import { canStartIdleTask } from '@/components/features/tasks/start-gate'
 import {
   deleteFile,
   deleteTaskByLocation,
@@ -85,7 +86,6 @@ export function TaskPanel({
   const router = useRouter()
   const taskSlug = useParams<{ task?: string }>().task
   const activeTask = useActiveTask()
-  const taskTitle = activeTask?.frontmatter.title ?? null
   const { mutate } = useSWRConfig()
   const taskContent = useTaskContent()
   const streamSlug = useStreamSlug()
@@ -153,8 +153,10 @@ export function TaskPanel({
 
   // Initialize from server data — inline during render so title/description
   // are visible on the very first paint (no useEffect timing gap).
-  if (taskContent && !initialized) {
-    setTitle(displayTitle(taskTitle, taskSlug ?? ''))
+  // Title is the raw frontmatter value (not displayTitle's slug fallback) so
+  // the start-task gate sees what the user actually saved — see issue #255.
+  if (taskContent && activeTask && !initialized) {
+    setTitle(activeTask.frontmatter.title ?? '')
     setDescription(taskContent.description ?? '')
     setInitialized(true)
   }
@@ -712,12 +714,15 @@ export function TaskPanel({
                   type="button"
                   onClick={() => runActions.start?.()}
                   disabled={
-                    !streamSlug ||
-                    !title.trim() ||
-                    (!description.trim() && visibleInputs.length === 0) ||
-                    isUploading ||
-                    runActions.isLoading ||
-                    runActions.upgradeNeeded
+                    !canStartIdleTask({
+                      streamSlug,
+                      title,
+                      hasDescription: !!description.trim(),
+                      hasInputs: visibleInputs.length > 0,
+                      isUploading,
+                      runActionsLoading: runActions.isLoading,
+                      runActionsUpgradeNeeded: runActions.upgradeNeeded,
+                    })
                   }
                   className="flex h-6 shrink-0 items-center justify-center rounded-full bg-zinc-900 px-3 font-mono text-[10px] font-semibold tracking-wider text-white uppercase transition-colors hover:bg-zinc-800 disabled:opacity-30"
                 >

--- a/happyhq/components/features/tasks/start-gate.test.ts
+++ b/happyhq/components/features/tasks/start-gate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { canStartIdleTask } from './start-gate'
+
+const READY = {
+  streamSlug: 'stream',
+  title: 'A title',
+  hasDescription: true,
+  hasInputs: false,
+  isUploading: false,
+  runActionsLoading: false,
+  runActionsUpgradeNeeded: false,
+}
+
+describe('canStartIdleTask', () => {
+  it('enables the button when stream + title + description are present', () => {
+    expect(canStartIdleTask(READY)).toBe(true)
+  })
+
+  it('enables the button when description is empty but inputs exist', () => {
+    expect(
+      canStartIdleTask({ ...READY, hasDescription: false, hasInputs: true }),
+    ).toBe(true)
+  })
+
+  it('disables the button without a stream', () => {
+    expect(canStartIdleTask({ ...READY, streamSlug: null })).toBe(false)
+  })
+
+  it('disables the button without a title', () => {
+    expect(canStartIdleTask({ ...READY, title: '' })).toBe(false)
+    expect(canStartIdleTask({ ...READY, title: '   ' })).toBe(false)
+    expect(canStartIdleTask({ ...READY, title: null })).toBe(false)
+  })
+
+  it('disables the button when neither description nor inputs are present', () => {
+    expect(
+      canStartIdleTask({ ...READY, hasDescription: false, hasInputs: false }),
+    ).toBe(false)
+  })
+
+  it('disables the button while uploads are in flight', () => {
+    expect(canStartIdleTask({ ...READY, isUploading: true })).toBe(false)
+  })
+
+  it('disables the button while run actions are loading', () => {
+    expect(canStartIdleTask({ ...READY, runActionsLoading: true })).toBe(false)
+  })
+
+  it('disables the button when an upgrade is required', () => {
+    expect(canStartIdleTask({ ...READY, runActionsUpgradeNeeded: true })).toBe(
+      false,
+    )
+  })
+})

--- a/happyhq/components/features/tasks/start-gate.ts
+++ b/happyhq/components/features/tasks/start-gate.ts
@@ -1,0 +1,30 @@
+// Single source of truth for whether the idle "Start Task" button is enabled.
+// The task card (home page) and task panel (desktop) call this with the same
+// inputs so the same idle task can't be enabled on one surface and disabled on
+// the other (issue #255).
+export function canStartIdleTask({
+  streamSlug,
+  title,
+  hasDescription,
+  hasInputs,
+  isUploading,
+  runActionsLoading,
+  runActionsUpgradeNeeded,
+}: {
+  streamSlug: string | null
+  title: string | null | undefined
+  hasDescription: boolean
+  hasInputs: boolean
+  isUploading: boolean
+  runActionsLoading: boolean
+  runActionsUpgradeNeeded: boolean
+}): boolean {
+  return (
+    streamSlug != null &&
+    !!title?.trim() &&
+    (hasDescription || hasInputs) &&
+    !isUploading &&
+    !runActionsLoading &&
+    !runActionsUpgradeNeeded
+  )
+}


### PR DESCRIPTION
## Summary

Closes #255.

The home-page task card and the desktop task panel each computed the "Start Task" enabled state independently, so the same idle task could end up enabled on one surface and disabled on the other (e.g. a task with whitespace title, or a task missing description+inputs). The two surfaces also disagreed about whether to fall back to the slug for the title check.

This PR introduces a single `canStartIdleTask` predicate and routes both surfaces through it.

## Changes

- New `components/features/tasks/start-gate.ts` — pure function with one rule: `streamSlug != null && title?.trim() && (hasDescription || hasInputs) && !isUploading && !runActionsLoading && !runActionsUpgradeNeeded`.
- New `components/features/tasks/start-gate.test.ts` — table-driven tests pinning each disable reason and the description-or-inputs OR.
- Card (`card/index.tsx`) now lifts `useOptimisticUploads` to the root so its `isUploading` covers drops anywhere on the card; `attachments-section.tsx` becomes a presentational wrapper.
- Panel (`panel/index.tsx`) drops the `displayTitle(taskTitle, taskSlug ?? '')` fallback at init — the gate now sees the user-saved title rather than a slug substitute, so a task with an empty/whitespace title is correctly disabled.

## Test plan

- [x] `pnpm test` (1454 passing, including the new 8 cases for `canStartIdleTask`)
- [x] `pnpm check-types` clean
- [x] `pnpm lint` clean
- [x] Browser-exercised both surfaces (card route `/tasks/inbox/<slug>`, panel route `/<stream>/<slug>`):
  - Ready task: both ENABLED
  - Description removed: both DISABLED
  - Whitespace title: both DISABLED (placeholder visible)
  - Real task with no description (only stream + title): panel DISABLED, "Add some context" checklist visible

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7)