### PR TITLE
fix(loops): label fix PRs with ralphie:ready-to-merge so QA picks them up

### DIFF
--- a/happyhq/.dev/PROMPT_bugs_fix.md
+++ b/happyhq/.dev/PROMPT_bugs_fix.md
@@ -55,7 +55,11 @@
    - **Visual evidence** — one sentence on what was exercised in step 5b, plus the screenshot(s) or log excerpt(s). For UI changes, upload screenshots via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <screenshot-dir>` and embed the returned URLs as inline `![alt](url)` markdown. For server-only changes, paste the relevant log lines or API response in a fenced block.
    - AI-assistance disclosure per @CONTRIBUTING.md (e.g., "Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.")
 
-9. **Label.** `gh issue edit ${ISSUE_NUMBER} --add-label "ralphie:fixed-in-pr"`. The PR's `Closes #` is the rest of the breadcrumb.
+9. **Label.** Two labels — one on the PR, one on the issue:
+   - `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"` — puts the PR in the QA triage queue ([qa-rubric.md](qa-rubric.md), [PROMPT_qa_triage.md](PROMPT_qa_triage.md)). Without this the PR opens but QA never sees it.
+   - `gh issue edit ${ISSUE_NUMBER} --add-label "ralphie:fixed-in-pr"` — prevents the bugs loop from re-picking the issue ([bugs.sh](bugs.sh) wrapper guard).
+
+   The PR's `Closes #` is the rest of the breadcrumb.
 
 10. **Return to base branch.** `git checkout ${BASE_BRANCH}`. Each session leaves the working tree on `${BASE_BRANCH}` so the next session (or the maintainer) starts from a clean baseline. Apply this on the skip paths too — if you abort and revert in step 6 of the guardrails, end on `${BASE_BRANCH}`.
 

--- a/happyhq/.dev/PROMPT_tech_debt_fix.md
+++ b/happyhq/.dev/PROMPT_tech_debt_fix.md
@@ -79,7 +79,11 @@
    - **Visual evidence** — one sentence per surface exercised in step 6a, plus the screenshot(s) or log excerpt(s). For UI changes, upload screenshots via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <screenshot-dir>` and embed the returned URLs as inline `![alt](url)` markdown. For server-only changes, paste the relevant log lines or API response in a fenced block.
    - AI-assistance disclosure per [CONTRIBUTING.md](CONTRIBUTING.md) (e.g., "Authored by the tech-debt loop. Reviewed by maintainer before merge.")
 
-10. **Label.** `gh issue edit ${ISSUE_NUMBER} --add-label "ralphie:fixed-in-pr"`. The PR's `Closes #` is the rest of the breadcrumb.
+10. **Label.** Two labels — one on the PR, one on the issue:
+    - `gh pr edit ${PR_NUMBER} --add-label "ralphie:ready-to-merge"` — puts the PR in the QA triage queue ([qa-rubric.md](qa-rubric.md), [PROMPT_qa_triage.md](PROMPT_qa_triage.md)). Without this the PR opens but QA never sees it.
+    - `gh issue edit ${ISSUE_NUMBER} --add-label "ralphie:fixed-in-pr"` — prevents the tech-debt loop from re-picking the issue (wrapper guard).
+
+    The PR's `Closes #` is the rest of the breadcrumb.
 
 11. **Return to base branch.** `git checkout ${BASE_BRANCH}`. Each session leaves the working tree on `${BASE_BRANCH}` so the next session (or the maintainer) starts from a clean baseline. Apply this on the skip paths too — if you abort and revert in step 6 of the guardrails, end on `${BASE_BRANCH}`.
 


### PR DESCRIPTION
## Summary

The bugs and tech-debt loops were labelling the *issue* (`ralphie:fixed-in-pr`) but applying no label to the *PR*. QA triage queries open PRs filtered to `ralphie:ready-to-merge` or `needs-qa` ([PROMPT_qa_triage.md:10](happyhq/.dev/PROMPT_qa_triage.md#L10)), so loop-authored fix PRs were silently skipped — confirmed today against open PRs #258 and #259, both with empty label sets.

The deps loop already does the right thing ([PROMPT_dependency_upgrade.md:57](happyhq/.dev/PROMPT_dependency_upgrade.md#L57)) — this aligns the bugs and tech-debt prompts to the same pattern.

## Why both labels stay

- **PR label (`ralphie:ready-to-merge`)** — new. Routes the PR into the QA triage queue.
- **Issue label (`ralphie:fixed-in-pr`)** — preserved. The `bugs.sh` / `tech-debt.sh` wrappers refuse to advance the loop unless the worked-on issue has a `ralphie:*` label after the session ([bugs.sh:214-216](happyhq/.dev/bugs.sh#L214-L216), [tech-debt.sh:213-215](happyhq/.dev/tech-debt.sh#L213-L215)). Removing it would break re-pick prevention.

## Why `ralphie:ready-to-merge` and not `needs-qa`

QA triage accepts either, but `ralphie:ready-to-merge` is the autonomous-loop label (deps already uses it). `needs-qa` is reserved for the manual override path — humans tagging non-Ralphie PRs by hand. Keeping autonomous output on a single label keeps the queue legible.

## Backfill

The two PRs from today's bugs run (#258, #259) need to be backfilled manually so the next QA run picks them up. Doing that as a follow-up to this merge:

```
gh pr edit 258 --add-label "ralphie:ready-to-merge"
gh pr edit 259 --add-label "ralphie:ready-to-merge"
```

## Test plan

- [ ] Merge this, then run `./qa.sh` after backfilling #258 and #259 — triage should now produce a non-empty queue.
- [ ] Next bugs-loop session: verify the resulting PR carries `ralphie:ready-to-merge` (`gh pr view <N> --json labels`) and the issue carries `ralphie:fixed-in-pr`.
- [ ] Same check on the next tech-debt session.

---

Authored by the maintainer with Claude Code assistance. Reviewed by maintainer before merge.