### PR TITLE
fix: accept web/<domain> shape when deleting task inputs

### DIFF
--- a/happyhq/lib/actions/tasks.test.ts
+++ b/happyhq/lib/actions/tasks.test.ts
@@ -1,0 +1,102 @@
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/constants.server', () => ({
+  HAPPYHQ_ROOT: '/mock/home/HappyHQ',
+}))
+
+const MOCK_ROOT = '/mock/home/HappyHQ'
+
+const { mockAccess, mockRm } = vi.hoisted(() => ({
+  mockAccess: vi.fn(),
+  mockRm: vi.fn(),
+}))
+
+vi.mock('node:fs/promises', () => ({
+  default: { access: mockAccess, rm: mockRm },
+  access: mockAccess,
+  rm: mockRm,
+}))
+
+vi.mock('@/lib/git/sync.server', () => ({
+  commitGitState: vi.fn(),
+}))
+
+vi.mock('@/lib/log.server', () => ({
+  log: vi.fn(),
+}))
+
+import { deleteTaskInput } from './tasks'
+
+describe('deleteTaskInput', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('deletes a single-segment file input', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    mockRm.mockResolvedValue(undefined)
+
+    await deleteTaskInput('task-1', 'project-brief')
+
+    const expected = path.join(
+      MOCK_ROOT,
+      'tasks',
+      'task-1',
+      'inputs',
+      'project-brief',
+    )
+    expect(mockRm).toHaveBeenCalledWith(expected, {
+      recursive: true,
+      force: true,
+    })
+  })
+
+  it('deletes a two-segment web input (web/<domain>)', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    mockRm.mockResolvedValue(undefined)
+
+    await deleteTaskInput('task-1', 'web/planning-wandsworth-gov-uk')
+
+    const expected = path.join(
+      MOCK_ROOT,
+      'tasks',
+      'task-1',
+      'inputs',
+      'web',
+      'planning-wandsworth-gov-uk',
+    )
+    expect(mockRm).toHaveBeenCalledWith(expected, {
+      recursive: true,
+      force: true,
+    })
+  })
+
+  it('rejects traversal attempts in single-segment names', async () => {
+    await expect(deleteTaskInput('task-1', '../escape')).rejects.toThrow(
+      /Invalid input name/,
+    )
+    expect(mockRm).not.toHaveBeenCalled()
+  })
+
+  it('rejects traversal attempts in the web/ domain segment', async () => {
+    await expect(deleteTaskInput('task-1', 'web/..')).rejects.toThrow(
+      /Invalid input name/,
+    )
+    expect(mockRm).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-web two-segment names', async () => {
+    await expect(deleteTaskInput('task-1', 'foo/bar')).rejects.toThrow(
+      /Invalid input name/,
+    )
+    expect(mockRm).not.toHaveBeenCalled()
+  })
+
+  it('rejects three-segment names', async () => {
+    await expect(
+      deleteTaskInput('task-1', 'web/example-com/extra'),
+    ).rejects.toThrow(/Invalid input name/)
+    expect(mockRm).not.toHaveBeenCalled()
+  })
+})

--- a/happyhq/lib/actions/tasks.ts
+++ b/happyhq/lib/actions/tasks.ts
@@ -82,14 +82,28 @@ export async function writeTaskDescription(
   log('task.updated', { task: taskSlug, field: 'description' })
 }
 
-/** Delete a file from a root task's inputs directory. */
+/**
+ * Delete an input from a root task's inputs directory.
+ *
+ * Web inputs surface to the UI as two-segment names (`web/<domain>`) — the
+ * `listFileItems` reader collapses each domain folder into one row. File
+ * inputs are single-segment (`<name>`). Validate each segment independently
+ * so `/` survives the safety check but traversal still doesn't.
+ */
 export async function deleteTaskInput(
   taskSlug: string,
   inputName: string,
 ): Promise<void> {
   assertSafeTaskSlug(taskSlug)
-  assertSafePathSegment(inputName, 'input name')
-  const inputDir = safePath(path.join(taskPath(taskSlug), 'inputs', inputName))
+  const parts = inputName.split('/')
+  if (parts.length === 2 && parts[0] === 'web') {
+    assertSafePathSegment(parts[1], 'input name')
+  } else if (parts.length === 1) {
+    assertSafePathSegment(parts[0], 'input name')
+  } else {
+    throw new Error('Invalid input name')
+  }
+  const inputDir = safePath(path.join(taskPath(taskSlug), 'inputs', ...parts))
   await deleteFileItem(
     inputDir,
     `[tasks/${taskSlug}] Remove input ${inputName}`,


### PR DESCRIPTION
Closes #280

## Why

Web URL inputs surface to the UI with `input.name = "web/<domain>"` (two-segment) — `listFileItems` collapses each domain folder into one row. The delete server action `deleteTaskInput` was written for single-segment file inputs and validated the whole name with `assertSafePathSegment`, whose regex (`/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/`) rejects `/`. Clicking the delete affordance on a web input therefore threw `Invalid input name` and the input was stuck on the task.

The fix splits the input name on `/`, accepts the `web/<domain>` shape by validating each segment independently, and joins the segments back into the path. Single-segment names keep going through the original guard. Anything else (non-`web/` two-segment, three-segment, traversal) is rejected.

## Regression test

`happyhq/lib/actions/tasks.test.ts` — six cases pin the contract: single-segment delete, `web/<domain>` delete, traversal rejection in both segment positions, non-`web/` two-segment rejection, three-segment rejection.

## Visual evidence

Server-only fix. Verified via unit tests (`pnpm test lib/actions/tasks.test.ts` — 6/6 passing) and the full suite (`pnpm test` — 1553/1553 passing). The chain from `AttachmentList.onDelete(input.name)` → `handleDeleteInput` → `deleteTaskInput` is what the issue traced; the bad regex was on the last hop, and the test exercises that hop with the exact `web/<domain>` shape produced by `listFileItems`.

---

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.