### PR TITLE
fix: broadcast task_content_changed after working iteration writeRunInfo

### DIFF
--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -729,6 +729,7 @@ async function runWorkingLoop(
         planningSessionId,
         workingSessionIds,
       })
+      broadcast(encodeEvent({ type: 'task_content_changed' }))
       log('run.stopped', {
         task: taskName,
         stream: streamName,
@@ -849,6 +850,7 @@ async function runWorkingLoop(
           planningSessionId,
           workingSessionIds,
         })
+        broadcast(encodeEvent({ type: 'task_content_changed' }))
         log('run.stopped', {
           task: taskName,
           stream: streamName,
@@ -880,6 +882,7 @@ async function runWorkingLoop(
           planningSessionId,
           workingSessionIds,
         })
+        broadcast(encodeEvent({ type: 'task_content_changed' }))
         broadcastErrorEvent(error, stderrTail)
         log('run.error', {
           task: taskName,
@@ -919,6 +922,7 @@ async function runWorkingLoop(
         planningSessionId,
         workingSessionIds,
       })
+      broadcast(encodeEvent({ type: 'task_content_changed' }))
       log('run.iteration', {
         task: taskName,
         iteration,
@@ -954,6 +958,7 @@ async function runWorkingLoop(
             planningSessionId,
             workingSessionIds,
           })
+          broadcast(encodeEvent({ type: 'task_content_changed' }))
           log('run.stopped', {
             task: taskName,
             stream: streamName,
@@ -1008,6 +1013,7 @@ async function runWorkingLoop(
         planningSessionId,
         workingSessionIds,
       })
+      broadcast(encodeEvent({ type: 'task_content_changed' }))
       log('run.stopped', {
         task: taskName,
         stream: streamName,
@@ -1032,6 +1038,7 @@ async function runWorkingLoop(
       planningSessionId,
       workingSessionIds,
     })
+    broadcast(encodeEvent({ type: 'task_content_changed' }))
     log('run.iteration', {
       task: taskName,
       iteration,
@@ -1057,6 +1064,7 @@ async function runWorkingLoop(
         planningSessionId,
         workingSessionIds,
       })
+      broadcast(encodeEvent({ type: 'task_content_changed' }))
       log('run.completed', {
         task: taskName,
         stream: streamName,
@@ -1095,6 +1103,7 @@ async function runWorkingLoop(
           planningSessionId,
           workingSessionIds,
         })
+        broadcast(encodeEvent({ type: 'task_content_changed' }))
         log('run.stopped', {
           task: taskName,
           stream: streamName,
@@ -1123,6 +1132,7 @@ async function runWorkingLoop(
     planningSessionId,
     workingSessionIds,
   })
+  broadcast(encodeEvent({ type: 'task_content_changed' }))
   log('run.stopped', {
     task: taskName,
     stream: streamName,


### PR DESCRIPTION
Closes #261

## Summary

Adds `broadcast(encodeEvent({ type: 'task_content_changed' }))` after each `writeRunInfo` call in `runWorkingLoop` (10 sites) so the panel sees state flips in real time instead of waiting for SWR's interval polling. Same shape as the discovery/planning broadcast pattern.

## Why

Working-iteration terminal states (user-stop, auth error, budget hit, no-progress, `[done]`, iteration_limit) and intermediate `working` writes update `.run.json` but don't push an SSE event. The panel only learns about state changes when an agent file-write triggers PostToolUse — which doesn't happen for terminal states (no agent write follows). Result: a finished run can render as "still running" for several seconds until the next SWR poll lands.

## Deviations from the report's framing

The report says the broadcast pattern "landed in c8596d6 for discovery and planning" — but c8596d6 lives on the `ralphie/discovery` branch and hasn't merged to `main` yet. So `runPlanningIteration` on `main` also lacks broadcasts after its `writeRunInfo` calls. That's outside this issue's scope and will arrive when the discovery branch merges. The diagnosis and prescription for working iteration are exactly right; the fix here is independent of that branch's status.

The report enumerated 9 sites; I applied the broadcast at 10 — added it after the no-progress write inside the catch block (the errored-iteration sibling of the post-iteration no-progress check at the bottom of the loop). The pattern is "every state flip broadcasts," and missing one would be the same bug class.

## Sites updated in `happyhq/lib/run/loop.server.ts`

1. Pre-iteration abort (user stop before iteration starts)
2. Mid-iteration user stop (catch block)
3. Auth error (catch block)
4. Iteration errored, status stays `working` (catch block)
5. No-progress on errored iteration (catch block)
6. Billing budget hit
7. Iteration completed normally (status `working`, iteration count updates)
8. `[done]` detected → `completed`
9. No-progress on completed iteration
10. `iteration_limit` reached

## Regression test

Skipped per the litmus test in `testing.md`. The only assertion would be "broadcast was called with `task_content_changed`" — that's a "mock was called" vanity test that locks in implementation. The user-visible contract (panel updates faster on state flip) is timing-dependent and not unit-testable without artificial latency. The c8596d6 commit on `ralphie/discovery` didn't add tests for the same pattern either.

## Verification

- `pnpm format` — clean
- `pnpm lint` — clean
- `pnpm check-types` — clean
- `pnpm --filter=happyhq test` — 1454 tests pass
- Dev server starts cleanly; `/api/run/stream` responds; smoke-test passes

The user-visible exercise (driving a real working run and watching SSE for `task_content_changed` events around state transitions) requires LLM/agent setup and isn't repro-able in a Playwright/curl loop without spending real cost on a multi-minute run. Diff is mechanical — same encoding, same call shape as the 6+ existing broadcasts elsewhere in the file.

## AI assistance disclosure

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.
