### PR TITLE
fix: harden playbook section in stream panel

### DIFF
--- a/happyhq/components/features/streams/panel/index.tsx
+++ b/happyhq/components/features/streams/panel/index.tsx
@@ -84,7 +84,6 @@ export function StreamPanel({
 
             <PlaybookSection
               playbookBody={playbookBody}
-              streamSlug={streamSlug!}
               onOpen={() =>
                 openOrFocusWindow(
                   'playbook',

--- a/happyhq/components/features/streams/sections/playbook-section.tsx
+++ b/happyhq/components/features/streams/sections/playbook-section.tsx
@@ -1,8 +1,5 @@
 'use client'
 
-import { writePlaybookBody } from '@/lib/actions'
-import { invalidateStream } from '@/lib/swr-helpers'
-import { useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
@@ -10,61 +7,17 @@ import remarkGfm from 'remark-gfm'
 
 export function PlaybookSection({
   playbookBody,
-  streamSlug,
   onOpen,
 }: {
   playbookBody: string | null
-  streamSlug: string
   onOpen: () => void
 }) {
-  const [editing, setEditing] = useState(false)
-  const [body, setBody] = useState(playbookBody ?? '')
-  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
-
-  // Flush pending save on unmount
-  useEffect(() => {
-    return () => clearTimeout(timerRef.current)
-  }, [])
-
-  // Auto-focus textarea when entering edit mode
-  useEffect(() => {
-    if (editing && textareaRef.current) {
-      textareaRef.current.focus()
-      // Place cursor at end
-      const len = textareaRef.current.value.length
-      textareaRef.current.setSelectionRange(len, len)
-    }
-  }, [editing])
-
-  const handleChange = (value: string) => {
-    setBody(value)
-    clearTimeout(timerRef.current)
-    timerRef.current = setTimeout(async () => {
-      await writePlaybookBody(streamSlug, value)
-      invalidateStream(streamSlug)
-    }, 500)
-  }
-
-  const handleBlur = () => {
-    setEditing(false)
-    // Flush any pending save immediately
-    if (timerRef.current) {
-      clearTimeout(timerRef.current)
-      timerRef.current = undefined
-      writePlaybookBody(streamSlug, body).then(() =>
-        invalidateStream(streamSlug),
-      )
-    }
-  }
-
-  // Empty state — show textarea with placeholder
-  if (!playbookBody && !editing) {
+  if (!playbookBody) {
     return (
       <div className="px-2 pt-1 pb-3">
         <button
           type="button"
-          onClick={() => setEditing(true)}
+          onClick={onOpen}
           className="w-full px-2 text-left text-xs text-zinc-400 transition-colors hover:text-zinc-600"
         >
           + Write playbook...
@@ -73,43 +26,14 @@ export function PlaybookSection({
     )
   }
 
-  // Editing mode — textarea
-  if (editing) {
-    return (
-      <div className="px-2 pt-1 pb-3">
-        <div className="px-2">
-          <textarea
-            ref={textareaRef}
-            value={body}
-            onChange={(e) => handleChange(e.target.value)}
-            onBlur={handleBlur}
-            rows={8}
-            className="w-full resize-none rounded-lg bg-transparent text-[13px] leading-relaxed text-zinc-600 outline-none placeholder:text-zinc-400"
-            placeholder="Write your playbook..."
-          />
-        </div>
-        <button
-          type="button"
-          onClick={onOpen}
-          className="flex w-full px-2 pt-2"
-        >
-          <span className="text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-600">
-            Open Playbook
-          </span>
-        </button>
-      </div>
-    )
-  }
-
-  // Read mode — rendered preview, click to edit
   return (
-    <div className="px-2 pt-1 pb-3">
+    <div className="min-h-0 px-2 pt-1 pb-3">
       <button
         type="button"
-        onClick={() => setEditing(true)}
-        className="relative w-full cursor-pointer px-2 text-left"
+        onClick={onOpen}
+        className="group relative block w-full cursor-pointer rounded-md px-2 py-1 text-left transition-colors hover:bg-zinc-950/5"
       >
-        <div className="max-h-[12rem] overflow-hidden rounded-lg">
+        <div className="max-h-[12rem] overflow-hidden">
           <div
             className="prose prose-slate prose-q"
             style={
@@ -129,12 +53,12 @@ export function PlaybookSection({
             </Markdown>
           </div>
         </div>
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-white to-transparent" />
-      </button>
-      <button type="button" onClick={onOpen} className="flex w-full px-2 pt-2">
-        <span className="text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-600">
-          Open Playbook
-        </span>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 rounded-b-md bg-gradient-to-t from-white to-transparent transition-opacity group-hover:from-zinc-100 group-hover:opacity-90" />
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100">
+          <span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-zinc-700 shadow-sm ring-1 ring-zinc-950/5">
+            Open Playbook
+          </span>
+        </div>
       </button>
     </div>
   )


### PR DESCRIPTION
Closes #19.

## Summary

- Remove inline-edit mode in the stream panel's playbook section. The section is now a single click target that opens the playbook file window — same outcome from clicking the body or the (now hover-only) "Open Playbook" pill. No more confusable two-affordance UX, no more layout snap from swapping markdown for a fixed 8-row textarea.
- Style the preview like a FileRow on hover: `rounded-md` with the same `hover:bg-zinc-950/5` background, and a centered "Open Playbook" pill that fades in.
- Fix a layout bug surfaced by long playbooks where the section took up its full intrinsic content height (~900px) instead of the visible 12rem clip, pushing Specs/Samples below the fold. Two compounding CSS quirks were responsible:
  - The wrapping flex item's default `min-height: auto` resolves to min-content (which ignores `max-height`). Fixed with `min-h-0` on the wrap.
  - The `<button>` element's default `display: inline-block` uses intrinsic (pre-clip) content height for line-box sizing. Fixed with `block` on the button.

## Test plan

- [x] Open a stream with a long populated playbook. Read-mode preview is capped at 12rem with a fade. Specs/Samples sections sit directly below — no extra empty space, no scroll required to reach them.
- [x] Hover over the playbook preview: rounded background appears (matches FileRow hover), "Open Playbook" pill fades in centered.
- [x] Click anywhere in the playbook preview → opens the playbook window.
- [x] Open a stream with an empty playbook: "+ Write playbook..." button visible; clicking opens the playbook window (with empty content) for editing.
- [x] Confirm no inline-edit mode triggers from any click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)