### PR TITLE
fix: append ID suffix to quick-add task slugs

### DIFF
--- a/happyhq/components/features/tasks/create/quick-add.tsx
+++ b/happyhq/components/features/tasks/create/quick-add.tsx
@@ -9,7 +9,7 @@ import { StreamPicker } from '@/components/features/tasks/atoms/stream-picker'
 import { useCurrentUser } from '@/lib/accounts/hooks'
 import { createTask, ingestTaskInput } from '@/lib/actions'
 import { ALLOWED_INPUT_ACCEPT } from '@/lib/file-types'
-import { toSlug } from '@/lib/format'
+import { generateTaskSlug } from '@/lib/format'
 import { taskItemsKey } from '@/lib/swr-keys'
 import { useStreams } from '@/stores/streamsStore'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -51,7 +51,7 @@ export function TaskQuickAdd({
   async function handleSubmit() {
     if (!canSubmit || isCreating) return
     const trimmed = title.trim()
-    const slug = toSlug(trimmed)
+    const slug = generateTaskSlug(trimmed)
     if (!slug) return
 
     setIsCreating(true)

--- a/happyhq/scripts/smoke-e2e.ts
+++ b/happyhq/scripts/smoke-e2e.ts
@@ -39,7 +39,11 @@ const SMOKE_ROOT = path.join(
   `happyhq-smoke-${crypto.randomUUID()}`,
 )
 const STREAM_SLUG = 'smoke'
-const TASK_SLUG = 'smoke-task'
+// generateTaskSlug appends `-<9-char Crockford Base32>` to the kebab title.
+// The browser-driven flow types "smoke task", so the created directory
+// matches `smoke-task-<suffix>` — discovered post-create rather than known
+// up front.
+const TASK_SLUG_PATTERN = /^smoke-task-[0-9a-z]+$/i
 
 // ---------------------------------------------------------------------------
 // Logging
@@ -130,7 +134,7 @@ function devServer(action: 'start' | 'wait-ready' | 'stop'): void {
 // Browser flow — task creation via the real UI
 // ---------------------------------------------------------------------------
 
-async function createTaskViaUI(): Promise<void> {
+async function createTaskViaUI(): Promise<string> {
   const browser = await chromium.launch({ headless: !HEADED })
   try {
     const ctx = await browser.newContext({
@@ -208,25 +212,44 @@ async function createTaskViaUI(): Promise<void> {
     // calls ingestTaskInput per file. Both are sequential awaits, so the
     // inputs directory is the right "task creation done" signal.
     log('waiting for task and inputs to land on disk')
-    const taskDir = path.join(SMOKE_ROOT, 'tasks', TASK_SLUG)
-    const inputsDir = path.join(taskDir, 'inputs')
+    const tasksRoot = path.join(SMOKE_ROOT, 'tasks')
     const deadline = Date.now() + 30_000
-    while (
-      !fs.existsSync(path.join(taskDir, 'task.md')) ||
-      !fs.existsSync(inputsDir) ||
-      fs.readdirSync(inputsDir).length === 0
-    ) {
-      if (Date.now() > deadline) {
-        const taskExists = fs.existsSync(path.join(taskDir, 'task.md'))
-        const inputs = fs.existsSync(inputsDir) ? fs.readdirSync(inputsDir) : []
-        fail(
-          'createTask',
-          `task=${taskExists} inputs=[${inputs.join(',')}]; never finished`,
-        )
+    let taskSlug: string | undefined
+    while (taskSlug === undefined) {
+      if (fs.existsSync(tasksRoot)) {
+        for (const entry of fs.readdirSync(tasksRoot)) {
+          if (!TASK_SLUG_PATTERN.test(entry)) continue
+          const taskDir = path.join(tasksRoot, entry)
+          const inputsDir = path.join(taskDir, 'inputs')
+          if (
+            fs.existsSync(path.join(taskDir, 'task.md')) &&
+            fs.existsSync(inputsDir) &&
+            fs.readdirSync(inputsDir).length > 0
+          ) {
+            taskSlug = entry
+            break
+          }
+        }
       }
-      await sleep(500)
+      if (taskSlug === undefined) {
+        if (Date.now() > deadline) {
+          const candidates = fs.existsSync(tasksRoot)
+            ? fs.readdirSync(tasksRoot)
+            : []
+          fail(
+            'createTask',
+            `no smoke-task-* directory with task.md + populated inputs/ landed; candidates=[${candidates.join(',')}]`,
+          )
+        }
+        await sleep(500)
+      }
     }
-    log('task created with inputs', fs.readdirSync(inputsDir).join(', '))
+    const inputsDir = path.join(tasksRoot, taskSlug, 'inputs')
+    log(
+      'task created with inputs',
+      `${taskSlug} → ${fs.readdirSync(inputsDir).join(', ')}`,
+    )
+    return taskSlug
   } finally {
     await browser.close()
   }
@@ -236,12 +259,15 @@ async function createTaskViaUI(): Promise<void> {
 // Run iterations via API
 // ---------------------------------------------------------------------------
 
-async function runIteration(mode: 'planning' | 'working'): Promise<void> {
+async function runIteration(
+  mode: 'planning' | 'working',
+  taskSlug: string,
+): Promise<void> {
   log(`POST /api/run/start ${mode}`)
   const startRes = await fetch(`${BASE_URL}/api/run/start`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ task: TASK_SLUG, stream: STREAM_SLUG, mode }),
+    body: JSON.stringify({ task: taskSlug, stream: STREAM_SLUG, mode }),
   })
   if (!startRes.ok) {
     fail(
@@ -275,8 +301,8 @@ async function runIteration(mode: 'planning' | 'working'): Promise<void> {
 // Assertions
 // ---------------------------------------------------------------------------
 
-function assertOutputs(): void {
-  const taskDir = path.join(SMOKE_ROOT, 'tasks', TASK_SLUG)
+function assertOutputs(taskSlug: string): void {
+  const taskDir = path.join(SMOKE_ROOT, 'tasks', taskSlug)
 
   const planMd = path.join(taskDir, 'plan.md')
   if (!fs.existsSync(planMd)) fail('assertions', 'plan.md missing')
@@ -384,10 +410,10 @@ async function main(): Promise<void> {
     seedFixtures()
     devServer('start')
     devServer('wait-ready')
-    await createTaskViaUI()
-    await runIteration('planning')
-    await runIteration('working')
-    assertOutputs()
+    const taskSlug = await createTaskViaUI()
+    await runIteration('planning', taskSlug)
+    await runIteration('working', taskSlug)
+    assertOutputs(taskSlug)
     assertNoErrors()
     log('PASS')
     success = true


### PR DESCRIPTION
Closes #257

## Why

Tasks created via the inline quick-add row at the top of the task list were saved with a plain kebab-case slug — no ID suffix. Two tasks created via quick-add with the same (or kebab-collapsing) title shared a slug and collided on disk: `createTask` calls `ensureDirectory`, which is forgiving on existing dirs, so the second create silently lands on the first task's directory.

The sidebar dialog path used `generateTaskSlug` and was unaffected. The quick-add path used `toSlug`. Two entry points to task creation, two slug functions, inconsistent collision-safety from day one.

## Fix

Swap the import in `components/features/tasks/create/quick-add.tsx` from `toSlug` to `generateTaskSlug` (the same helper the sidebar dialog and the chat-driven Start Task flow already use). `generateTaskSlug` is `toSlug` + a 9-char Crockford Base32 suffix (7 chars timestamp, 2 chars random).

No regression test added: the contract worth pinning ("quick-add slugs include a unique suffix") is already covered at the unit level by the existing `generateTaskSlug` tests in `lib/format.test.ts`. A test on "quick-add imports `generateTaskSlug`" would lock the implementation; a behavior test covering it has the same answer to the litmus question (revert this exact line) under any reasonable reimplementation.

## Visual evidence

Created two tasks with the same title "Quick add bug 257" via the inline quick-add row, then queried `/api/fs/task-items`:

```
[
  { "slug": "quick-add-bug-257-1mzw9x3e9", "title": "Quick add bug 257" },
  { "slug": "quick-add-bug-257-1mzw9w6pa", "title": "Quick add bug 257" }
]
```

Both tasks render as separate rows in the task list:

![two-tasks-same-title](https://ralphie.happyhq.com/pr/259/aba77a82-f867-456c-846f-12c117e88062/01-two-tasks-same-title.png)

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.