### PR TITLE
chore: harden QA rubric against rubber-stamping author exercise

### DIFF
--- a/happyhq/.dev/PROMPT_qa_execute.md
+++ b/happyhq/.dev/PROMPT_qa_execute.md
@@ -21,7 +21,7 @@
 4. **Check out the PR's branch.** `gh pr checkout ${PR_NUMBER}` from the qa worktree. If `pnpm-lock.yaml` changed in the diff (`gh pr diff ${PR_NUMBER} --name-only | grep pnpm-lock.yaml`): `pnpm install` from the repo root. Else skip.
 
 5. **Run the verification from the plan's "How to verify" section.** Two cases:
-   - **Litmus test passes — author's testing covers it.** Re-read the cited testing in the PR body / artifacts (`gh pr view ${PR_NUMBER} --comments`). Confirm it actually covers what the plan claimed and that the kind of verification matches the kind of risk (per the rubric's pitfalls). If it doesn't (the plan was wrong), write a quick verification yourself — note the deviation in the qa-pass / qa-fail comment.
+   - **Litmus test passes — author's testing covers it.** Independently reproduce the load-bearing piece of the author's exercise — run their curl, hand-roll their fixture, drive the same UI path. Confirm it actually covers what the plan claimed and that the kind of verification matches the kind of risk (per the rubric's pitfalls). If it doesn't (the plan was wrong), write a quick verification yourself — note the deviation in the qa-pass / qa-fail comment.
    - **Explicit verification steps.** Carry out what the plan describes. The means is whatever the plan named:
      - **Driving UI** → use Playwright MCP tools per `.dev/exercising-the-ui.md`. For any artifacts you create (streams, tasks, uploads), use stream slug `qa-bespoke-${PR_NUMBER}`.
      - **API probe** → curl per CLAUDE.md "Using HappyHQ's API for verification".

--- a/happyhq/.dev/qa-rubric.md
+++ b/happyhq/.dev/qa-rubric.md
@@ -38,6 +38,7 @@ These are failure modes we've actually seen. Name them when they apply; reject t
 - **Smoke as verification.** Smoke is the backstop. It runs the golden path with one fixture; it doesn't verify what changed unless the change is on that exact path.
 - **Prior QA comments as proof.** They're previous verdicts, possibly the verdict being re-evaluated. Read them for context, never count them as the author's testing.
 - **"I tested it thoroughly" without artifacts.** The claim has to be verifiable against embedded evidence — screenshots, log excerpts, output. If it isn't, treat the surface as untested.
+- **Author's exercise transcript as proof.** A curl, log excerpt, or screenshot pasted into the PR body is the author's claim, not your verification. If the PR body says "I ran X and got Y," you run X and confirm Y yourself, or you treat that surface as untested. Re-reading the transcript is not re-running it.
 
 ## What "verify" looks like
 
@@ -112,6 +113,8 @@ These tune _how_ QA runs. Not gates.
 **Cite evidence, always.** Every comment links or quotes specific artifacts. "QA: pass — looked fine" is never the comment; "QA: pass — drove learning-mode entry, observed brief ack and agent proceeding to learn; smoke PASS in 78s" is.
 
 **Read the author's testing skeptically.** The author's exercise is upstream defense, not blank trust. Look at the embedded evidence and judge whether it covers what could break.
+
+**First-hand or it didn't happen.** Every claim in your qa-pass comment must cite something you did — a file you read, a command you ran, a UI you drove. The author's evidence is upstream defense; your evidence is what makes the pass real. If your comment paraphrases the PR body, you haven't done QA.
 
 **A pass isn't just the label.** The comment is the artifact a future reader uses to understand what was verified. Write it so someone reading the PR a month later understands what the QA loop saw.
 


### PR DESCRIPTION
## Why

PR #287's QA pass quoted the author's curl transcript back as evidence rather than re-running it. The rubber-stamp was permitted by two specific bits of wording: the rubric's pitfalls list didn't name "transcript pasted into the PR body" as a failure mode, and PROMPT_qa_execute.md step 5 said *Re-read the cited testing* — which the agent satisfied by reading the body again.

## What

- **New pitfall** in qa-rubric.md: *Author's exercise transcript as proof* — names re-reading vs re-running explicitly.
- **New principle** in qa-rubric.md: *First-hand or it didn't happen* — every qa-pass comment must cite something the QA agent itself did.
- **Step 5 wording** in PROMPT_qa_execute.md: *Re-read the cited testing* → *Independently reproduce the load-bearing piece of the author's exercise*.

No mechanical floor on tool calls — trusting the wording and watching the next batch's behavior.

## Test plan

- [ ] Next QA batch produces qa-pass comments that cite first-hand tool calls (not quoted PR body transcripts)
- [ ] If a quoted-body pass slips through, tighten the prompt further

🤖 Generated with [Claude Code](https://claude.com/claude-code)