### PR TITLE
chore: memoize openWindow in use-desktop-windows (#271)

### DIFF
--- a/happyhq/components/features/desktop/windows/use-desktop-windows.ts
+++ b/happyhq/components/features/desktop/windows/use-desktop-windows.ts
@@ -18,13 +18,18 @@ export function useDesktopWindows(
   // Read canvasWidth from the store at call time (getState), not as a
   // subscription. Subscribing would re-render on every ResizeObserver
   // frame during CSS transitions, causing jank in heavy components.
-  const openWindow: typeof openWindowRaw = (config) =>
-    openWindowRaw(
-      config,
-      canvasRef?.current?.getBoundingClientRect().width ??
-        useWindowStore.getState().canvasWidth ??
-        undefined,
-    )
+  // Memoised so the downstream useCallbacks below have a stable
+  // dependency and don't churn on every render.
+  const openWindow = useCallback<typeof openWindowRaw>(
+    (config) =>
+      openWindowRaw(
+        config,
+        canvasRef?.current?.getBoundingClientRect().width ??
+          useWindowStore.getState().canvasWidth ??
+          undefined,
+      ),
+    [openWindowRaw, canvasRef],
+  )
   const closeWindow = useWindowStore((s) => s.closeWindow)
   const focusWindow = useWindowStore((s) => s.focusWindow)
   const moveWindow = useWindowStore((s) => s.moveWindow)


### PR DESCRIPTION
Closes #271

## Summary

`openWindow` in `use-desktop-windows.ts` was a plain function recreated on every render. The four `useCallback`s that list it as a dep (`openOrFocusWindow`, `openFileWindow`, `openDirectoryWindow`, `openDynamicDirectoryWindow`) were therefore re-created every render too — defeating their own purpose. Wrapping `openWindow` in `useCallback([openWindowRaw, canvasRef])` gives the downstream callbacks a stable dep and stops the churn through the window system.

## Per-site classification

| Site | Verdict | Rationale |
| --- | --- | --- |
| `components/features/desktop/windows/use-desktop-windows.ts:21` | **Improvement** | The four downstream `useCallback`s already declared `openWindow` as a dep — they were correct, the missing memoization on `openWindow` defeated them. Memoizing is a genuine perf improvement, not directive-conformance. |

## Verification

- `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` — all green (1538 tests pass).
- Probed with the rule temporarily flipped to `warn`: the 4 `exhaustive-deps` warnings in `use-desktop-windows.ts` collapse to 0. Remaining warnings across the repo (9) belong to the other child issues in #269.
- Exercised the desktop windowing surface end-to-end: opened the Playbook window and a Specs (.md) window on the `ca-session-prep` stream — both render, focus correctly, and stack as expected. No regressions visible.

![desktop windows](https://ralphie.happyhq.com/pr/271/d290b8ce-51de-409a-b614-91d4e7b43ad0/271-two-windows.png)

## Terminal action deferred

Per the child issue scope, this PR does **not** flip `react-hooks/exhaustive-deps`. Parent #269 handles the final flip to `error` once all children close.

## AI assistance

Authored by the tech-debt loop. Reviewed by maintainer before merge.