### PR TITLE
chore: decouple bugs prompts from rubric, simplify rubric

### DIFF
--- a/happyhq/.dev/PROMPT_bugs_fix.md
+++ b/happyhq/.dev/PROMPT_bugs_fix.md
@@ -1,48 +1,39 @@
 0a. Read @bugs-rubric.md — this is the spec. Apply it literally.
 0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
 0c. The issue you are working: #${ISSUE_NUMBER}. Read it: `gh issue view ${ISSUE_NUMBER} --comments`.
+0d. ${DRY_RUN_NOTE}
+0e. ${OVERRIDE_NOTE}
 
-1. **Reproduce.** Establish the bug locally — write a failing test, or run the steps in the issue and confirm the failure mode. If repro cannot be established from the issue + linked logs + a focused investigation, apply `ralphie:skip-not-reproducible` (rubric rule 7), post the rubric-shaped comment, exit. Use `~/HappyHQ/.logs/$(date +%Y-%m-%d).jsonl` and `npx tsx scripts/read-logs.ts` for runtime logs (see @CLAUDE.md "Debugging Q").
+1. **Reproduce.** Establish the bug locally — write a failing test, or run the steps in the issue and confirm the failure mode. If repro cannot be established from the issue + linked logs + a focused investigation, apply `ralphie:skip-not-reproducible`, post the rubric-shaped comment, exit. Use `~/HappyHQ/.logs/$(date +%Y-%m-%d).jsonl` and `npx tsx scripts/read-logs.ts` for runtime logs (see @CLAUDE.md "Debugging Q").
 
-2. **Understand and form an opinion.** Before branching: trace the symptom to the cause. Read the relevant code paths. Build a mental model of what's actually happening. Then ask honest questions:
-   - Is the report's framing right? Is the cause where the user thinks it is, or somewhere else?
-   - Is this really a bug, or is it intentional behavior the user has mistaken for a bug?
-   - If the fix would be a constraint (cap, limit, truncate, hide), the unbounded behavior has a cause — find it and fix the cause, even when it lives in nearby code. Scope follows the cause: touch nearby code when it's the cause, leave it when it's just adjacent and looks improvable.
-   - Is this one bug, or part of a pattern that should be surfaced separately?
-
-   **If the framing is wrong** (the symptom has a different cause than the report assumes; or the described behavior is intentional) → take the **Rescope path** (rubric Path / "Rescope path" section): file a rephrased child issue with what the loop saw, comment on the original with a link and clear undo instructions, apply `ralphie:skip-needs-rescope` to the original, exit. Do NOT branch or write code.
+2. **Understand and form an opinion.** Before branching: trace the symptom to the cause and judge whether the report's framing is right. If the framing is wrong → take the rubric's Rescope outcome: file a rephrased child issue, comment on the original with a link and clear undo instructions, apply `ralphie:skip-needs-rescope`, exit. Do NOT branch or write code.
 
 3. **Branch.** Once you've confirmed the framing and the cause: `git checkout ${BASE_BRANCH} && git checkout -b fix/${ISSUE_NUMBER}-<short-slug>`. The slug is 2–4 hyphenated words derived from the issue title.
 
-4. **Fix + regression test.** Implement the smallest change that fixes the cause you identified in step 2. Add a regression test that fails before the fix and passes after, **only if there's a behavior contract worth pinning** (see note [3]). Tests verify behavior, not implementation (see @CLAUDE.md). Use Sonnet subagents for parallel reads/searches; use Opus for debugging or architectural calls.
+4. **Fix + regression test.** Implement the fix. Add a regression test that fails before the fix and passes after, only if there's a behavior contract worth pinning per the rubric's "Tests defend behavior, not lines" principle (and see @testing.md). Use Sonnet subagents for parallel reads/searches; use Opus for debugging or architectural calls.
 
-5. **Verify.** From the `happyhq/` directory, run `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test`. If any fail, fix and re-run. If they fail twice, apply `ralphie:skip-verification-failed` (rubric rule 9), post the rubric-shaped comment with the failing output included, exit.
+5. **Verify.** From the `happyhq/` directory, run `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test`. If any fail, fix and re-run. If they fail twice, apply `ralphie:skip-verification-failed`, post the rubric-shaped comment with the failing output included, exit.
 
-5b. **Exercise.** Try the change end-to-end the way a real user would experience it, before opening the PR. Code-only checks (lint/types/test) prove the plumbing; this step proves the behavior. Apply this to every fix — pick the right tool for the surface, don't skip because "it's not a UI change."
+5b. **Validate.** Drive the surface before opening the PR.
 
