### PR TITLE
Explain why Start Task is disabled, fix stream-assign staleness

### DIFF
--- a/happyhq/app/globals.css
+++ b/happyhq/app/globals.css
@@ -170,6 +170,29 @@
   animation: fade-in 200ms ease-out forwards;
 }
 
+@keyframes nudge {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-3px);
+  }
+  40% {
+    transform: translateX(3px);
+  }
+  60% {
+    transform: translateX(-2px);
+  }
+  80% {
+    transform: translateX(2px);
+  }
+}
+
+.animate-nudge {
+  animation: nudge 0.35s ease-out;
+}
+
 @keyframes bounce-subtle {
   0%,
   100% {

--- a/happyhq/components/features/desktop/providers/desktop-initializer.tsx
+++ b/happyhq/components/features/desktop/providers/desktop-initializer.tsx
@@ -2,7 +2,7 @@
 
 import { useCurrentUser } from '@/lib/accounts/hooks'
 import type { ChatMessage } from '@/lib/chat/types'
-import type { DesktopData } from '@/lib/fs/types'
+import type { DesktopData, TaskItem } from '@/lib/fs/types'
 import { FetchError, fetcher } from '@/lib/swr'
 import { desktopDataKey, taskItemsKey } from '@/lib/swr-keys'
 import { useDesktopStore } from '@/stores/desktopStore'
@@ -241,8 +241,21 @@ export function DesktopInitializer() {
   }, [isRunActive, activitySteps, statusLine, mockMode])
 
   // ── Run actions ───────────────────────────────────────────────────
+  // Prefer the task's assigned stream (from the task list cache) over the URL
+  // stream. After the user assigns a stream from inside the panel, the task
+  // cache updates immediately via mutate(taskItemsKey()); the URL only catches
+  // up after router.push completes. Without this preference, start() would
+  // POST `stream: ''` during the window before navigation lands (#256).
+  const { data: allTasks } = useSWR<TaskItem[]>(
+    taskSlug ? taskItemsKey() : null,
+    fetcher,
+  )
+  const taskAssignedStream =
+    (taskSlug && Array.isArray(allTasks)
+      ? (allTasks.find((t) => t.slug === taskSlug)?.frontmatter.stream ?? '')
+      : '') || streamSlug
   const runActions = useRunActions(
-    streamSlug,
+    taskAssignedStream,
     taskSlug ?? '',
     isRunActive,
     token,

--- a/happyhq/components/features/tasks/card/attachments-section.tsx
+++ b/happyhq/components/features/tasks/card/attachments-section.tsx
@@ -4,11 +4,10 @@ import type { PendingFile } from '@/components/features/tasks/hooks/use-optimist
 import { deleteTaskInput } from '@/lib/actions'
 import { ALLOWED_INPUT_ACCEPT } from '@/lib/file-types'
 import type { FileItem } from '@/lib/fs/types'
-import { useTaskStore } from '@/stores/taskStore'
 import type { RefObject } from 'react'
 import { useCallback } from 'react'
 import { AttachmentList } from '../atoms/attachment-list'
-import { useTaskMutate } from '../hooks/use-task-swr'
+import { useActiveTaskSlug, useTaskMutate } from '../hooks/use-task-swr'
 
 interface AttachmentsSectionProps {
   visibleInputs: FileItem[]
@@ -23,12 +22,13 @@ export function AttachmentsSection({
   handleFiles,
   fileInputRef,
 }: AttachmentsSectionProps) {
-  const taskSlug = useTaskStore((s) => s.taskSlug)
+  const taskSlug = useActiveTaskSlug()
   const refresh = useTaskMutate()
 
   const handleDeleteInput = useCallback(
     async (inputName: string) => {
-      await deleteTaskInput(taskSlug!, inputName)
+      if (!taskSlug) return
+      await deleteTaskInput(taskSlug, inputName)
       refresh?.()
     },
     [taskSlug, refresh],

--- a/happyhq/components/features/tasks/card/debug/mock-task-panel.tsx
+++ b/happyhq/components/features/tasks/card/debug/mock-task-panel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useActiveTaskSlug } from '@/components/features/tasks/hooks/use-task-swr'
 import {
   MOCK_BUDGET_STOPPED_CONTENT,
   MOCK_DISCOVERING_STEPS,
@@ -26,7 +27,7 @@ import { mutate } from 'swr'
  * Only rendered in development when a task is expanded.
  */
 export function MockTaskPanel() {
-  const taskSlug = useTaskStore((s) => s.taskSlug)
+  const taskSlug = useActiveTaskSlug()
   const mockMode = useTaskStore((s) => s.mockMode)
   const [activePhase, setActivePhase] = useState<MockPhase | null>(null)
   const [budgetStoppedDuring, setBudgetStoppedDuring] =

--- a/happyhq/components/features/tasks/card/description-section.test.tsx
+++ b/happyhq/components/features/tasks/card/description-section.test.tsx
@@ -9,11 +9,7 @@ const mockState = vi.hoisted(() => ({
 vi.mock('../hooks/use-task-swr', () => ({
   useTaskContentData: () => mockState.content,
   useTaskMutate: () => vi.fn(),
-}))
-
-vi.mock('@/stores/taskStore', () => ({
-  useTaskStore: (selector: (s: { taskSlug: string }) => unknown) =>
-    selector({ taskSlug: 'task-1' }),
+  useActiveTaskSlug: () => 'task-1',
 }))
 
 vi.mock('@/lib/actions', () => ({

--- a/happyhq/components/features/tasks/card/description-section.tsx
+++ b/happyhq/components/features/tasks/card/description-section.tsx
@@ -2,19 +2,25 @@
 
 import { ReadOnlyDescription } from '@/components/features/tasks/atoms/readonly-description'
 import { writeTaskDescription } from '@/lib/actions'
-import { useTaskStore } from '@/stores/taskStore'
 import { useEffect, useRef, useState } from 'react'
-import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
+import {
+  useActiveTaskSlug,
+  useTaskContentData,
+  useTaskMutate,
+} from '../hooks/use-task-swr'
 
 export function DescriptionSection() {
-  const taskSlug = useTaskStore((s) => s.taskSlug)
-  return <EditableDescription key={taskSlug} />
+  const taskSlug = useActiveTaskSlug()
+  // Section only renders inside a route that guarantees [task] is in the URL,
+  // so taskSlug is never null in practice. Early-return narrows the type
+  // instead of forcing `taskSlug!` assertions in the editor below.
+  if (!taskSlug) return null
+  return <EditableDescription key={taskSlug} taskSlug={taskSlug} />
 }
 
-function EditableDescription() {
+function EditableDescription({ taskSlug }: { taskSlug: string }) {
   const content = useTaskContentData()
   const hasRun = !!content?.run?.status
-  const taskSlug = useTaskStore((s) => s.taskSlug)
   const refresh = useTaskMutate()
   const [isEditing, setIsEditing] = useState(false)
 
@@ -57,7 +63,7 @@ function EditableDescription() {
     setDescription(value)
     clearTimeout(descTimerRef.current)
     descTimerRef.current = setTimeout(async () => {
-      await writeTaskDescription(taskSlug!, value)
+      await writeTaskDescription(taskSlug, value)
       refresh?.()
     }, 500)
   }

--- a/happyhq/components/features/tasks/card/index.tsx
+++ b/happyhq/components/features/tasks/card/index.tsx
@@ -7,7 +7,7 @@ import { useTaskStore } from '@/stores/taskStore'
 import { useOptimisticUploads } from '../hooks/use-optimistic-uploads'
 import { useTaskData } from '../hooks/use-task-data'
 import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
-import { canStartIdleTask } from '../start-gate'
+import { idleTaskBlockedHint, idleTaskBlockedReason } from '../start-gate'
 import { AttachmentsSection } from './attachments-section'
 import { DescriptionSection } from './description-section'
 import { OutputsSection } from './outputs-section'
@@ -26,13 +26,16 @@ import { PlanSection } from './plan-section'
  * transforms into the duration label when each phase completes.
  */
 export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
+  // Identity flows from the taskItem prop (which itself comes from the
+  // taskItemsKey() SWR cache up in TaskListHome). No store mirror — that's
+  // what produced the staleness in #256.
+  const taskSlug = taskItem.slug
+  const streamSlug = taskItem.frontmatter.stream ?? null
+  const taskTitle = taskItem.frontmatter.title
+
   // Data lifecycle — SSE activity, run actions, debounced refresh, run-end detection.
   // Lives here (inside SWRConfig boundary) so all useTaskSWR() hooks see data on frame 1.
-  useTaskData({
-    taskSlug: taskItem.slug,
-    streamSlug: taskItem.frontmatter.stream ?? null,
-    taskTitle: taskItem.frontmatter.title,
-  })
+  useTaskData({ taskSlug, streamSlug })
 
   const content = useTaskContentData()
   const refresh = useTaskMutate()
@@ -40,9 +43,6 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
   const runActionsLoading = useTaskStore((s) => s.runActionsLoading)
   const runActionsUpgradeNeeded = useTaskStore((s) => s.runActionsUpgradeNeeded)
   const billingWarning = useTaskStore((s) => s.runActionsBillingWarning)
-  const taskTitle = useTaskStore((s) => s.taskTitle)
-  const taskSlug = useTaskStore((s) => s.taskSlug)
-  const streamSlug = useTaskStore((s) => s.streamSlug)
 
   // Derive status from TaskItem first (instant), SWR content second (may be delayed).
   const runStatus = content?.run?.status ?? taskItem.run?.status ?? null
@@ -75,13 +75,15 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
     enabled: isIdle,
   })
 
-  const canStart = canStartIdleTask({
+  const blockedReason = idleTaskBlockedReason({
     streamSlug,
     title: taskTitle,
     isUploading: uploads.isUploading,
     runActionsLoading,
     runActionsUpgradeNeeded,
   })
+  const canStart = blockedReason == null
+  const blockedHint = idleTaskBlockedHint(blockedReason)
 
   // ── Sections ──────────────────────────────────────────────────────
   const sections: React.ReactNode[] = []
@@ -110,7 +112,7 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
           isDiscovering || isPlanning || isWorking ? 'animate-fade-in-fast' : ''
         }
       >
-        <PlanSection isPlanning={isPlanning} />
+        <PlanSection isPlanning={isPlanning} streamSlug={streamSlug} />
       </div>,
     )
   }
@@ -124,7 +126,7 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
           isDiscovering || isPlanning || isWorking ? 'animate-fade-in-fast' : ''
         }
       >
-        <OutputsSection isWorking={isWorking} />
+        <OutputsSection isWorking={isWorking} streamSlug={streamSlug} />
       </div>,
     )
   }
@@ -180,20 +182,18 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
               <UpgradePrompt variant="inline-small" title="Upgrade" />
             </div>
           )}
-          <div className="flex items-center justify-center px-4 py-2.5">
+          <div className="flex items-center justify-center gap-3 px-4 py-2.5">
             <button
               type="button"
               onClick={() => runStart?.()}
               disabled={!canStart}
-              title={
-                streamSlug == null
-                  ? 'Assign a stream to run this task'
-                  : undefined
-              }
               className="flex h-6 shrink-0 items-center justify-center rounded-full bg-zinc-900 px-3 font-mono text-[10px] font-semibold tracking-wider text-white uppercase transition-colors hover:bg-zinc-800 disabled:opacity-30"
             >
               Start Task
             </button>
+            {blockedHint && (
+              <span className="text-sm text-zinc-500">{blockedHint}</span>
+            )}
           </div>
         </div>
       )}

--- a/happyhq/components/features/tasks/card/index.tsx
+++ b/happyhq/components/features/tasks/card/index.tsx
@@ -7,7 +7,7 @@ import { useTaskStore } from '@/stores/taskStore'
 import { useOptimisticUploads } from '../hooks/use-optimistic-uploads'
 import { useTaskData } from '../hooks/use-task-data'
 import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
-import { idleTaskBlockedHint, idleTaskBlockedReason } from '../start-gate'
+import { canStartIdleTask } from '../start-gate'
 import { AttachmentsSection } from './attachments-section'
 import { DescriptionSection } from './description-section'
 import { OutputsSection } from './outputs-section'
@@ -25,7 +25,15 @@ import { PlanSection } from './plan-section'
  * Activity headers and section headers occupy the same slot — the activity
  * transforms into the duration label when each phase completes.
  */
-export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
+export function TaskCard({
+  taskItem,
+  onAttemptStart,
+}: {
+  taskItem: TaskItem
+  // Fires when the user clicks the Start Task button while it's not yet
+  // satisfied. Lets the parent nudge attention to the hint below the card.
+  onAttemptStart?: () => void
+}) {
   // Identity flows from the taskItem prop (which itself comes from the
   // taskItemsKey() SWR cache up in TaskListHome). No store mirror — that's
   // what produced the staleness in #256.
@@ -75,15 +83,13 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
     enabled: isIdle,
   })
 
-  const blockedReason = idleTaskBlockedReason({
+  const canStart = canStartIdleTask({
     streamSlug,
     title: taskTitle,
     isUploading: uploads.isUploading,
     runActionsLoading,
     runActionsUpgradeNeeded,
   })
-  const canStart = blockedReason == null
-  const blockedHint = idleTaskBlockedHint(blockedReason)
 
   // ── Sections ──────────────────────────────────────────────────────
   const sections: React.ReactNode[] = []
@@ -182,18 +188,26 @@ export function TaskCard({ taskItem }: { taskItem: TaskItem }) {
               <UpgradePrompt variant="inline-small" title="Upgrade" />
             </div>
           )}
-          <div className="flex items-center justify-center gap-3 px-4 py-2.5">
+          <div className="flex items-center justify-center px-4 py-2.5">
             <button
               type="button"
-              onClick={() => runStart?.()}
-              disabled={!canStart}
-              className="flex h-6 shrink-0 items-center justify-center rounded-full bg-zinc-900 px-3 font-mono text-[10px] font-semibold tracking-wider text-white uppercase transition-colors hover:bg-zinc-800 disabled:opacity-30"
+              // aria-disabled (rather than HTML disabled) so the button still
+              // receives the click event when prerequisites aren't met — we
+              // route it to the parent's nudge handler instead of dropping it
+              // silently, which would leave the user wondering why nothing
+              // happened.
+              aria-disabled={!canStart}
+              onClick={() => {
+                if (!canStart) {
+                  onAttemptStart?.()
+                  return
+                }
+                runStart?.()
+              }}
+              className="flex h-6 shrink-0 items-center justify-center rounded-full bg-zinc-900 px-3 font-mono text-[10px] font-semibold tracking-wider text-white uppercase transition-colors hover:bg-zinc-800 aria-disabled:cursor-not-allowed aria-disabled:opacity-30 aria-disabled:hover:bg-zinc-900"
             >
               Start Task
             </button>
-            {blockedHint && (
-              <span className="text-sm text-zinc-500">{blockedHint}</span>
-            )}
           </div>
         </div>
       )}

--- a/happyhq/components/features/tasks/card/outputs-section.tsx
+++ b/happyhq/components/features/tasks/card/outputs-section.tsx
@@ -16,7 +16,11 @@ import { useTaskStore } from '@/stores/taskStore'
 import { useWindowStore } from '@/stores/windowStore'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
+import {
+  useActiveTaskSlug,
+  useTaskContentData,
+  useTaskMutate,
+} from '../hooks/use-task-swr'
 
 /**
  * Outputs/work section — mirrors the panel's work section behavior.
@@ -26,7 +30,13 @@ import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
  *
  * The activity header and section header occupy the same slot.
  */
-export function OutputsSection({ isWorking }: { isWorking?: boolean }) {
+export function OutputsSection({
+  isWorking,
+  streamSlug,
+}: {
+  isWorking?: boolean
+  streamSlug: string | null
+}) {
   const content = useTaskContentData()
   const runApprove = useTaskStore((s) => s.runApprove)
   const runContinue = useTaskStore((s) => s.runContinue)
@@ -35,8 +45,7 @@ export function OutputsSection({ isWorking }: { isWorking?: boolean }) {
   const upgradeNeeded = useTaskStore((s) => s.runActionsUpgradeNeeded)
   const isRunActive = useTaskStore((s) => s.isRunActive)
   const activitySteps = useTaskStore((s) => s.activitySteps)
-  const streamSlug = useTaskStore((s) => s.streamSlug)
-  const taskSlug = useTaskStore((s) => s.taskSlug)
+  const taskSlug = useActiveTaskSlug()
   const isStopping = useTaskStore((s) => s.runActionsStopping)
   const refresh = useTaskMutate()
   const router = useRouter()

--- a/happyhq/components/features/tasks/card/plan-section.tsx
+++ b/happyhq/components/features/tasks/card/plan-section.tsx
@@ -16,7 +16,11 @@ import { useTaskStore } from '@/stores/taskStore'
 import { useWindowStore } from '@/stores/windowStore'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
+import {
+  useActiveTaskSlug,
+  useTaskContentData,
+  useTaskMutate,
+} from '../hooks/use-task-swr'
 
 /**
  * Plan section — mirrors the panel's plan section behavior.
@@ -27,7 +31,13 @@ import { useTaskContentData, useTaskMutate } from '../hooks/use-task-swr'
  * The activity header and section header occupy the same slot — the activity
  * transforms into the duration label when the phase completes.
  */
-export function PlanSection({ isPlanning }: { isPlanning?: boolean }) {
+export function PlanSection({
+  isPlanning,
+  streamSlug,
+}: {
+  isPlanning?: boolean
+  streamSlug: string | null
+}) {
   const content = useTaskContentData()
   const runStatus = content?.run?.status ?? null
   const runStart = useTaskStore((s) => s.runStart)
@@ -36,8 +46,7 @@ export function PlanSection({ isPlanning }: { isPlanning?: boolean }) {
   const runActionsLoading = useTaskStore((s) => s.runActionsLoading)
   const isRunActive = useTaskStore((s) => s.isRunActive)
   const activitySteps = useTaskStore((s) => s.activitySteps)
-  const streamSlug = useTaskStore((s) => s.streamSlug)
-  const taskSlug = useTaskStore((s) => s.taskSlug)
+  const taskSlug = useActiveTaskSlug()
   const isStopping = useTaskStore((s) => s.runActionsStopping)
   const refresh = useTaskMutate()
   const router = useRouter()

--- a/happyhq/components/features/tasks/hooks/use-task-data.ts
+++ b/happyhq/components/features/tasks/hooks/use-task-data.ts
@@ -15,7 +15,6 @@ import { useTerminalErrorToast } from './use-terminal-error-toast'
 interface TaskIdentity {
   taskSlug: string
   streamSlug: string | null
-  taskTitle: string
 }
 
 /**
@@ -23,25 +22,21 @@ interface TaskIdentity {
  * SWR fetch, real-time SSE activity, run actions, debounced refresh,
  * and run-end detection.
  *
- * Lives inside the TaskCard (within the SWRConfig boundary from the
- * route page). Server data is read by section components via
- * useTaskContentData() — SWRConfig fallback ensures data on frame 1.
+ * Identity (taskSlug, streamSlug, title) is read directly from props/SWR by
+ * the card and its sections — see useActiveTaskItem in use-task-swr.ts.
+ * This hook only owns client-only state: run activity + run action handles.
  */
 export function useTaskData(task: TaskIdentity | null) {
   const { token } = useCurrentUser()
   const hasStream = task?.streamSlug != null
   const mockMode = useTaskStore((s) => s.mockMode)
 
-  // ── Reset store when task identity changes ──────────────────────────
-  // useLayoutEffect fires before paint so TaskCard never sees stale data.
-  // Deps on task.taskSlug so the effect re-fires on task switches (not just mount).
+  // ── Reset client-only state when the active task changes ─────────────
+  // useLayoutEffect fires before paint so sections never see leaked SSE
+  // activity from the previous task.
   useLayoutEffect(() => {
     if (!task) return
-    useTaskStore.getState().reset({
-      taskSlug: task.taskSlug,
-      streamSlug: task.streamSlug,
-      taskTitle: task.taskTitle,
-    })
+    useTaskStore.getState().resetForTaskSwitch()
   }, [task?.taskSlug])
 
   // ── SWR fetch for task content ──────────────────────────────────────

--- a/happyhq/components/features/tasks/hooks/use-task-swr.ts
+++ b/happyhq/components/features/tasks/hooks/use-task-swr.ts
@@ -4,17 +4,24 @@ import type { TaskContent } from '@/lib/fs/types'
 import { fetcher } from '@/lib/swr'
 import { taskContentKey } from '@/lib/swr-keys'
 import { useTaskStore } from '@/stores/taskStore'
+import { useParams } from 'next/navigation'
 import useSWR from 'swr'
+
+// Task identity for the home page card surface comes from the URL
+// (`/tasks/inbox/[task]`) — never from a duplicated copy in zustand, never
+// via re-subscribing to the items-list SWR cache (which churns every SSE
+// tick during a run). The URL is the only source that's both authoritative
+// and stable across cache refetches.
+export function useActiveTaskSlug(): string | null {
+  return useParams<{ task?: string }>().task ?? null
+}
 
 /**
  * SWR-backed hook for task card server data.
- * Reads task identity from taskStore (client-only state)
- * and returns the cached content from SWR's global cache.
- *
  * Same pattern as useDesktopData() for the desktop side.
  */
 export function useTaskSWR() {
-  const taskSlug = useTaskStore((s) => s.taskSlug)
+  const taskSlug = useActiveTaskSlug()
 
   const swrKey = taskSlug ? taskContentKey(taskSlug) : null
 

--- a/happyhq/components/features/tasks/list/expanded.tsx
+++ b/happyhq/components/features/tasks/list/expanded.tsx
@@ -3,10 +3,16 @@
 import { TaskCard } from '@/components/features/tasks'
 import type { TaskItem } from '@/lib/fs/types'
 
-export function TaskDetail({ taskItem }: { taskItem: TaskItem }) {
+export function TaskDetail({
+  taskItem,
+  onAttemptStart,
+}: {
+  taskItem: TaskItem
+  onAttemptStart?: () => void
+}) {
   return (
     <div className="rounded-b-md bg-white">
-      <TaskCard taskItem={taskItem} />
+      <TaskCard taskItem={taskItem} onAttemptStart={onAttemptStart} />
     </div>
   )
 }

--- a/happyhq/components/features/tasks/list/task-list-home.tsx
+++ b/happyhq/components/features/tasks/list/task-list-home.tsx
@@ -5,6 +5,10 @@ import { TaskQuickAdd } from '@/components/features/tasks/create/quick-add'
 import { TaskListItemActions } from '@/components/features/tasks/list/actions'
 import { TaskDetail } from '@/components/features/tasks/list/expanded'
 import { TaskListItem } from '@/components/features/tasks/list/item'
+import {
+  idleTaskBlockedHint,
+  idleTaskBlockedReason,
+} from '@/components/features/tasks/start-gate'
 import { useTrackRecentTask } from '@/hooks/use-track-recent'
 import type { TaskItem } from '@/lib/fs/types'
 import { fetcher } from '@/lib/swr'
@@ -12,7 +16,7 @@ import { taskContentKey, taskItemsKey } from '@/lib/swr-keys'
 import { ListChecks } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import useSWR, { preload } from 'swr'
 
 const MockTaskPanel =
@@ -71,6 +75,15 @@ export function TaskListHome({ selectedTask }: { selectedTask?: string } = {}) {
     router.push('/tasks', { scroll: false })
   }
 
+  // Nudge counter — incremented each time a user clicks the disabled Start
+  // Task button. TaskCardHint keys its animated wrapper on this so the CSS
+  // animation auto-fires on the remount. Only one card is expanded at a
+  // time, so a single counter suffices.
+  const [nudgeCounter, setNudgeCounter] = useState(0)
+  const handleAttemptStart = useCallback(() => {
+    setNudgeCounter((c) => c + 1)
+  }, [])
+
   return (
     <div className="flex h-svh flex-col overflow-y-auto">
       <div className="mx-auto flex w-full max-w-3xl flex-col px-6 pt-16 pb-24">
@@ -106,8 +119,16 @@ export function TaskListHome({ selectedTask }: { selectedTask?: string } = {}) {
                         selected={isSelected}
                         onSelect={() => handleSelectTask(task)}
                       />
-                      {isSelected && <TaskDetail taskItem={task} />}
+                      {isSelected && (
+                        <TaskDetail
+                          taskItem={task}
+                          onAttemptStart={handleAttemptStart}
+                        />
+                      )}
                     </div>
+                    {isSelected && (
+                      <TaskCardHint task={task} nudgeCounter={nudgeCounter} />
+                    )}
                   </div>
                 )
               })
@@ -117,6 +138,56 @@ export function TaskListHome({ selectedTask }: { selectedTask?: string } = {}) {
           </div>
         </div>
       </div>
+    </div>
+  )
+}
+
+// Persistent-prerequisite hint shown beneath an expanded idle card. Surfaces
+// only the user-actionable cases that don't resolve on their own (no-title,
+// no-stream). Transient cases (uploading, loading) are left to the disabled
+// button to communicate — they clear in seconds and the attachments area
+// already shows upload progress.
+//
+// The row always renders (with a non-breaking space when there's no hint) so
+// that filling in the missing prerequisite doesn't cause the tasks below to
+// jump up — no layout shift mid-interaction.
+function TaskCardHint({
+  task,
+  nudgeCounter,
+}: {
+  task: TaskItem
+  nudgeCounter: number
+}) {
+  const hasRun = task.run?.status != null
+  const reason = hasRun
+    ? null
+    : idleTaskBlockedReason({
+        streamSlug: task.frontmatter.stream ?? null,
+        title: task.frontmatter.title,
+        isUploading: false,
+        runActionsLoading: false,
+        runActionsUpgradeNeeded: false,
+      })
+  const hint =
+    reason === 'no-title' || reason === 'no-stream'
+      ? idleTaskBlockedHint(reason)
+      : null
+  return (
+    <div className="mt-2 text-center text-xs">
+      {hint ? (
+        // Re-key on nudgeCounter so a click on the disabled Start Task
+        // button remounts this node and the CSS animation auto-fires.
+        // Counter starts at 0 so the first paint doesn't shake.
+        <span
+          key={nudgeCounter}
+          className={nudgeCounter > 0 ? 'animate-nudge inline-block' : ''}
+        >
+          <span className="font-medium text-zinc-600">Hint:</span>{' '}
+          <span className="text-zinc-500">{hint}</span>
+        </span>
+      ) : (
+        ' '
+      )}
     </div>
   )
 }

--- a/happyhq/components/features/tasks/panel/index.tsx
+++ b/happyhq/components/features/tasks/panel/index.tsx
@@ -39,7 +39,10 @@ import {
 import { WorkingRow } from '@/components/features/tasks/atoms/working-row'
 import { useOptimisticUploads } from '@/components/features/tasks/hooks/use-optimistic-uploads'
 import { shouldShowWorkSection } from '@/components/features/tasks/panel/work-gate'
-import { canStartIdleTask } from '@/components/features/tasks/start-gate'
+import {
+  idleTaskBlockedHint,
+  idleTaskBlockedReason,
+} from '@/components/features/tasks/start-gate'
 import {
   deleteFile,
   deleteTaskByLocation,
@@ -790,45 +793,58 @@ export function TaskPanel({
             )}
 
           {/* Start (idle only) — sticky footer outside scroll area */}
-          {!hasRun && (
-            <div className="shrink-0 border-t border-zinc-200 bg-zinc-50">
-              {runActions.upgradeNeeded && (
-                <div className="flex items-center justify-between gap-3 border-b border-violet-300/40 bg-violet-100/60 px-4 py-2">
-                  <span className="text-sm text-violet-800">
-                    Upgrade for more usage
-                  </span>
-                  <UpgradePrompt variant="inline-small" title="Upgrade" />
-                </div>
-              )}
-              {!runActions.upgradeNeeded &&
-                runActions.billingWarning === 'low_balance' && (
-                  <div className="flex items-center justify-between gap-3 border-b border-violet-300/40 bg-violet-100/60 px-4 py-2">
-                    <span className="text-sm text-violet-800">
-                      Less than 5 minutes of usage left
-                    </span>
-                    <UpgradePrompt variant="inline-small" title="Upgrade" />
+          {!hasRun &&
+            (() => {
+              // Read the assigned stream from frontmatter — SWR updates this
+              // immediately on assignment. useStreamSlug() (URL-derived) lags
+              // behind router.push and would leave the button disabled until
+              // the route navigation settles (#256 stale-button report).
+              const assignedStream = activeTask?.frontmatter.stream ?? null
+              const blockedReason = idleTaskBlockedReason({
+                streamSlug: assignedStream,
+                title,
+                isUploading,
+                runActionsLoading: runActions.isLoading,
+                runActionsUpgradeNeeded: runActions.upgradeNeeded,
+              })
+              const blockedHint = idleTaskBlockedHint(blockedReason)
+              return (
+                <div className="shrink-0 border-t border-zinc-200 bg-zinc-50">
+                  {runActions.upgradeNeeded && (
+                    <div className="flex items-center justify-between gap-3 border-b border-violet-300/40 bg-violet-100/60 px-4 py-2">
+                      <span className="text-sm text-violet-800">
+                        Upgrade for more usage
+                      </span>
+                      <UpgradePrompt variant="inline-small" title="Upgrade" />
+                    </div>
+                  )}
+                  {!runActions.upgradeNeeded &&
+                    runActions.billingWarning === 'low_balance' && (
+                      <div className="flex items-center justify-between gap-3 border-b border-violet-300/40 bg-violet-100/60 px-4 py-2">
+                        <span className="text-sm text-violet-800">
+                          Less than 5 minutes of usage left
+                        </span>
+                        <UpgradePrompt variant="inline-small" title="Upgrade" />
+                      </div>
+                    )}
+                  <div className="flex items-center justify-center gap-3 px-4 py-2.5">
+                    <button
+                      type="button"
+                      onClick={() => runActions.start?.()}
+                      disabled={blockedReason != null}
+                      className="flex h-6 shrink-0 items-center justify-center rounded-full bg-zinc-900 px-3 font-mono text-[10px] font-semibold tracking-wider text-white uppercase transition-colors hover:bg-zinc-800 disabled:opacity-30"
+                    >
+                      Start Task
+                    </button>
+                    {blockedHint && (
+                      <span className="text-sm text-zinc-500">
+                        {blockedHint}
+                      </span>
+                    )}
                   </div>
-                )}
-              <div className="flex items-center justify-center px-4 py-2.5">
-                <button
-                  type="button"
-                  onClick={() => runActions.start?.()}
-                  disabled={
-                    !canStartIdleTask({
-                      streamSlug,
-                      title,
-                      isUploading,
-                      runActionsLoading: runActions.isLoading,
-                      runActionsUpgradeNeeded: runActions.upgradeNeeded,
-                    })
-                  }
-                  className="flex h-6 shrink-0 items-center justify-center rounded-full bg-zinc-900 px-3 font-mono text-[10px] font-semibold tracking-wider text-white uppercase transition-colors hover:bg-zinc-800 disabled:opacity-30"
-                >
-                  Start Task
-                </button>
-              </div>
-            </div>
-          )}
+                </div>
+              )
+            })()}
         </div>
 
         {/* Right — metadata sidebar */}

--- a/happyhq/components/features/tasks/panel/index.tsx
+++ b/happyhq/components/features/tasks/panel/index.tsx
@@ -39,10 +39,7 @@ import {
 import { WorkingRow } from '@/components/features/tasks/atoms/working-row'
 import { useOptimisticUploads } from '@/components/features/tasks/hooks/use-optimistic-uploads'
 import { shouldShowWorkSection } from '@/components/features/tasks/panel/work-gate'
-import {
-  idleTaskBlockedHint,
-  idleTaskBlockedReason,
-} from '@/components/features/tasks/start-gate'
+import { canStartIdleTask } from '@/components/features/tasks/start-gate'
 import {
   deleteFile,
   deleteTaskByLocation,
@@ -792,59 +789,50 @@ export function TaskPanel({
               </div>
             )}
 
-          {/* Start (idle only) — sticky footer outside scroll area */}
-          {!hasRun &&
-            (() => {
-              // Read the assigned stream from frontmatter — SWR updates this
-              // immediately on assignment. useStreamSlug() (URL-derived) lags
-              // behind router.push and would leave the button disabled until
-              // the route navigation settles (#256 stale-button report).
-              const assignedStream = activeTask?.frontmatter.stream ?? null
-              const blockedReason = idleTaskBlockedReason({
-                streamSlug: assignedStream,
-                title,
-                isUploading,
-                runActionsLoading: runActions.isLoading,
-                runActionsUpgradeNeeded: runActions.upgradeNeeded,
-              })
-              const blockedHint = idleTaskBlockedHint(blockedReason)
-              return (
-                <div className="shrink-0 border-t border-zinc-200 bg-zinc-50">
-                  {runActions.upgradeNeeded && (
-                    <div className="flex items-center justify-between gap-3 border-b border-violet-300/40 bg-violet-100/60 px-4 py-2">
-                      <span className="text-sm text-violet-800">
-                        Upgrade for more usage
-                      </span>
-                      <UpgradePrompt variant="inline-small" title="Upgrade" />
-                    </div>
-                  )}
-                  {!runActions.upgradeNeeded &&
-                    runActions.billingWarning === 'low_balance' && (
-                      <div className="flex items-center justify-between gap-3 border-b border-violet-300/40 bg-violet-100/60 px-4 py-2">
-                        <span className="text-sm text-violet-800">
-                          Less than 5 minutes of usage left
-                        </span>
-                        <UpgradePrompt variant="inline-small" title="Upgrade" />
-                      </div>
-                    )}
-                  <div className="flex items-center justify-center gap-3 px-4 py-2.5">
-                    <button
-                      type="button"
-                      onClick={() => runActions.start?.()}
-                      disabled={blockedReason != null}
-                      className="flex h-6 shrink-0 items-center justify-center rounded-full bg-zinc-900 px-3 font-mono text-[10px] font-semibold tracking-wider text-white uppercase transition-colors hover:bg-zinc-800 disabled:opacity-30"
-                    >
-                      Start Task
-                    </button>
-                    {blockedHint && (
-                      <span className="text-sm text-zinc-500">
-                        {blockedHint}
-                      </span>
-                    )}
-                  </div>
+          {/* Start (idle only) — sticky footer outside scroll area.
+              Read the assigned stream from frontmatter — SWR updates this
+              immediately on assignment. useStreamSlug() (URL-derived) lags
+              behind router.push and would leave the button disabled until
+              the route navigation settles (#256 stale-button report). */}
+          {!hasRun && (
+            <div className="shrink-0 border-t border-zinc-200 bg-zinc-50">
+              {runActions.upgradeNeeded && (
+                <div className="flex items-center justify-between gap-3 border-b border-violet-300/40 bg-violet-100/60 px-4 py-2">
+                  <span className="text-sm text-violet-800">
+                    Upgrade for more usage
+                  </span>
+                  <UpgradePrompt variant="inline-small" title="Upgrade" />
                 </div>
-              )
-            })()}
+              )}
+              {!runActions.upgradeNeeded &&
+                runActions.billingWarning === 'low_balance' && (
+                  <div className="flex items-center justify-between gap-3 border-b border-violet-300/40 bg-violet-100/60 px-4 py-2">
+                    <span className="text-sm text-violet-800">
+                      Less than 5 minutes of usage left
+                    </span>
+                    <UpgradePrompt variant="inline-small" title="Upgrade" />
+                  </div>
+                )}
+              <div className="flex items-center justify-center px-4 py-2.5">
+                <button
+                  type="button"
+                  onClick={() => runActions.start?.()}
+                  disabled={
+                    !canStartIdleTask({
+                      streamSlug: activeTask?.frontmatter.stream ?? null,
+                      title,
+                      isUploading,
+                      runActionsLoading: runActions.isLoading,
+                      runActionsUpgradeNeeded: runActions.upgradeNeeded,
+                    })
+                  }
+                  className="flex h-6 shrink-0 items-center justify-center rounded-full bg-zinc-900 px-3 font-mono text-[10px] font-semibold tracking-wider text-white uppercase transition-colors hover:bg-zinc-800 disabled:opacity-30"
+                >
+                  Start Task
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Right — metadata sidebar */}

--- a/happyhq/components/features/tasks/start-gate.test.ts
+++ b/happyhq/components/features/tasks/start-gate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { canStartIdleTask } from './start-gate'
+import {
+  canStartIdleTask,
+  idleTaskBlockedHint,
+  idleTaskBlockedReason,
+} from './start-gate'
 
 const READY = {
   streamSlug: 'stream',
@@ -43,5 +47,62 @@ describe('canStartIdleTask', () => {
     expect(canStartIdleTask({ ...READY, runActionsUpgradeNeeded: true })).toBe(
       false,
     )
+  })
+})
+
+describe('idleTaskBlockedReason', () => {
+  it('returns null when startable', () => {
+    expect(idleTaskBlockedReason(READY)).toBeNull()
+  })
+
+  it('reports no-title before no-stream when both are missing', () => {
+    // Title is the most actionable knob: the user is staring at it as they
+    // type. Surface it first.
+    expect(
+      idleTaskBlockedReason({ ...READY, title: '', streamSlug: null }),
+    ).toBe('no-title')
+  })
+
+  it('reports no-stream when title is set but stream is missing', () => {
+    expect(idleTaskBlockedReason({ ...READY, streamSlug: null })).toBe(
+      'no-stream',
+    )
+  })
+
+  it('reports uploading after content prerequisites are met', () => {
+    expect(idleTaskBlockedReason({ ...READY, isUploading: true })).toBe(
+      'uploading',
+    )
+  })
+
+  it('reports loading for in-flight start requests', () => {
+    expect(idleTaskBlockedReason({ ...READY, runActionsLoading: true })).toBe(
+      'loading',
+    )
+  })
+
+  it('reports upgrade-needed when out of quota', () => {
+    expect(
+      idleTaskBlockedReason({ ...READY, runActionsUpgradeNeeded: true }),
+    ).toBe('upgrade-needed')
+  })
+})
+
+describe('idleTaskBlockedHint', () => {
+  it('returns null when nothing is blocking', () => {
+    expect(idleTaskBlockedHint(null)).toBeNull()
+  })
+
+  it('returns user-actionable hints for content reasons', () => {
+    expect(idleTaskBlockedHint('no-title')).toBe('Add a title to start')
+    expect(idleTaskBlockedHint('no-stream')).toBe('Assign a stream to start')
+    expect(idleTaskBlockedHint('uploading')).toBe('Waiting for upload…')
+  })
+
+  it('returns null for reasons surfaced elsewhere', () => {
+    // `loading` is sub-second; `upgrade-needed` already has its own banner
+    // directly above the button.
+    expect(idleTaskBlockedHint('loading')).toBeNull()
+    expect(idleTaskBlockedHint('upgrade-needed')).toBeNull()
   })
 })

--- a/happyhq/components/features/tasks/start-gate.ts
+++ b/happyhq/components/features/tasks/start-gate.ts
@@ -3,24 +3,55 @@
 // inputs so the same idle task can't be enabled on one surface and disabled on
 // the other (issue #255). Discovery fills in any gaps before planning, so
 // title + stream is the only content requirement.
-export function canStartIdleTask({
-  streamSlug,
-  title,
-  isUploading,
-  runActionsLoading,
-  runActionsUpgradeNeeded,
-}: {
+
+type StartGateInput = {
   streamSlug: string | null
   title: string | null | undefined
   isUploading: boolean
   runActionsLoading: boolean
   runActionsUpgradeNeeded: boolean
-}): boolean {
-  return (
-    streamSlug != null &&
-    !!title?.trim() &&
-    !isUploading &&
-    !runActionsLoading &&
-    !runActionsUpgradeNeeded
-  )
+}
+
+export function canStartIdleTask(input: StartGateInput): boolean {
+  return idleTaskBlockedReason(input) == null
+}
+
+// Reasons surfaced as helper text next to the disabled Start Task button (#256).
+// `loading` and `upgrade-needed` are intentionally omitted: loading is
+// sub-second and upgrade has its own banner directly above the button.
+export type IdleTaskBlockedReason =
+  | 'no-title'
+  | 'no-stream'
+  | 'uploading'
+  | 'loading'
+  | 'upgrade-needed'
+
+// Returns the highest-priority reason the button is disabled, or null when
+// startable. Ordered most-actionable first so the user sees the next knob to
+// turn, not a transient state.
+export function idleTaskBlockedReason({
+  streamSlug,
+  title,
+  isUploading,
+  runActionsLoading,
+  runActionsUpgradeNeeded,
+}: StartGateInput): IdleTaskBlockedReason | null {
+  if (!title?.trim()) return 'no-title'
+  if (streamSlug == null) return 'no-stream'
+  if (isUploading) return 'uploading'
+  if (runActionsLoading) return 'loading'
+  if (runActionsUpgradeNeeded) return 'upgrade-needed'
+  return null
+}
+
+const HINT_BY_REASON: Partial<Record<IdleTaskBlockedReason, string>> = {
+  'no-title': 'Add a title to start',
+  'no-stream': 'Assign a stream to start',
+  uploading: 'Waiting for upload…',
+}
+
+export function idleTaskBlockedHint(
+  reason: IdleTaskBlockedReason | null,
+): string | null {
+  return reason ? (HINT_BY_REASON[reason] ?? null) : null
 }

--- a/happyhq/stores/taskStore.ts
+++ b/happyhq/stores/taskStore.ts
@@ -7,14 +7,11 @@ import { create } from 'zustand'
 const EMPTY_STEPS: ActivityStep[] = []
 
 // ── State shape ─────────────────────────────────────────────────────────
-// Client-only state — server data (TaskContent) lives in SWR (see use-task-swr.ts).
+// Client-only state — server data (TaskContent, TaskItem) lives in SWR
+// (see use-task-swr.ts → useActiveTaskItem / useTaskContentData).
+// Per CLAUDE.md, the store holds no server-derived fields.
 
 export interface TaskState {
-  // Task identity
-  taskSlug: string | null
-  streamSlug: string | null
-  taskTitle: string
-
   // Run state (hydrated by useTaskData from useRunActivity — SSE, not server data)
   isRunActive: boolean
   activitySteps: ActivityStep[]
@@ -56,22 +53,15 @@ export interface TaskState {
   }) => void
   setMockMode: (enabled: boolean) => void
 
-  // Reset for task transitions
-  reset: (props: {
-    taskSlug: string
-    streamSlug: string | null
-    taskTitle: string
-  }) => void
+  // Reset client-only state on task transitions (called by useTaskData when
+  // the active task slug changes). Identity is no longer in the store, so
+  // this clears only SSE-derived run state and action handles.
+  resetForTaskSwitch: () => void
 }
 
 // ── Global singleton store ──────────────────────────────────────────────
 
 export const useTaskStore = create<TaskState>()((set) => ({
-  // Task identity
-  taskSlug: null,
-  streamSlug: null,
-  taskTitle: '',
-
   // Run state
   isRunActive: false,
   activitySteps: EMPTY_STEPS,
@@ -120,30 +110,20 @@ export const useTaskStore = create<TaskState>()((set) => ({
 
   setMockMode: (enabled) => set({ mockMode: enabled }),
 
-  reset: ({ taskSlug, streamSlug, taskTitle }) =>
-    set((prev) => {
-      const sameTask = prev.taskSlug === taskSlug
-      return {
-        taskSlug,
-        streamSlug,
-        taskTitle,
-        isRunActive: sameTask ? prev.isRunActive : false,
-        activitySteps: sameTask ? prev.activitySteps : EMPTY_STEPS,
-        statusLine: sameTask ? prev.statusLine : null,
-        mockMode: false,
-        runStart: sameTask ? prev.runStart : null,
-        runStop: sameTask ? prev.runStop : null,
-        runApprove: sameTask ? prev.runApprove : null,
-        runContinue: sameTask ? prev.runContinue : null,
-        runAnswerQuestion: sameTask ? prev.runAnswerQuestion : null,
-        runActionsLoading: sameTask ? prev.runActionsLoading : false,
-        runActionsStopping: sameTask ? prev.runActionsStopping : false,
-        runActionsUpgradeNeeded: sameTask
-          ? prev.runActionsUpgradeNeeded
-          : false,
-        runActionsBillingWarning: sameTask
-          ? prev.runActionsBillingWarning
-          : null,
-      }
+  resetForTaskSwitch: () =>
+    set({
+      isRunActive: false,
+      activitySteps: EMPTY_STEPS,
+      statusLine: null,
+      mockMode: false,
+      runStart: null,
+      runStop: null,
+      runApprove: null,
+      runContinue: null,
+      runAnswerQuestion: null,
+      runActionsLoading: false,
+      runActionsStopping: false,
+      runActionsUpgradeNeeded: false,
+      runActionsBillingWarning: null,
     }),
 }))


### PR DESCRIPTION
## Summary

Closes #256. The "Start Task" button now explains itself when it can't be used, the staleness that left it disabled after assigning a stream is fixed at the root, and clicking the disabled button nudges attention to the hint.

- A `Hint: …` line renders below the expanded card naming the unmet prerequisite (`Add a title to start` / `Assign a stream to start`). Always-rendered slot — no layout shift when the prerequisite is filled in.
- Clicking the button while disabled triggers a brief horizontal shake on the hint. Button switched to `aria-disabled` so the click still fires; handler routes to a nudge callback when the gate isn't satisfied.
- The staleness root cause (the symptom that made the button stay disabled until you closed/reopened the card) was a `useEffect` bridge in `use-task-data.ts` mirroring server-derived identity into the Zustand store, violating CLAUDE.md's "no server data in stores" rule. The bridge is removed: card sections read `taskSlug` from the URL via a new `useActiveTaskSlug()` helper (stable across SWR ticks); `streamSlug` is passed as a one-hop prop from `TaskCard` to the two sections that need it. The store now holds only client-only state.
- Matching fix on the panel surface: `useRunActions` and the disable gate now read the task's assigned stream from frontmatter rather than the URL stream slug, so `start()` posts the correct stream during the window before `router.push` lands.

## Test plan

- [ ] Quick-add a task with no stream → expand it → "Hint: Assign a stream to start" appears below the card.
- [ ] Click the disabled Start Task button → the hint shakes briefly.
- [ ] Assign a stream via the Assign action → the hint disappears (replaced by reserved whitespace, no jump) and Start Task becomes clickable immediately, without closing/reopening the card.
- [ ] Type a title via QuickAdd → no-title case resolves the same way.
- [ ] Switch between expanded tasks → run state and Start callback don't leak from the previous task into the next (the pre-paint cleanup in `use-task-data.ts` is documented as load-bearing for this).
- [ ] Panel surface: open a task with no stream → assign a stream from the sidebar listbox → Start Task enables immediately and posts the correct stream when clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)