### PR TITLE
fix: stabilize sampleTypes order in listSamples

### DIFF
--- a/happyhq/lib/fs/read.server.test.ts
+++ b/happyhq/lib/fs/read.server.test.ts
@@ -51,6 +51,7 @@ import {
   listChats,
   listDirectory,
   listFileItems,
+  listSamples,
   parseRunInfo,
   readChatJson,
   readStreamContent,
@@ -349,6 +350,45 @@ describe('readStreamContent', () => {
     expect(result.specs).toEqual([])
     expect(result.samples).toEqual([])
     expect(result.sampleTypes).toEqual([])
+  })
+})
+
+// --- listSamples ---
+
+describe('listSamples', () => {
+  it('returns sampleTypes in readdir order regardless of I/O completion order', async () => {
+    // Three categories: 'a', 'b', 'c'. Make 'a' the slowest to resolve and 'c'
+    // the fastest, so push-during-await would shuffle order to ['c', 'b', 'a'].
+    const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+    const delayByCat: Record<string, number> = { a: 30, b: 15, c: 0 }
+
+    mockReaddir.mockImplementation(async (dirPath: unknown) => {
+      const p = dirPath as string
+      if (p.endsWith('/samples'))
+        return [
+          makeDirent('a', true),
+          makeDirent('b', true),
+          makeDirent('c', true),
+        ] as Dirent[]
+      // Inside each category dir: no sample files (keeps the test focused on
+      // sampleTypes order; samples are sorted by mtime separately).
+      return [] as Dirent[]
+    })
+    mockReadFile.mockImplementation(async (filePath: unknown) => {
+      const p = filePath as string
+      const cat = (['a', 'b', 'c'] as const).find((c) =>
+        p.includes(`/samples/${c}/`),
+      )
+      if (cat) await delay(delayByCat[cat])
+      throw enoent()
+    })
+    mockStat.mockResolvedValue(makeStats())
+
+    const first = await listSamples(path.join(MOCK_ROOT, 'samples'))
+    const second = await listSamples(path.join(MOCK_ROOT, 'samples'))
+
+    expect(first.sampleTypes.map((t) => t.slug)).toEqual(['a', 'b', 'c'])
+    expect(second.sampleTypes.map((t) => t.slug)).toEqual(['a', 'b', 'c'])
   })
 })
 

--- a/happyhq/lib/fs/read.server.ts
+++ b/happyhq/lib/fs/read.server.ts
@@ -460,13 +460,12 @@ export async function listSamples(
     (e) => e.isDirectory() && !e.name.startsWith('.'),
   )
 
-  const sampleTypes: SampleType[] = []
   const nested = await Promise.all(
     categories.map(async (cat) => {
       try {
         assertSafePathSegment(cat.name, 'sample category')
       } catch {
-        return []
+        return null
       }
       const catDir = path.join(safeSamplesDir, cat.name)
 
@@ -477,10 +476,10 @@ export async function listSamples(
       ])
 
       const categoryTitle = parseTitle(metaRaw)
-      sampleTypes.push({ slug: cat.name, title: categoryTitle })
+      const type: SampleType = { slug: cat.name, title: categoryTitle }
       const descriptions = indexMd ? parseIndexDescriptions(indexMd) : {}
 
-      return fileItems.map(
+      const items = fileItems.map(
         (item) =>
           ({
             ...item,
@@ -489,10 +488,14 @@ export async function listSamples(
             description: descriptions[item.name] ?? '',
           }) as SampleEntry,
       )
+      return { type, items }
     }),
   )
 
-  const flat = nested.flat()
+  // Order tracks `categories` (deterministic readdir order), not I/O completion
+  // — pushing inside the async callbacks above would shuffle on each call.
+  const sampleTypes = nested.flatMap((n) => (n ? [n.type] : []))
+  const flat = nested.flatMap((n) => (n ? n.items : []))
   flat.sort((a, b) => {
     const dt =
       new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime()


### PR DESCRIPTION
Closes #284

## Root cause

`listSamples` in `happyhq/lib/fs/read.server.ts` mutated the `sampleTypes` array inside the async callback passed to `Promise.all`, so each callback pushed *after* awaiting its own file reads. The resulting order was I/O-completion order, not the deterministic `readdir` order of `categories`. Because SWR refetches stream content on window focus (e.g. opening the playbook window), the Samples section's rows visibly reordered between refetches even though no underlying data changed.

## Fix

Each async callback now returns `{ type, items }`. `sampleTypes` and `flat` are derived from the resolved `nested` array after `Promise.all` settles, so order tracks the input `categories` array. The existing `flat.sort(...)` by `modifiedAt` is unchanged.

## Regression test

`happyhq/lib/fs/read.server.test.ts:357` — staggers per-category mock delays so that without the fix the resolution order would be reversed; asserts `sampleTypes` slugs come back in `readdir` order across two consecutive calls.

## Verification

`pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` all green (1554 tests). The new test exercises the same code path with synthetic I/O timing crafted to trigger the original bug — it fails against the pre-fix implementation and passes after.

---

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.