-- **Exercise the contract the issue describes, at the surface it describes.** If the issue says "user sees X," drive the surface and watch for X. Unit tests below the surface complement the Exercise; they don't replace it.
 - **Read [@.dev/exercising-the-ui.md](.dev/exercising-the-ui.md) first.** It owns the UI-driving knowledge: helpers (`scripts/dev-server.ts`, Playwright MCP), pitfalls (`networkidle` lies in dev mode, hotkeys need focus, dynamic button labels, slow first-compile, route-gated menu items, env-specific slugs), and the routing cheat-sheet. Saves you rediscovering them.
 - Pick the right tool for the surface:
   - **UI-visible** — Playwright MCP tools to drive the affected screen. Capture screenshots.
   - **Server-only** — drive the API per [CLAUDE.md](CLAUDE.md) "Using HappyHQ's API for verification". Capture the relevant log excerpt or API response.
   - **Mixed** (server change with a UI surface, e.g. a toast triggered by a server event) — both.
-- For a **behavior fix**: induce the failure mode the issue describes and confirm the new state appears.
-- For a **behavior-preserving fix**: drive the happy path on each surface you touched and confirm nothing visible regressed.
-- Look at the evidence. Does the issue's user-visible contract actually hold? Sweep for adjacent regressions — the symptom you fixed is one part; "did anything else break" is the other.
 - **A synthetic trigger that hits the same code path is fine.** You're verifying the contract, not the cause. If the natural failure mode is hard to set up, trigger an equivalent one — a `throw` early in the same path, a bogus env var on the spawned process (`FOO= some-command`), a named file moved aside. Cheaper to set up wins.
 - **Restore what you touch.** Three rules:
   - **Named allowlist.** Touch only what you set out to touch.
   - **Atomic restore + watchdog.** `trap 'mv ~/.x.bak ~/.x' EXIT INT TERM` for the foreground, plus a `nohup bash -c 'sleep 600 && [ -f ~/.x.bak ] && mv ~/.x.bak ~/.x' &` watchdog so an abandoned session still restores. For source edits, `git checkout -- <file>` and `git status --short` to confirm clean. Verify the restore before reporting done.
   - **Never touch:** shell/git config, `~/.ssh`, `~/.aws`, `~/.gnupg`, the macOS keychain, anything needing `sudo` / Touch ID. No `rm -rf` in $HOME.
-- **If it doesn't work:** rework once. If still broken on the second attempt, apply `ralphie:skip-cannot-verify` (rubric rule 10) with evidence showing what you saw vs. what was expected, stop the dev server, exit.
+- **If it doesn't work:** rework once. If still broken on the second attempt, apply `ralphie:skip-cannot-verify` with evidence showing what you saw vs. what was expected, stop the dev server, exit.
 - **If you can't reach the surface:** name the tactics you tried and what each produced before applying `ralphie:skip-cannot-verify`. "Moved `~/.x` aside, run completed normally — failure didn't trigger" counts. "Couldn't reach the surface" with no attempt described doesn't. The trail goes in the skip-comment.
 - **If it works:** keep the evidence path(s) — they go in the PR body in step 8. Always stop the dev server when done: `npx tsx scripts/dev-server.ts stop`.
 
-6. **Risk gate.** With the diff in hand, apply the rubric's "Risk gate" decision tree:
-   - Run `git diff --stat origin/main...HEAD -- ':!*.md' ':!*.mdx'`. (Use `origin/main`, not the local `main` ref — when running from a worktree the local `main` may be stale.) Spec/doc updates (`*.md`/`*.mdx`) are excluded from the count — they don't carry the same review burden as code, and bundling them with the fix keeps design and implementation in sync.
-   - If under threshold (≤10 files AND ≤300 net lines added) → proceed to step 7.
-   - If over threshold AND low-risk per the rubric's criteria → proceed to step 7 with a "Why this is over threshold but low risk" section in the PR body.
-   - If over threshold AND high-risk per the rubric's criteria → take the **Split path** (rubric Path B): create child issues, comment on parent, apply `ralphie:split-into-children`, revert the branch (`git checkout ${BASE_BRANCH} && git branch -D fix/${ISSUE_NUMBER}-<slug>`), exit. Do not push.
+6. **Risk gate.** Apply the rubric's risk gate against the diff:
+   - Run `git diff --stat origin/main...HEAD -- ':!*.md' ':!*.mdx'`. (Use `origin/main`, not the local `main` ref — when running from a worktree the local `main` may be stale.)
+   - Ship → proceed to step 7. If the over-threshold-low-risk case applies, add a "Why this is over threshold but low risk" section to the PR body.
+   - Split → take the rubric's Split outcome: create child issues, comment on parent, apply `ralphie:split-into-children`, revert the branch (`git checkout ${BASE_BRANCH} && git branch -D fix/${ISSUE_NUMBER}-<slug>`), exit. Do not push.
 
 7. **Commit.** `git add -A && git commit -m "fix: <one-line summary>\n\nCloses #${ISSUE_NUMBER}"`.
 
