### PR TITLE
fix: heal stale 'working' runs on read after server crash / HMR

### DIFF
--- a/happyhq/lib/fs/read.server.ts
+++ b/happyhq/lib/fs/read.server.ts
@@ -3,6 +3,7 @@ import { open, readdir, readFile, stat } from 'node:fs/promises'
 import path from 'node:path'
 
 import { HAPPYHQ_ROOT } from '@/lib/constants.server'
+import { healIfStaleRun } from '@/lib/run/loop.server'
 
 import { assessTextQuality } from './assess-quality.server'
 import {
@@ -637,6 +638,9 @@ export async function listAllTaskItems(): Promise<TaskItem[]> {
               // Malformed .run.json — leave as null
             }
           }
+          if (run) {
+            run = await healIfStaleRun(entry.name, run)
+          }
 
           items.push({
             slug: entry.name,
@@ -790,6 +794,9 @@ export async function readTaskContent(
     } catch {
       // Malformed .run.json — return null rather than crashing.
     }
+  }
+  if (run) {
+    run = await healIfStaleRun(taskSlug, run)
   }
 
   return {

--- a/happyhq/lib/run/loop.server.helpers.test.ts
+++ b/happyhq/lib/run/loop.server.helpers.test.ts
@@ -105,9 +105,21 @@ vi.mock('@/lib/config/config.server', () => ({
 import {
   clearStaleRun,
   getActiveDiscoverySessionId,
+  healIfStaleRun,
   setActiveDiscoverySessionId,
   updateRunInfoPendingQuestions,
 } from './loop.server'
+
+// Test-only: poke the module's globalThis-keyed state so we can simulate a
+// live run in this process. Mirrors STATE_KEY in loop.server.ts.
+const STATE_KEY = Symbol.for('__happyhq_run_loop_state__')
+function setActiveRunForTest(stream: string | null, task: string | null): void {
+  const g = globalThis as unknown as Record<symbol, any>
+  const state = g[STATE_KEY]
+  if (!state) throw new Error('loop.server state not initialised')
+  state.activeRunStream = stream
+  state.activeRunTask = task
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -151,10 +163,12 @@ beforeEach(() => {
   mockClearDirectory.mockResolvedValue(undefined)
   mockUpdateTaskMdPending.mockReset().mockResolvedValue(undefined)
   setActiveDiscoverySessionId(null)
+  setActiveRunForTest(null, null)
 })
 
 afterEach(() => {
   setActiveDiscoverySessionId(null)
+  setActiveRunForTest(null, null)
 })
 
 // ---------------------------------------------------------------------------
@@ -327,6 +341,52 @@ describe('clearStaleRun', () => {
 
     await clearStaleRun(taskName)
 
+    expect(mockWriteTextFile).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// healIfStaleRun — lazy on-read self-heal after server crash / HMR
+// ---------------------------------------------------------------------------
+
+describe('healIfStaleRun', () => {
+  it('heals an active-status run with no live loop owner to stopped/lost', async () => {
+    const stale = baseRun({ status: 'working' })
+    mockReadFile.mockResolvedValue(JSON.stringify(stale))
+
+    const healed = await healIfStaleRun(taskName, stale)
+
+    expect(healed).toMatchObject({
+      status: 'stopped',
+      stoppedDuring: 'working',
+      stopReason: 'error',
+      error: 'Run lost (server restarted)',
+    })
+    const write = getLastRunInfoWrite()
+    expect(write).toMatchObject({
+      status: 'stopped',
+      stoppedDuring: 'working',
+      stopReason: 'error',
+      error: 'Run lost (server restarted)',
+    })
+  })
+
+  it('is a no-op when the active run in this process owns the task', async () => {
+    setActiveRunForTest('s1', taskName)
+    const live = baseRun({ status: 'working' })
+
+    const result = await healIfStaleRun(taskName, live)
+
+    expect(result).toBe(live)
+    expect(mockWriteTextFile).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op for terminal-status runs (no liveness check, no write)', async () => {
+    const done = baseRun({ status: 'completed' })
+
+    const result = await healIfStaleRun(taskName, done)
+
+    expect(result).toBe(done)
     expect(mockWriteTextFile).not.toHaveBeenCalled()
   })
 })

--- a/happyhq/lib/run/loop.server.ts
+++ b/happyhq/lib/run/loop.server.ts
@@ -346,6 +346,48 @@ export async function clearStaleRun(taskName: string): Promise<void> {
 }
 
 /**
+ * Lazy self-heal: when a reader observes a task whose `.run.json` claims an
+ * active phase but no live loop in this process owns it, flip it to `stopped`
+ * with `error: 'Run lost (server restarted)'` and return the healed view.
+ *
+ * Why: after a server crash / HMR / `kill -9`, the writer that would have
+ * finalised the run is gone but the on-disk state still says `working`. The
+ * single-active-run-per-process invariant means at most one task workspace-wide
+ * is stale at a time, so this check is O(1) and only writes once per stale read.
+ */
+export async function healIfStaleRun(
+  taskName: string,
+  info: RunInfo,
+): Promise<RunInfo> {
+  if (
+    info.status !== 'discovering' &&
+    info.status !== 'planning' &&
+    info.status !== 'working'
+  ) {
+    return info
+  }
+  const active = getActiveRunInfo()
+  if (active && active.task === taskName) {
+    return info
+  }
+  await clearStaleRun(taskName)
+  const stoppedDuring: RunInfo['stoppedDuring'] =
+    info.status === 'discovering'
+      ? 'discovery'
+      : info.status === 'planning'
+        ? 'planning'
+        : 'working'
+  return {
+    ...info,
+    status: 'stopped',
+    stoppedDuring,
+    stopReason: 'error',
+    error: 'Run lost (server restarted)',
+    pendingQuestions: undefined,
+  }
+}
+
+/**
  * Get info about the currently active run, or null if no run is active.
  * Used by the /api/run/active endpoint so the chat view can show busy state.
  */


### PR DESCRIPTION
Closes #283

## Why

After a dev-server crash / HMR cycle / `kill -9`, a task's `.run.json` can be left claiming `status: working` (or `planning`/`discovering`) while no live loop in this process owns it. The user sees an apparently-running run that will never advance. Today the only recovery is to manually click Stop, which routes through `clearStaleRun()`.

## What

Lazy, on-read self-heal. A new `healIfStaleRun(taskName, info)` in `lib/run/loop.server.ts` checks active status against `getActiveRunInfo()`; if the run claims an active phase but no live loop owns it, it calls `clearStaleRun()` and returns the corrected `RunInfo`. The two reader paths in `lib/fs/read.server.ts` (`readTaskContent` and `listAllTaskItems`) invoke it post-parse. No new state, no boot-time sweep, no logs coupling. Zero overhead until a stale task is read; the single-active-run-per-process invariant means at most one task workspace-wide can be stale at any time.

## Tests

Three new tests in `lib/run/loop.server.helpers.test.ts:347-396` mirror the rubric the issue asks for:
- stale active-status run with no live owner heals to `stopped` + `error: 'Run lost (server restarted)'`
- live-owned run is a no-op (no write)
- terminal-status run is a no-op (no liveness check, no write)

## Exercise

Drove `/api/fs/task?task=hello-test` against the dev server with a hand-rolled stale `.run.json` claiming `status: working`:

```
$ curl -s http://localhost:3030/api/fs/task?task=hello-test
{
  "run": {
    "status": "stopped",
    "stoppedDuring": "working",
    "stopReason": "error",
    "error": "Run lost (server restarted)",
    ...
  }
}
```

On-disk `.run.json` was rewritten to match. Second read returned the same terminal state with no further writes (terminal no-op path).

---

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.