### PR TITLE
chore: flip exhaustive-deps to warn + fix Category A bridges

### DIFF
--- a/happyhq/components/features/chat/chat-page-shell.tsx
+++ b/happyhq/components/features/chat/chat-page-shell.tsx
@@ -31,6 +31,10 @@ export function ChatPageShell({
   chats: ChatEntry[]
   initialHistory: ChatHistoryData
 }) {
+  // Why mount-only: the parent page sets key={sessionId}, so this component
+  // remounts whenever the session changes. Adding `streamSlug`/`chats` to
+  // deps would re-run reset() on incidental prop updates (e.g., upstream
+  // SWR chat refreshes) and wipe desktopStore window state mid-session.
   useLayoutEffect(() => {
     useDesktopStore.getState().reset()
     if (streamSlug) {
@@ -40,6 +44,7 @@ export function ChatPageShell({
       globalMutate(desktopDataKey(streamSlug), { chats } as any, false)
       useStreamsStore.getState().setActiveStreamSlug(streamSlug)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (

--- a/happyhq/components/features/tasks/hooks/use-task-data.ts
+++ b/happyhq/components/features/tasks/hooks/use-task-data.ts
@@ -34,15 +34,22 @@ export function useTaskData(task: TaskIdentity | null) {
 
   // ── Reset store when task identity changes ──────────────────────────
   // useLayoutEffect fires before paint so TaskCard never sees stale data.
-  // Deps on task.taskSlug so the effect re-fires on task switches (not just mount).
+  // Re-firing on streamSlug/taskTitle changes is safe: reset() preserves
+  // run state when taskSlug is unchanged, so this just updates the identity
+  // fields if the task gets a stream assigned or is renamed mid-session.
+  // (Destructured to scalars because the caller passes a fresh object literal
+  // each render — depending on `task` directly would re-fire every render.)
+  const taskSlug = task?.taskSlug
+  const taskStreamSlug = task?.streamSlug ?? null
+  const taskTitle = task?.taskTitle
   useLayoutEffect(() => {
-    if (!task) return
+    if (!taskSlug || taskTitle === undefined) return
     useTaskStore.getState().reset({
-      taskSlug: task.taskSlug,
-      streamSlug: task.streamSlug,
-      taskTitle: task.taskTitle,
+      taskSlug,
+      streamSlug: taskStreamSlug,
+      taskTitle,
     })
-  }, [task?.taskSlug])
+  }, [taskSlug, taskStreamSlug, taskTitle])
 
   // ── SWR fetch for task content ──────────────────────────────────────
   // This is the "owner" that triggers the fetch. Card components read the

--- a/happyhq/eslint.config.mjs
+++ b/happyhq/eslint.config.mjs
@@ -9,7 +9,7 @@ const eslintConfig = [
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       'react/no-unescaped-entities': 'off',
-      'react-hooks/exhaustive-deps': 'off',
+      'react-hooks/exhaustive-deps': 'warn',
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-empty-interface': 'off',
       '@typescript-eslint/no-empty-object-type': 'off',


### PR DESCRIPTION
Closes #270

## Summary

Step 1+2 of parent #269. Flips `react-hooks/exhaustive-deps` from `off` to `warn` in `eslint.config.mjs`, and addresses the two Category A "server-data → store identity bridge" sites that share #256's stale-prop shape. Lint stays green at `warn` (11 warnings remain across Categories B/C/D — those are sibling children of #269).

## Per-site classification

| Site | Verdict | Decision | Rationale |
| --- | --- | --- | --- |
| `eslint.config.mjs:12` | Improvement | Flip `off` → `warn` | Surfaces an entire category of silent staleness bugs (#256 was one). No CI break at `warn`. |
| `chat-page-shell.tsx:34` | Directive-conformance only | Per-line `eslint-disable-next-line` with reason | Parent page sets `key={sessionId}`, so this is mount-only by design. Adding `streamSlug`/`chats` to deps would re-fire `reset()` on incidental prop updates (e.g., upstream SWR chat refreshes) and wipe `desktopStore` window state mid-session. The rule wants something that isn't right here. |
| `use-task-data.ts:38` | Improvement | Fix in place (destructure to scalar deps) | Caller passes a fresh object literal each render, so `[task]` (which is what the rule suggests) would re-fire every render. Destructuring to `taskSlug`/`taskStreamSlug`/`taskTitle` satisfies the rule, captures the real identity, and is safe — `reset()` preserves run state when `taskSlug` is unchanged, so re-firing on stream-assign or rename mid-session just updates the identity fields. |

## Deviations from the issue body

The body's hypothesis for the chat shell was "Most likely fix in place (add deps, ensure effect is idempotent on re-run)." On inspection the effect is intentionally non-idempotent — it calls `reset()`, which is destructive — and the parent's `key={sessionId}` strategy already provides the correct identity boundary. Per-line disable with a reason comment is the right shape; the body's "judgment — bucket per site" preamble covers this.

The body's hypothesis for `use-task-data.ts` was "change deps to `[task]`." That fails on inspection because the caller (`components/features/tasks/card/index.tsx:31`) constructs a fresh `TaskIdentity` literal each render. Destructuring to scalars is the smallest fix that satisfies the rule without churn.

## Verification

- `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` (1538/1538) all green.
- `pnpm lint` with the rule active reports the expected 11 remaining warnings (Categories B/C/D from parent #269); the 2 Category A sites are no longer flagged.

## Visual evidence

Exercised in dev (`PORT=3030`) via Playwright MCP — both touched surfaces render correctly:

- `/tasks/email-intros/test-2-1n04dsxes` — task card renders with title, description, attachments, and Start Task button (use-task-data path).
- `/chat/<sessionId>` — chat shell mounts cleanly; composer shows the correct stream ("Email Intros") indicating `useDesktopStore.setSelectedStream` and `useStreamsStore.setActiveStreamSlug` both fired (chat-page-shell path).

Screenshots captured locally at `.dev/.playwright-mcp/270-task-card.png` and `.dev/.playwright-mcp/270-chat-page.png`. Evidence-upload tool requires R2 credentials not present in this checkout — happy to re-run and inline if needed.

## AI disclosure

Authored by the tech-debt loop (Claude Opus 4.7). Reviewed by maintainer before merge.