@@ -50,7 +41,7 @@
    - `Closes #${ISSUE_NUMBER}`
    - One-paragraph root-cause summary (the **why**)
    - **Deviations from the report's framing** (if any) — what you concluded was actually broken vs. what was reported
-   - **"Why this is over threshold but low risk"** section (if rule 6 sub-case applied)
+   - **"Why this is over threshold but low risk"** section (if that case applied at step 6)
    - Link to the regression test (`<file>:<line>`) if one was written
    - **Visual evidence** — one sentence on what was exercised in step 5b, plus the screenshot(s) or log excerpt(s). For UI changes, upload screenshots via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <screenshot-dir>` and embed the returned URLs as inline `![alt](url)` markdown. For server-only changes, paste the relevant log lines or API response in a fenced block.
    - AI-assistance disclosure per @CONTRIBUTING.md (e.g., "Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.")
@@ -61,21 +52,11 @@
 
    The PR's `Closes #` is the rest of the breadcrumb.
 
-10. **Return to base branch.** `git checkout ${BASE_BRANCH}`. Each session leaves the working tree on `${BASE_BRANCH}` so the next session (or the maintainer) starts from a clean baseline. Apply this on the skip paths too — if you abort and revert in step 6 of the guardrails, end on `${BASE_BRANCH}`.
+10. **Return to base branch.** `git checkout ${BASE_BRANCH}`. Each session leaves the working tree on `${BASE_BRANCH}` so the next session (or the maintainer) starts from a clean baseline. Apply this on the skip paths too — if you abort and revert in step 6, end on `${BASE_BRANCH}`.
 
-11. ${DRY_RUN_NOTE}
+11. Exit.
 
-12. ${OVERRIDE_NOTE}
-
-13. Exit.
-
-**[1]** ONE issue per session. Do not pick up other issues, do not chain. The orchestrator handles the next one.
-**[2]** Hard constraints from @bugs-rubric.md are non-negotiable: never push to `main`, never modify `happyhq/ee/`, `.github/`, CI workflows, lockfiles (beyond what the focused fix demands), or licensing files. If the fix would require any of these, apply `ralphie:skip-out-of-scope` and exit.
-**[3]** A regression test is required _when there is a behavior contract worth pinning_. Apply the litmus test from @testing.md before writing one: "what bug would this catch?" If the only answer is "someone reverted this exact line" (e.g. asserting an asset path equals `/brand/q.svg`, asserting a specific class name, asserting copy text), the test is a vanity test — don't write it. Asset swaps, copy tweaks, and CSS-only fixes are visually verified, not test-locked. If you cannot articulate a user-visible contract the test defends, the fix is either too trivial to need a test, or you haven't found the right contract yet — re-think before writing one.
-**[4]** Tests verify behavior — what the system guarantees to the user. 50 different implementations should pass the same test. Test conditional rendering driven by state, input/output contracts, error paths, security boundaries. Never `toBeTruthy()`, snapshots, "renders without crashing", asserts on specific src/href/class/copy values, or "mock was called" (unless the call IS the contract).
-**[5]** Capture the **why** in the PR body and (if non-obvious) a code comment. Never narrate **what** in comments — well-named code does that.
-**[6]** If you discover the fix requires a schema migration / new env var / new dep / CI change mid-implementation, stop, revert your changes (`git checkout ${BASE_BRANCH} && git branch -D fix/${ISSUE_NUMBER}-...`), apply `ralphie:skip-out-of-scope`, exit.
-**[7]** AI disclosure in the PR body is required by @CONTRIBUTING.md. Never omit it.
-**[8]** When applying any `ralphie:skip-*` label, the comment uses the rubric's "Comment shape" format. Always.
-**[9]** Engage seriously, don't follow the report blindly. A bug report is the user's best guess at what's wrong and where; your job is to read the code and decide whether the framing is right. The "Understand and form an opinion" step (2) is where the real engineering happens — if you skip it and jump straight to fixing, you'll end up fixing symptoms instead of causes. When the framing is wrong, file a rephrased child issue via the Rescope path rather than shipping a wrong-shape fix.
-**[10]** If you're adding a new element to an existing UI surface, check it's distinguishable from neighbors of similar shape.
+**[1]** Honor the rubric's Hard Constraints. If the fix would require modifying anything they forbid, take the Skip path with `ralphie:skip-out-of-scope`.
+**[2]** If you discover mid-implementation that the fix requires a schema migration / new env var / new dep / CI change, stop, revert (`git checkout ${BASE_BRANCH} && git branch -D fix/${ISSUE_NUMBER}-...`), apply `ralphie:skip-out-of-scope`, exit.
+**[3]** When applying any `ralphie:skip-*` label, the comment uses the rubric's "Comment shape" format. Always.
+**[4]** If you're adding a new element to an existing UI surface, check it's distinguishable from neighbors of similar shape.

