### PR TITLE
chore: flip react-hooks/exhaustive-deps to error (closes #269)

### DIFF
--- a/happyhq/eslint.config.mjs
+++ b/happyhq/eslint.config.mjs
@@ -9,7 +9,7 @@ const eslintConfig = [
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       'react/no-unescaped-entities': 'off',
-      'react-hooks/exhaustive-deps': 'warn',
+      'react-hooks/exhaustive-deps': 'error',
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-empty-interface': 'off',
       '@typescript-eslint/no-empty-object-type': 'off',


### PR DESCRIPTION
## Summary

- Final housekeeping PR for #269. The four child PRs (#274, #275, #276, #277) resolved all 13 sites the rule flagged.
- Flips `react-hooks/exhaustive-deps` from `warn` → `error` in `happyhq/eslint.config.mjs` so future regressions fail CI instead of accumulating as warnings.

Closes #269.

## Test plan

- [x] `pnpm --filter=happyhq lint` passes with the rule at `error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)