### PR TITLE
fix(desktop): restore-from-maximize anchors to saved position

### DIFF
--- a/happyhq/components/features/desktop/shell.tsx
+++ b/happyhq/components/features/desktop/shell.tsx
@@ -89,17 +89,21 @@ export function DesktopShell({ children }: { children: ReactNode }) {
   const { openOrFocusWindow, openFileWindow, openDirectoryWindow } =
     useDesktopWindows(canvasRef)
 
-  // Keep stored canvas width in sync so useDesktopWindows() works without a ref
-  const setCanvasWidth = useWindowStore((s) => s.setCanvasWidth)
+  // Keep stored canvas size in sync so useDesktopWindows() and WindowFrame's
+  // drag bounds work without each consumer needing its own ResizeObserver.
+  const setCanvasSize = useWindowStore((s) => s.setCanvasSize)
   useEffect(() => {
     const el = canvasRef.current
     if (!el) return
     const observer = new ResizeObserver(([entry]) => {
-      setCanvasWidth(entry.contentRect.width)
+      setCanvasSize({
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      })
     })
     observer.observe(el)
     return () => observer.disconnect()
-  }, [setCanvasWidth])
+  }, [setCanvasSize])
 
   // ── Derived layout ────────────────────────────────────────────────
   const showPanel = openPanel.type !== 'empty'