--- a/happyhq/.dev/PROMPT_bugs_triage.md
+++ b/happyhq/.dev/PROMPT_bugs_triage.md
@@ -1,21 +1,22 @@
 0a. Read @bugs-rubric.md — this is the spec. Apply it literally.
 0b. Read @CLAUDE.md and @CONTRIBUTING.md (repo root) for repo conventions referenced by the rubric.
+0c. ${DRY_RUN_NOTE}
 
-1. Get the queue: `gh issue list --label bug --state open --limit 100 --json number,title,author,labels,body,createdAt --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)]'`. Empty → exit cleanly.
+1. Get the queue: `gh issue list --label bug --state open --limit 100 --json number,title,author,labels,body,createdAt --jq '[.[] | select(.labels | map(.name) | any(startswith("ralphie:")) | not)]'`. Empty → exit 0 silently.
 
-2. For each issue in the queue (oldest first), in parallel where it makes sense (use Sonnet subagents for reads/searches), evaluate against rubric rules 1–6 (the Phase 1 entries). Read the issue body, ALL comments (`gh issue view <#> --comments`), and any linked logs. For rule 2 (third-party), fetch the author association: `gh api repos/:owner/:repo/issues/<#> --jq '.author_association'` — values OWNER and MEMBER are insiders, anything else (CONTRIBUTOR, FIRST_TIMER, NONE, etc.) is third-party. For rule 6 (size estimate), do a focused code search for the symbols/files the issue mentions before deciding.
+2. Walk the queue oldest first. For each issue:
+   - Read the issue body, ALL comments (`gh issue view <#> --comments`), and any linked logs.
+   - Evaluate against the rubric's Skip conditions in order. Bail at the earliest match.
+   - When a condition depends on author association, fetch it: `gh api repos/:owner/:repo/issues/<#> --jq '.author_association'`.
+   - When a condition depends on size, do a focused code search for the symbols/files the issue mentions first.
 
-3. For each issue, choose ONE outcome:
-   - **Skip** (matches a rubric rule): apply the matching `ralphie:skip-*` label and post the comment in the rubric's "Comment shape" format. Use `gh issue edit <#> --add-label "<label>"` and `gh issue comment <#> --body "..."`.
-   - **Eligible** (passes rules 1–6): leave the issue untouched. Unlabeled = queued for Phase 2.
+   Use Sonnet subagents for reads/searches that can run in parallel.
 
-4. ${DRY_RUN_NOTE}
+3. For each issue, one outcome:
+   - **Skip** (a Skip condition matched): `gh issue edit <#> --add-label "<label>"` plus `gh issue comment <#> --body "..."` in the rubric's "Comment shape" format.
+   - **Eligible** (no Skip condition matched): leave it untouched. Unlabeled = queued for the fix loop.
 
-5. When the queue is exhausted, print a one-line summary: `Triaged N issues: X skipped, Y eligible.` Exit.
+4. When the queue is exhausted, print: `Triaged N issues: X skipped, Y eligible.` Exit.
 
