### PR TITLE
chore: add missing setter deps to exhaustive-deps callsites (#273)

### DIFF
--- a/happyhq/components/features/chat/composer.tsx
+++ b/happyhq/components/features/chat/composer.tsx
@@ -102,18 +102,21 @@ export const Composer = memo(function Composer({
   // Track whether the latest value change came from local typing (handleInput already resized)
   const localChangeRef = useRef(false)
 
-  const handleFiles = useCallback((files: FileList) => {
-    // Filter to supported types — the <input> has accept but drag-and-drop bypasses it
-    const allowed = Array.from(files).filter((f) =>
-      isAllowedInputFilename(f.name),
-    )
-    for (const file of allowed) {
-      setStagedFiles((prev) => [
-        ...prev,
-        { id: crypto.randomUUID(), name: file.name, file },
-      ])
-    }
-  }, [])
+  const handleFiles = useCallback(
+    (files: FileList) => {
+      // Filter to supported types — the <input> has accept but drag-and-drop bypasses it
+      const allowed = Array.from(files).filter((f) =>
+        isAllowedInputFilename(f.name),
+      )
+      for (const file of allowed) {
+        setStagedFiles((prev) => [
+          ...prev,
+          { id: crypto.randomUUID(), name: file.name, file },
+        ])
+      }
+    },
+    [setStagedFiles],
+  )
 
   const handleSubmit = useCallback(() => {
     const trimmed = value.trim()
@@ -134,7 +137,15 @@ export const Composer = memo(function Composer({
       }
       setHeightExpanded(false)
     }
-  }, [value, disabled, onSubmit, stagedFiles, clearOnSubmit])
+  }, [
+    value,
+    disabled,
+    onSubmit,
+    stagedFiles,
+    clearOnSubmit,
+    setValue,
+    setStagedFiles,
+  ])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/happyhq/components/features/desktop/panels/task.tsx
+++ b/happyhq/components/features/desktop/panels/task.tsx
@@ -49,7 +49,7 @@ export function TaskPanelView() {
   // Auto-open settings sidebar for streamless tasks
   useEffect(() => {
     if (!streamSlug) setSidebarOpen(true)
-  }, [streamSlug])
+  }, [streamSlug, setSidebarOpen])
 
   // Auto-open file from sessionStorage handoff (click in (app) task card)
   useEffect(() => {


### PR DESCRIPTION
Closes #273

## Summary

Adds the missing setter dependencies that `react-hooks/exhaustive-deps` flags at three Category D sites (split from #269). `useState` setters are stable by React's contract, and `setSidebarOpen` is wrapped in `useCallback` in `stores/desktopStore.tsx:301-304`. In practice these are usually harmless to omit, but including them eliminates a stale-closure window where a parent could swap the underlying callback prop (`onStagedFilesChange`, `onValueChange`) between renders and `handleFiles` / `handleSubmit` would keep calling the old reference. Clears Category D from the parent on the path to promoting the rule to `error`.

## Per-site classification

| Site | Verdict | Rationale |
| --- | --- | --- |
| `components/features/chat/composer.tsx:116` (`handleFiles` missing `setStagedFiles`) | Improvement | `setStagedFiles` is itself a `useCallback` over `onStagedFilesChange` — if a parent swaps the prop, the old `handleFiles` closure would call the previous handler. Unlikely in current callers but the dep correctly closes the window. |
| `components/features/chat/composer.tsx:137` (`handleSubmit` missing `setValue`, `setStagedFiles`) | Improvement | Same shape as above — these setters depend on parent props, so adding them keeps `handleSubmit` synced with the current callback identity. |
| `components/features/desktop/panels/task.tsx:52` (effect missing `setSidebarOpen`) | Improvement | `setSidebarOpen` is `useCallback`-wrapped over `[setSidebarOpenStore, panelType]`. If `openPanel.type` ever changes while the effect is mounted, the stale closure would tag the wrong panel. Verified the hook memoizes the setter, so adding the dep is safe (no re-run loop). |

## Adjacent latent issues

None noticed.

## Adjacent follow-ups filed

None.

## Deviations from the issue body

None — followed the body's default ("add the dep") for all three sites; no fallback to `eslint-disable` was needed.

## Verification

- `pnpm lint` — clean
- `pnpm check-types` — clean
- `pnpm --filter=happyhq test` — 1538/1538 passing
- Note: the parent (#269) holds the terminal action (flipping the rule from `warn` to `error`); this PR does not touch `eslint.config.mjs`.

## Visual evidence

Exercised the chat composer (the surface containing the changed `handleFiles` / `handleSubmit`) and the desktop task panel sidebar auto-open on a streamless task (the effect with the added `setSidebarOpen` dep). Both render and behave as before.

Screenshots captured locally at `.playwright-mcp/01-composer-typed.png`, `.playwright-mcp/02-chat-composer.png`, `.playwright-mcp/03-streamless-task-sidebar.png`. Upload to R2 was skipped — `R2_ACCOUNT_ID` not configured in this worktree.

## AI assistance

Authored by the tech-debt loop. Reviewed by maintainer before merge.