--- a/happyhq/components/features/desktop/windows/markdown/frontmatter/block.tsx
+++ b/happyhq/components/features/desktop/windows/markdown/frontmatter/block.tsx
@@ -338,7 +338,7 @@ function LabelCell({ Icon, label }: { Icon: LucideIcon; label: string }) {
 }
 
 export function FrontmatterBlock({ fields }: FrontmatterBlockProps) {
-  const entries = Object.entries(fields).filter(([k]) => k !== 'title')
+  const entries = Object.entries(fields)
   if (entries.length === 0) return null
 
   return (

--- a/happyhq/components/features/desktop/windows/window-frame.tsx
+++ b/happyhq/components/features/desktop/windows/window-frame.tsx
@@ -74,6 +74,22 @@ export function WindowFrame({
   const y = useMotionValue(position.y)
   const width = useMotionValue(size.width)
   const height = useMotionValue(size.height)
+  // Read canvas size from the store and derive a STATIC drag-constraints
+  // object. We deliberately avoid passing dragConstraints as a ref —
+  // framer-motion would otherwise observe the element's resize and call
+  // scalePositionWithinConstraints(), which re-anchors the restored window
+  // to the maximized bottom/right edges. Static bounds skip that path.
+  const canvasWidth = useWindowStore((s) => s.canvasWidth)
+  const canvasHeight = useWindowStore((s) => s.canvasHeight)
+  const dragConstraints =
+    canvasWidth != null && canvasHeight != null
+      ? {
+          left: 0,
+          top: 0,
+          right: Math.max(0, canvasWidth - size.width),
+          bottom: Math.max(0, canvasHeight - size.height),
+        }
+      : undefined
   const windowRef = useRef<HTMLDivElement>(null)
   const resizeStateRef = useRef<ResizeState | null>(null)
   const resizeAbortRef = useRef<AbortController | null>(null)
@@ -224,12 +240,8 @@ export function WindowFrame({
       dragMomentum={false}
       dragListener={false}
       dragControls={controls}
-      dragConstraints={dragConstraintsRef}
-      style={
-        isMaximized
-          ? { zIndex, inset: 0, width: '100%', height: '100%' }
-          : { x, y, zIndex, width, height }
-      }
+      dragConstraints={dragConstraints}
+      style={{ x, y, zIndex, width, height }}
       onDragEnd={() => {
         document.body.style.userSelect = ''
         onDragEnd({ x: x.get(), y: y.get() })

--- a/happyhq/stores/windowStore.test.ts
+++ b/happyhq/stores/windowStore.test.ts
@@ -338,6 +338,31 @@ describe('windowStore', () => {
     })
   })
 
+  describe('setCanvasSize', () => {
+    it('keeps maximized windows full-bleed when the canvas resizes', () => {
+      useWindowStore.getState().openWindow(markdownConfig)
+      useWindowStore
+        .getState()
+        .toggleMaximize('plan', { width: 1200, height: 800 })
+
+      useWindowStore.getState().setCanvasSize({ width: 900, height: 600 })
+
+      const win = useWindowStore.getState().windows[0]
+      expect(win.isMaximized).toBe(true)
+      expect(win.size).toEqual({ width: 900, height: 600 })
+    })
+
+    it('leaves non-maximized windows untouched', () => {
+      useWindowStore.getState().openWindow(markdownConfig)
+      const originalSize = { ...useWindowStore.getState().windows[0].size }
+
+      useWindowStore.getState().setCanvasSize({ width: 900, height: 600 })
+
+      const win = useWindowStore.getState().windows[0]
+      expect(win.size).toEqual(originalSize)
+    })
+  })
+
   describe('openWindow preserves layout for already-open windows', () => {
     it('preserves position and size when called for an already-open window', () => {
       useWindowStore.getState().openWindow(markdownConfig)

--- a/happyhq/stores/windowStore.ts
+++ b/happyhq/stores/windowStore.ts
@@ -161,8 +161,10 @@ interface WindowStoreState {
   nextZIndex: number
   /** Last-known canvas width — set by the shell, read by useDesktopWindows. */
   canvasWidth: number | null
+  /** Last-known canvas height — set by the shell, read by WindowFrame for drag bounds. */
+  canvasHeight: number | null
 
-  setCanvasWidth: (width: number) => void
+  setCanvasSize: (size: { width: number; height: number }) => void
   openWindow: (config: WindowConfig, canvasWidth?: number) => void
   closeWindow: (id: string) => void
   focusWindow: (id: string) => void
@@ -195,8 +197,19 @@ export const useWindowStore = create<WindowStoreState>((set, get) => ({
   windows: [],
   nextZIndex: 31,
   canvasWidth: null,
+  canvasHeight: null,
 
-  setCanvasWidth: (width: number) => set({ canvasWidth: width }),
+  setCanvasSize: ({ width, height }) =>
+    set((s) => ({
+      canvasWidth: width,
+      canvasHeight: height,
+      // Keep maximized windows full-bleed when the canvas resizes (previously
+      // handled implicitly by CSS width:100%/inset:0; now the maximized size
+      // lives in the store, so we update it explicitly here).
+      windows: s.windows.map((w) =>
+        w.isMaximized ? { ...w, size: { width, height } } : w,
+      ),
+    })),
   openWindow: (config, canvasWidth) => {
     const { windows, nextZIndex } = get()
     const existing = windows.find((w) => w.id === config.id)


### PR DESCRIPTION
## Summary

- Restored windows now land at their saved position instead of being pinned to the maximized layout's bottom edge. Root cause: framer-motion's drag-with-ref-constraints uses a ResizeObserver to call \`scalePositionWithinConstraints\` whenever the element resizes, which re-anchors the window. Switched to a static \`dragConstraints\` object derived from canvas + window size and drive position/size with motion values across both maximized and restored states, so framer-motion sees no layout flip.
- Show \`title\` in the frontmatter property table — it was being filtered out, but the title isn't rendered anywhere else, so it just disappeared from the UI.

## Test plan

- [ ] Open a markdown window, drag it to a non-default position, maximize, then restore — window lands at the dragged position
- [ ] Open a markdown window, maximize, restore — window lands at its original position
- [ ] Resize the browser while a window is maximized — the maximized window tracks the new canvas size
- [ ] Drag a (non-maximized) window — still constrained to the canvas
- [ ] Open a markdown doc with a \`title\` frontmatter field — title appears as a row in the property table
- [ ] \`pnpm --filter=happyhq test stores/windowStore.test.ts\` — 30 tests pass (2 new tests cover the canvas-resize → maximized-windows invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)