-**[1]** Apply the rubric in order. Bail at the earliest stop — don't evaluate rule 6 if rule 1 already trips.
-**[2]** Never write code in this phase. Never branch, commit, push, or open a PR. Triage is read-only on the repo and write-only on GitHub metadata (labels + comments).
-**[3]** A skip comment is for the human, the label is for the next Ralphie. Both are required for a skip.
-**[4]** If the rubric is ambiguous about an issue, lean toward eligible — Phase 2 has its own gates (rules 7–9). False eligibility is cheaper than false skip.
-**[5]** Never apply two `ralphie:*` labels to the same issue. First match wins.
-**[6]** If `gh` returns an empty queue, exit 0 silently. No error, no comment.
+**[1]** Never write code in this phase. Never branch, commit, push, or open a PR. Triage is read-only on the repo and write-only on GitHub metadata (labels + comments).
+**[2]** First match wins — never apply two `ralphie:*` labels to the same issue.

--- a/happyhq/.dev/bugs-rubric.md
+++ b/happyhq/.dev/bugs-rubric.md
@@ -58,7 +58,7 @@ Apply when the issue isn't workable — either before engaging or after a fix at
 - Reporter isn't OWNER/MEMBER and the report lacks repro details a third party would need to provide → `ralphie:skip-third-party-unclear`.
 - Issue body or comments contain unresolved questions for the maintainer → `ralphie:skip-needs-decision`.
 - Requires a schema migration, new env var, new dependency, or `.github/`/CI/workflow change → `ralphie:skip-out-of-scope`.
-- No reasonable repro can be inferred from issue + linked logs, or the repro couldn't be established locally → `ralphie:skip-not-reproducible`.
+- No reasonable repro can be inferred from issue + linked logs, or the repro couldn't be established locally (settle for close-enough — a synthetic trigger, a partial reproduction from logs — when full repro isn't possible; only skip when even close-enough is out of reach) → `ralphie:skip-not-reproducible`.
 - Clearly enormous on a quick code search — well over the size threshold before even starting → `ralphie:skip-too-big`. (Borderline cases: engage anyway; the actual diff will sort Ship vs Split.)
 - After fixing: `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` failed twice → `ralphie:skip-verification-failed`.
 - After fixing: validation against the user-visible contract couldn't be confirmed (failure didn't reproduce, new state didn't appear, regression visible after one rework, or surface unreachable after a concrete reproducer attempt) → `ralphie:skip-cannot-verify`.
@@ -110,5 +110,7 @@ These shape every decision.
 **A fix isn't just the diff.** Leave the surrounding code consistent with the change. If the fix changes documented behavior, update the spec in the same PR. If you notice a pattern across recent issues, surface it for the maintainer. If you skip, leave a rationale specific enough that a human can act on it without re-investigating.
 
 **Capture the why, not the what.** Put the why in the PR body and (if non-obvious) in a code comment. Never narrate what in comments — well-named code does that.
+
+**Validate behavior, not just plumbing.** Code-only checks (lint, types, unit tests) prove the plumbing. Exercise the user-visible contract at the surface where it lives to prove the behavior.
 
 **Tests defend behavior, not lines.** Apply `testing.md`'s litmus: "what bug would this catch?" If the only answer is "someone reverted this exact line" — hardcoded asset paths, class names, copy strings, "this element exists" assertions — it's a vanity test. Skip it. Asset swaps, copy tweaks, and CSS-only fixes are visually verified, not test-locked. If you cannot articulate a user-visible contract the test defends, the fix is either too trivial to need a test, or you haven't found the right contract yet — re-think before writing one.

--- a/happyhq/.dev/bugs-rubric.md
+++ b/happyhq/.dev/bugs-rubric.md
@@ -18,7 +18,8 @@ For every bug, walk these:
 2. **Read the code.** Trace symptom to cause. Don't trust the report's hypothesis; verify it. Look for prior art on this surface — recent issues with the same shape, in-flight PRs, specs documenting the affected behavior.
 3. **Form an opinion.** Sometimes the report is right. Sometimes the symptom is real but the cause lives somewhere else. Sometimes the described behavior is intentional. Your read is the value-add.
 4. **Write the right fix.** The "right thing" is the real cause, not the symptom — don't band-aid past it if the underlying problem is what's broken. The "right way" is the change that leaves the system simpler and clearer than you found it.
-5. **Assess the diff.** With the actual change in hand, judge review risk. The size of the diff is a rough proxy; what touched and how it's tested is the real signal.
+5. **Validate.** Exercise the user-visible contract at the surface where it lives — code-only checks (lint/types/tests) prove the plumbing; this proves the behavior. For a behavior fix, induce the failure and confirm the new state. For a behavior-preserving fix, drive the happy path on each surface you touched. Sweep for adjacent regressions.
+6. **Assess the diff.** With the actual change in hand, judge review risk. The size of the diff is a rough proxy; what touched and how it's tested is the real signal.
 
 Then ask the litmus test again. The honest answer takes one of four shapes — **ship**, **split**, **rescope**, or **skip**.
 
