### PR TITLE
fix: keep description caret in place mid-edit

### DIFF
--- a/happyhq/components/features/tasks/card/description-section.test.tsx
+++ b/happyhq/components/features/tasks/card/description-section.test.tsx
@@ -73,4 +73,30 @@ describe('DescriptionSection — cursor stability while typing', () => {
 
     expect(textarea.value).toBe('loaded from server')
   })
+
+  it('does not snap caret to end when an unrelated rerender happens mid-edit', () => {
+    // hasRun=true so we render the readonly view first, then click into edit.
+    mockState.content = {
+      ...baseContent,
+      description: 'hello world',
+      run: { status: 'completed' },
+    } as unknown as TaskContent
+    const { rerender } = render(<DescriptionSection />)
+
+    // Enter edit mode by clicking the readonly view.
+    fireEvent.click(screen.getByText('hello world'))
+    const textarea = screen.getByPlaceholderText(
+      'Add context...',
+    ) as HTMLTextAreaElement
+
+    // Simulate the user clicking mid-text to fix a typo.
+    textarea.setSelectionRange(5, 5)
+    expect(textarea.selectionStart).toBe(5)
+
+    // An unrelated rerender (e.g. an SWR refresh) must not move the caret.
+    rerender(<DescriptionSection />)
+
+    expect(textarea.selectionStart).toBe(5)
+    expect(textarea.selectionEnd).toBe(5)
+  })
 })

--- a/happyhq/components/features/tasks/card/description-section.tsx
+++ b/happyhq/components/features/tasks/card/description-section.tsx
@@ -34,11 +34,24 @@ function EditableDescription() {
   const descTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   )
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   // Flush pending save on unmount
   useEffect(() => {
     return () => clearTimeout(descTimerRef.current)
   }, [])
+
+  // Place caret at end on the transition into edit mode only.
+  // Doing this in the ref callback re-ran on every render and snapped the
+  // caret to the end on every keystroke (#265).
+  useEffect(() => {
+    if (!isEditing) return
+    const el = textareaRef.current
+    if (!el) return
+    el.focus()
+    const end = el.value.length
+    el.setSelectionRange(end, end)
+  }, [isEditing])
 
   const handleChange = (value: string) => {
     setDescription(value)
@@ -68,12 +81,7 @@ function EditableDescription() {
   return (
     <div className="mt-[0.5px] px-4 py-2">
       <textarea
-        ref={(el) => {
-          if (el && isEditing) {
-            el.focus()
-            el.selectionStart = el.selectionEnd = el.value.length
-          }
-        }}
+        ref={textareaRef}
         value={description}
         onChange={(e) => {
           if (!isEditing) setIsEditing(true)

--- a/happyhq/components/features/tasks/panel/index.tsx
+++ b/happyhq/components/features/tasks/panel/index.tsx
@@ -225,6 +225,18 @@ export function TaskPanel({
     setFocusTarget(null)
   }, [focusTarget, setFocusTarget, onSidebarOpenChange])
 
+  // Place caret at end on the transition into edit mode only.
+  // Doing this in the ref callback re-ran on every render and snapped the
+  // caret to the end on every keystroke (#265).
+  useEffect(() => {
+    if (!isEditingDescription) return
+    const el = descriptionRef.current
+    if (!el) return
+    el.focus()
+    const end = el.value.length
+    el.setSelectionRange(end, end)
+  }, [isEditingDescription])
+
   // ── Auto-resize textarea ────────────────────────────────────────────
   const autoResize = (el: HTMLTextAreaElement) => {
     el.style.height = ''
@@ -379,13 +391,7 @@ export function TaskPanel({
                 <textarea
                   ref={(el) => {
                     descriptionRef.current = el
-                    if (el) {
-                      autoResize(el)
-                      if (isEditingDescription) {
-                        el.focus()
-                        el.selectionStart = el.selectionEnd = el.value.length
-                      }
-                    }
+                    if (el) autoResize(el)
                   }}
                   value={description}
                   onChange={(e) => {


### PR DESCRIPTION
Closes #265

## Why

The task description textarea used an inline `ref` callback that re-ran on every render. While `isEditing` was true it force-reset the caret to the end of the value, so each keystroke (`onChange` → `setDescription` → re-render → ref callback fires again) snapped the cursor back to the end. The intent was to position the caret at the end **once** when entering edit mode, not on every render. Result: the description field was effectively append-only — typing in the middle to fix a typo or pluralise a word silently appended to the end.

The fix moves the focus + caret-to-end behaviour out of the inline ref callback and into a `useEffect` keyed on `isEditing`, so it runs only on the false→true transition. Two sites had the same anti-pattern: `components/features/tasks/card/description-section.tsx` and `components/features/tasks/panel/index.tsx`.

## Regression test

`components/features/tasks/card/description-section.test.tsx:78` — asserts that an unrelated rerender mid-edit (e.g. an SWR refresh) does not move the caret. Fails before the fix (selectionStart 11, the end of "hello world"); passes after (selectionStart 5).

## Visual evidence

Drove the panel surface in a real browser (`/email-intros/tom-brady-bill-bellichek`):

1. Clicked the rendered description to enter edit mode — caret correctly placed at end (position 1039) on entry.
2. Re-positioned the caret to the middle (position 50, between "hypothe" and "tical").
3. Typed `Z`, `A`, `P` one after another. Each character was inserted in-place — the caret advanced 50 → 51 → 52 → 53, the end of the text was unchanged, and the visible result was `tical exerZAPcise: write`.

![panel-mid-edit](https://ralphie.happyhq.com/pr/266/807483a0-4b23-4c1b-9f6a-399431be6859/265-01-panel-mid-edit.png)

Without the fix, the caret would have snapped back to the end after the first keystroke and the typed characters would have appended to the tail of the description instead.

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.