@@ -113,6 +114,12 @@ These tune _how_ the work gets done. Not gates.
 
 **Pattern fit, not pattern match.** If prior art fits, follow it. If it doesn't, don't deform the fix to make it fit. Think about the most appropriate decision given the user experience and the developer experience.
 
+**If you reach for a constraint, look for the cause.** When the fix would be a cap, limit, truncate, or hide, the unbounded behavior has a cause — find it and fix the cause, even when it lives in nearby code. Scope follows the cause: touch nearby code when it's the cause, leave it when it's just adjacent and looks improvable.
+
 **A fix isn't just the diff.** Leave the surrounding code consistent with the change. If the fix changes documented behavior, update the spec in the same PR. If you notice a pattern across recent issues, surface it for the maintainer. If you skip, leave a rationale specific enough that a human can act on it without re-investigating.
 
-**Tests defend behavior, not lines.** Apply `testing.md`'s litmus: "what bug would this catch?" If the only answer is "someone reverted this exact line" — hardcoded asset paths, class names, copy strings, "this element exists" assertions — it's a vanity test. Skip it. Asset swaps, copy tweaks, and CSS-only fixes are visually verified, not test-locked.
+**Capture the why, not the what.** Put the why in the PR body and (if non-obvious) in a code comment. Never narrate what in comments — well-named code does that.
+
+**Tests defend behavior, not lines.** Apply `testing.md`'s litmus: "what bug would this catch?" If the only answer is "someone reverted this exact line" — hardcoded asset paths, class names, copy strings, "this element exists" assertions — it's a vanity test. Skip it. Asset swaps, copy tweaks, and CSS-only fixes are visually verified, not test-locked. If you cannot articulate a user-visible contract the test defends, the fix is either too trivial to need a test, or you haven't found the right contract yet — re-think before writing one.
+
+Tests verify behavior — what the system guarantees to the user. 50 different implementations should pass the same test. Test conditional rendering driven by state, input/output contracts, error paths, security boundaries. Never `toBeTruthy()`, snapshots, "renders without crashing", asserts on specific src/href/class/copy values, or "mock was called" (unless the call IS the contract).

--- a/happyhq/.dev/bugs-rubric.md
+++ b/happyhq/.dev/bugs-rubric.md
@@ -4,24 +4,13 @@ Source of truth for how Ralphie judges open `bug`-labeled issues. Both `PROMPT_b
 
 ## The litmus test
 
-Approach every bug as an engineer who cares about the quality of both the user experience and the developer experience. Ask one question:
+Approach every bug as an engineer who cares about both the user experience and the developer experience. Ask one question:
 
 > **Am I fixing the right thing, the right way?**
 
-Everything else in this rubric is how to answer that honestly. A bug report is the reporter's best guess at what's wrong and where — it's not a script to execute. The work is to figure out what's actually broken, decide whether and how to respond, and see the fix through.
+A bug report is the reporter's best guess. It's not a script to execute. The work is to figure out what's broken, decide whether and how to respond, and see the fix through.
 
-## How to answer the litmus test
-
-For every bug, walk these:
-
-1. **Reproduce it.** The report describes a symptom. Get the symptom to happen — or get as close as the available logs and code allow.
-2. **Read the code.** Trace symptom to cause. Don't trust the report's hypothesis; verify it. Look for prior art on this surface — recent issues with the same shape, in-flight PRs, specs documenting the affected behavior.
-3. **Form an opinion.** Sometimes the report is right. Sometimes the symptom is real but the cause lives somewhere else. Sometimes the described behavior is intentional. Your read is the value-add.
-4. **Write the right fix.** The "right thing" is the real cause, not the symptom — don't band-aid past it if the underlying problem is what's broken. The "right way" is the change that leaves the system simpler and clearer than you found it.
-5. **Validate.** Exercise the user-visible contract at the surface where it lives — code-only checks (lint/types/tests) prove the plumbing; this proves the behavior. For a behavior fix, induce the failure and confirm the new state. For a behavior-preserving fix, drive the happy path on each surface you touched. Sweep for adjacent regressions.
-6. **Assess the diff.** With the actual change in hand, judge review risk. The size of the diff is a rough proxy; what touched and how it's tested is the real signal.
-
-Then ask the litmus test again. The honest answer takes one of four shapes — **ship**, **split**, **rescope**, or **skip**.
+The answer takes one of four shapes — **ship**, **split**, **rescope**, or **skip**.
 
 ## The four outcomes
 
@@ -63,16 +52,16 @@ If the original is purely "this isn't a bug, it's intentional" and there's no un
 
 ### Skip — various `ralphie:skip-*` labels
 
-Bail before engagement when the issue isn't workable. In rough order:
+Apply when the issue isn't workable — either before engaging or after a fix attempt:
 
 - Fix would touch `happyhq/ee/` → `ralphie:skip-ee`.
 - Reporter isn't OWNER/MEMBER and the report lacks repro details a third party would need to provide → `ralphie:skip-third-party-unclear`.
 - Issue body or comments contain unresolved questions for the maintainer → `ralphie:skip-needs-decision`.
 - Requires a schema migration, new env var, new dependency, or `.github/`/CI/workflow change → `ralphie:skip-out-of-scope`.
 - No reasonable repro can be inferred from issue + linked logs, or the repro couldn't be established locally → `ralphie:skip-not-reproducible`.
-- Clearly enormous on a quick code search — well over the size threshold before even starting → `ralphie:skip-too-big`. (Borderline cases: engage and decide at step 5.)
+- Clearly enormous on a quick code search — well over the size threshold before even starting → `ralphie:skip-too-big`. (Borderline cases: engage anyway; the actual diff will sort Ship vs Split.)
 - After fixing: `pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm --filter=happyhq test` failed twice → `ralphie:skip-verification-failed`.
-- After fixing: the exercise step couldn't confirm the user-visible contract (failure didn't reproduce, new state didn't appear, regression visible after one rework, or surface unreachable after a concrete reproducer attempt) → `ralphie:skip-cannot-verify`.
+- After fixing: validation against the user-visible contract couldn't be confirmed (failure didn't reproduce, new state didn't appear, regression visible after one rework, or surface unreachable after a concrete reproducer attempt) → `ralphie:skip-cannot-verify`.
 
 A `ralphie:*` label is terminal. The maintainer removes it to re-queue.
 
@@ -106,20 +95,20 @@ These are failure modes we've seen. Name them when they apply; reject them.
 
 ## Principles
 
-These tune _how_ the work gets done. Not gates.
+These shape every decision.
 
 **Simple, maintainable, understandable.** This is the bar for every fix. If the change makes the system harder to read, harder to change later, or harder for the next person to hold in their head, it's the wrong shape — even if it makes the symptom go away. Optimize for the reader who shows up six months from now with no context.
 
-**When triage is ambiguous, lean toward eligible.** The fix loop has its own gates — false eligibility is cheaper than false skip. A wrong skip closes a door on a real issue; a wrong eligible just means the fix loop does the extra evaluation and bails if it has to.
+**When triage is ambiguous, lean toward eligible.** The fix loop has its own gates — a wrong skip closes a door on a real issue; a wrong eligible just means the fix loop does the extra evaluation and bails if it has to.
 
 **Pattern fit, not pattern match.** If prior art fits, follow it. If it doesn't, don't deform the fix to make it fit. Think about the most appropriate decision given the user experience and the developer experience.
 
 **If you reach for a constraint, look for the cause.** When the fix would be a cap, limit, truncate, or hide, the unbounded behavior has a cause — find it and fix the cause, even when it lives in nearby code. Scope follows the cause: touch nearby code when it's the cause, leave it when it's just adjacent and looks improvable.
+
+**Review risk isn't size.** The size of the diff is a rough proxy; what touched and how it's tested is the real signal. A 12-file mechanical rename can be lower risk than a 30-line edit to critical infrastructure.
 
 **A fix isn't just the diff.** Leave the surrounding code consistent with the change. If the fix changes documented behavior, update the spec in the same PR. If you notice a pattern across recent issues, surface it for the maintainer. If you skip, leave a rationale specific enough that a human can act on it without re-investigating.
 
 **Capture the why, not the what.** Put the why in the PR body and (if non-obvious) in a code comment. Never narrate what in comments — well-named code does that.
 
 **Tests defend behavior, not lines.** Apply `testing.md`'s litmus: "what bug would this catch?" If the only answer is "someone reverted this exact line" — hardcoded asset paths, class names, copy strings, "this element exists" assertions — it's a vanity test. Skip it. Asset swaps, copy tweaks, and CSS-only fixes are visually verified, not test-locked. If you cannot articulate a user-visible contract the test defends, the fix is either too trivial to need a test, or you haven't found the right contract yet — re-think before writing one.
-
-Tests verify behavior — what the system guarantees to the user. 50 different implementations should pass the same test. Test conditional rendering driven by state, input/output contracts, error paths, security boundaries. Never `toBeTruthy()`, snapshots, "renders without crashing", asserts on specific src/href/class/copy values, or "mock was called" (unless the call IS the contract).

--- a/happyhq/.dev/bugs-rubric.md
+++ b/happyhq/.dev/bugs-rubric.md
@@ -46,7 +46,7 @@ Don't push the over-size PR. Instead:
 
 ### Rescope — `ralphie:skip-needs-rescope`
 
-The framing is wrong: the symptom has a different cause than the report assumes, or the described behavior is intentional and not a bug. **This is the most valuable thing the loop does** — converting a misframed report into a workable issue.
+The framing is wrong: the symptom has a different cause than the report assumes, or the described behavior is intentional and not a bug.
 
 File a rephrased child issue: `gh issue create --label bug --title "<rephrased title>" --body "..."`. Body includes:
 
@@ -108,6 +108,8 @@ These are failure modes we've seen. Name them when they apply; reject them.
 These tune _how_ the work gets done. Not gates.
 
 **Simple, maintainable, understandable.** This is the bar for every fix. If the change makes the system harder to read, harder to change later, or harder for the next person to hold in their head, it's the wrong shape — even if it makes the symptom go away. Optimize for the reader who shows up six months from now with no context.
+
+**When triage is ambiguous, lean toward eligible.** The fix loop has its own gates — false eligibility is cheaper than false skip. A wrong skip closes a door on a real issue; a wrong eligible just means the fix loop does the extra evaluation and bails if it has to.
 
 **Pattern fit, not pattern match.** If prior art fits, follow it. If it doesn't, don't deform the fix to make it fit. Think about the most appropriate decision given the user experience and the developer experience.
 


### PR DESCRIPTION
## Summary

Cleans up the boundary between [happyhq/.dev/bugs-rubric.md](happyhq/.dev/bugs-rubric.md) and its two prompts ([PROMPT_bugs_triage.md](happyhq/.dev/PROMPT_bugs_triage.md), [PROMPT_bugs_fix.md](happyhq/.dev/PROMPT_bugs_fix.md)) so that the rubric is the contract (what good looks like, what outcomes mean, what to refuse) and the prompts are one implementation of it (commands, sequence, mechanics).

**Decoupling test:** drop in a different bugs-rubric using the same named outcomes / principles / sections, prompts run unchanged.

### Prompts

- Resync vocabulary: no more "rule N", "Path B", "Phase 1/2" — references named outcomes, sections, and principles instead.
- Cut judgment content that restated rubric criteria (test-quality rules, "engage seriously" framing, threshold numbers, Hard Constraints restatement).
- Move mode preambles (`DRY_RUN_NOTE`, `OVERRIDE_NOTE`) to the top so the mode is established up-front.
- Tighten dense steps (e.g. triage step 2) into per-concern bullets.
- Rename fix prompt step 5b from Exercise → Validate.

### Rubric

- Drop the "How to answer the litmus test" walk — it paralleled the prompt's procedural arc, which is what actually owns the flow.
- Tighten the litmus section.
- New principles to carry contract claims that had no home: **Review risk isn't size**, **Validate behavior, not just plumbing**, **If you reach for a constraint, look for the cause**, **Capture the why, not the what**, **When triage is ambiguous, lean toward eligible**.
- Extend the **Tests defend behavior, not lines** principle with the "can't articulate a contract → re-think before writing" check.
- Restore "settle for close-enough" nuance on the `skip-not-reproducible` bullet.
- Fix Skip section's stale "exercise step" reference and the broken "step 5" pointer in the too-big bullet.
- Replace Principles' overloaded "These tune _how_ the work gets done" framing with "These shape every decision."

## Test plan

- [ ] Read both prompts and confirm no internal rubric numbering, no restated criteria.
- [ ] Read the rubric standalone and confirm it makes sense as a contract without referencing prompt internals.
- [ ] Sanity-check that all `ralphie:skip-*` outcomes and named sections referenced by the prompts still exist in the rubric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)