### PR TITLE
fix: refuse to mount HAPPYHQ_ROOT without a .happyhq marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ A few capabilities are off by default and enabled via env vars (see [`happyhq/.e
 - **User accounts** — sign-in via InstantDB + Google OAuth
 - **Billing** — Stripe-backed subscriptions (requires accounts; lives under `ee/`)
 
+## Local data folder
+
+HappyHQ stores its workspace at `~/HappyHQ` by default. On first run the app creates this folder and writes a `.happyhq` marker (`{"schemaVersion":1}`) so it can tell its own data folder apart from any unrelated directory you might point it at.
+
+Override the location by setting `HAPPYHQ_ROOT` in `happyhq/.env.local`:
+
+```sh
+HAPPYHQ_ROOT="$HOME/Documents/HappyHQ"
+```
+
+If `HAPPYHQ_ROOT` points at a non-empty folder that lacks the marker, the app refuses to mount and prints how to fix it. Note: on macOS the default filesystem is case-insensitive, so `~/happyhq` and `~/HappyHQ` resolve to the same path — if you happen to clone this repo into your home directory, set `HAPPYHQ_ROOT` to a different folder.
+
 ## Common commands
 
 - `pnpm dev` — start the dev server

--- a/happyhq/instrumentation.ts
+++ b/happyhq/instrumentation.ts
@@ -1,5 +1,19 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { ensureDataRoot, DataRootError } =
+      await import('@/lib/fs/data-root.server')
+    try {
+      ensureDataRoot()
+    } catch (error) {
+      if (error instanceof DataRootError) {
+        // Print and stop further startup work. Downstream fs entry points
+        // (e.g. readStreams) re-call ensureDataRoot and throw the cached
+        // error, so the app surfaces the same message to anyone who hits it.
+        console.error(error.message)
+        return
+      }
+      throw error
+    }
     const { initializeGitRepo } = await import('@/lib/git/init.server')
     const { seedQMemory } = await import('@/lib/q/seed.server')
     try {

--- a/happyhq/lib/fs/data-root.server.test.ts
+++ b/happyhq/lib/fs/data-root.server.test.ts
@@ -1,0 +1,100 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockRoot } = vi.hoisted(() => {
+  return { mockRoot: { path: '' } }
+})
+
+vi.mock('@/lib/constants.server', () => ({
+  get HAPPYHQ_ROOT() {
+    return mockRoot.path
+  },
+}))
+
+import {
+  _resetDataRootCacheForTests,
+  DataRootError,
+  ensureDataRoot,
+} from './data-root.server'
+
+let tmpRoot: string
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(path.join(tmpdir(), 'happyhq-data-root-test-'))
+  mockRoot.path = path.join(tmpRoot, 'HappyHQ')
+  _resetDataRootCacheForTests()
+})
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+describe('ensureDataRoot', () => {
+  it('creates the directory and writes the marker on first run', () => {
+    ensureDataRoot()
+    const marker = path.join(mockRoot.path, '.happyhq')
+    expect(() => statSync(marker)).not.toThrow()
+  })
+
+  it('writes the marker when the directory exists but is empty', () => {
+    mkdirSync(mockRoot.path, { recursive: true })
+    ensureDataRoot()
+    const marker = path.join(mockRoot.path, '.happyhq')
+    expect(() => statSync(marker)).not.toThrow()
+  })
+
+  it('proceeds quietly when the marker is already present', () => {
+    mkdirSync(mockRoot.path, { recursive: true })
+    writeFileSync(path.join(mockRoot.path, '.happyhq'), '{"schemaVersion":1}\n')
+    writeFileSync(path.join(mockRoot.path, 'foo'), 'bar')
+    expect(() => ensureDataRoot()).not.toThrow()
+  })
+
+  it('throws when the directory has unrelated content and no marker', () => {
+    mkdirSync(mockRoot.path, { recursive: true })
+    mkdirSync(path.join(mockRoot.path, 'node_modules'))
+    writeFileSync(path.join(mockRoot.path, 'package.json'), '{}')
+    let err: unknown
+    try {
+      ensureDataRoot()
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeInstanceOf(DataRootError)
+    const msg = (err as Error).message
+    expect(msg).toContain('happyhq data folder is not initialized')
+    expect(msg).toContain(mockRoot.path)
+    expect(msg).toContain('node_modules/')
+    expect(msg).toContain('package.json')
+    expect(msg).toContain('source checkout')
+    expect(msg).toContain('HAPPYHQ_ROOT=')
+  })
+
+  it('migrates a pre-marker happyhq root by detecting our .gitignore', () => {
+    mkdirSync(mockRoot.path, { recursive: true })
+    writeFileSync(
+      path.join(mockRoot.path, '.gitignore'),
+      '.DS_Store\n.chats/\n.logs/\n',
+    )
+    mkdirSync(path.join(mockRoot.path, 'tasks'))
+    expect(() => ensureDataRoot()).not.toThrow()
+    expect(() => statSync(path.join(mockRoot.path, '.happyhq'))).not.toThrow()
+  })
+
+  it('caches the failure so subsequent calls throw without re-checking', () => {
+    mkdirSync(mockRoot.path, { recursive: true })
+    writeFileSync(path.join(mockRoot.path, 'stray'), 'x')
+    expect(() => ensureDataRoot()).toThrow(DataRootError)
+    // Even if we clean up the folder, the cached failure still throws.
+    rmSync(path.join(mockRoot.path, 'stray'))
+    expect(() => ensureDataRoot()).toThrow(DataRootError)
+  })
+})

--- a/happyhq/lib/fs/data-root.server.ts
+++ b/happyhq/lib/fs/data-root.server.ts
@@ -14,6 +14,16 @@ import { HAPPYHQ_ROOT } from '@/lib/constants.server'
 const MARKER_FILE = '.happyhq'
 const MARKER_CONTENT = JSON.stringify({ schemaVersion: 1 }, null, 2) + '\n'
 
+/**
+ * Write the `.happyhq` marker into an existing directory. Exposed so tools
+ * that legitimately construct a happyhq data root from scratch (e.g. the
+ * smoke harnesses, which pre-seed content before booting) can declare the
+ * root rather than tripping the ensureDataRoot guard.
+ */
+export function writeDataRootMarker(rootDir: string): void {
+  writeFileSync(path.join(rootDir, MARKER_FILE), MARKER_CONTENT, 'utf-8')
+}
+
 export class DataRootError extends Error {
   constructor(message: string) {
     super(message)
@@ -84,7 +94,7 @@ function runChecks(): void {
 }
 
 function writeMarker(): void {
-  writeFileSync(path.join(HAPPYHQ_ROOT, MARKER_FILE), MARKER_CONTENT, 'utf-8')
+  writeDataRootMarker(HAPPYHQ_ROOT)
 }
 
 function looksLikeHappyhqRoot(entries: string[]): boolean {

--- a/happyhq/lib/fs/data-root.server.ts
+++ b/happyhq/lib/fs/data-root.server.ts
@@ -1,0 +1,147 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { platform } from 'node:os'
+import path from 'node:path'
+
+import { HAPPYHQ_ROOT } from '@/lib/constants.server'
+
+const MARKER_FILE = '.happyhq'
+const MARKER_CONTENT = JSON.stringify({ schemaVersion: 1 }, null, 2) + '\n'
+
+export class DataRootError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DataRootError'
+  }
+}
+
+type EnsureResult = { ok: true } | { ok: false; error: DataRootError }
+let cached: EnsureResult | null = null
+
+/**
+ * Validate that HAPPYHQ_ROOT is a happyhq data folder, not an arbitrary
+ * directory. Throws DataRootError if a non-empty path lacks the `.happyhq`
+ * marker — preventing the app from registering streams against, for example,
+ * a source checkout that happens to share the path (macOS case-insensitive
+ * `~/happyhq` ↔ `~/HappyHQ`).
+ */
+export function ensureDataRoot(): void {
+  if (cached) {
+    if (!cached.ok) throw cached.error
+    return
+  }
+  try {
+    runChecks()
+    cached = { ok: true }
+  } catch (e) {
+    if (e instanceof DataRootError) {
+      cached = { ok: false, error: e }
+    }
+    throw e
+  }
+}
+
+export function _resetDataRootCacheForTests(): void {
+  cached = null
+}
+
+function runChecks(): void {
+  if (!existsSync(HAPPYHQ_ROOT)) {
+    mkdirSync(HAPPYHQ_ROOT, { recursive: true })
+    writeMarker()
+    return
+  }
+  const s = statSync(HAPPYHQ_ROOT)
+  if (!s.isDirectory()) {
+    throw new DataRootError(
+      `HAPPYHQ_ROOT exists but is not a directory: ${HAPPYHQ_ROOT}`,
+    )
+  }
+  const entries = readdirSync(HAPPYHQ_ROOT)
+  if (entries.includes(MARKER_FILE)) return
+  // "Empty" here mirrors readStreams' visibility filter: dot-prefixed entries
+  // (.cache from dev-server, .DS_Store, etc.) never register as streams, so
+  // their presence alone shouldn't block first-run init.
+  const visibleEntries = entries.filter((e) => !e.startsWith('.'))
+  if (visibleEntries.length === 0) {
+    writeMarker()
+    return
+  }
+  // Pre-marker data roots written by older versions: detect via our own
+  // .gitignore (initializeGitRepo writes it deterministically) and migrate
+  // in-place by writing the marker.
+  if (looksLikeHappyhqRoot(entries)) {
+    writeMarker()
+    return
+  }
+  throw new DataRootError(buildError(entries))
+}
+
+function writeMarker(): void {
+  writeFileSync(path.join(HAPPYHQ_ROOT, MARKER_FILE), MARKER_CONTENT, 'utf-8')
+}
+
+function looksLikeHappyhqRoot(entries: string[]): boolean {
+  if (!entries.includes('.gitignore')) return false
+  try {
+    const content = readFileSync(path.join(HAPPYHQ_ROOT, '.gitignore'), 'utf-8')
+    return content.includes('.chats/') && content.includes('.logs/')
+  } catch {
+    return false
+  }
+}
+
+function buildError(entries: string[]): string {
+  const indicators = [
+    '.git',
+    'node_modules',
+    'package.json',
+    'pnpm-workspace.yaml',
+  ]
+  const matched = indicators.filter((n) => entries.includes(n))
+  const looksLikeSource = matched.length > 0
+  const sampleNames = looksLikeSource ? matched : entries.slice(0, 3)
+  const sample = sampleNames.map((name) => {
+    try {
+      return statSync(path.join(HAPPYHQ_ROOT, name)).isDirectory()
+        ? `${name}/`
+        : name
+    } catch {
+      return name
+    }
+  })
+
+  const lines: string[] = []
+  lines.push('')
+  lines.push('✗ happyhq data folder is not initialized')
+  lines.push('')
+  lines.push(`  Path: ${HAPPYHQ_ROOT}`)
+  lines.push(`  Found: ${sample.join(', ')}`)
+  if (looksLikeSource) {
+    lines.push('         (looks like a source checkout, not happyhq data)')
+  }
+  lines.push('')
+  if (platform() === 'darwin') {
+    lines.push('  Note: on macOS, ~/happyhq and ~/HappyHQ are the same path')
+    lines.push(
+      '  (case-insensitive filesystem) — likely you cloned this repo into ~/.',
+    )
+    lines.push('')
+  }
+  lines.push(
+    '  Fix: point happyhq at a different folder. Add this to happyhq/.env.local:',
+  )
+  lines.push('')
+  lines.push('      HAPPYHQ_ROOT="$HOME/Documents/HappyHQ"')
+  lines.push('')
+  lines.push('  Then restart: pnpm dev')
+  lines.push('')
+  lines.push('  More: README → "Local data folder"')
+  return lines.join('\n')
+}

--- a/happyhq/lib/fs/read.server.test.ts
+++ b/happyhq/lib/fs/read.server.test.ts
@@ -30,6 +30,11 @@ const { mockAccess, mockOpen, mockReadFile, mockReaddir, mockStat } =
     }
   })
 
+// readStreams gates on ensureDataRoot; stub it so these tests don't touch the real fs.
+vi.mock('./data-root.server', () => ({
+  ensureDataRoot: vi.fn(),
+}))
+
 vi.mock('node:fs/promises', () => ({
   default: {
     access: mockAccess,

--- a/happyhq/lib/fs/read.server.ts
+++ b/happyhq/lib/fs/read.server.ts
@@ -6,6 +6,7 @@ import { HAPPYHQ_ROOT } from '@/lib/constants.server'
 import { healIfStaleRun } from '@/lib/run/loop.server'
 
 import { assessTextQuality } from './assess-quality.server'
+import { ensureDataRoot } from './data-root.server'
 import {
   assertSafePathSegment,
   safePath,
@@ -834,6 +835,7 @@ export async function streamExists(streamName: string): Promise<boolean> {
  * Returns newest-first by birthtime. Empty array if ~/HappyHQ/ doesn't exist.
  */
 export async function readStreams(): Promise<StreamEntry[]> {
+  ensureDataRoot()
   try {
     const entries = await readdir(HAPPYHQ_ROOT, { withFileTypes: true })
     const streams = await Promise.all(

--- a/happyhq/scripts/smoke-discovery.ts
+++ b/happyhq/scripts/smoke-discovery.ts
@@ -38,6 +38,8 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
+import { writeDataRootMarker } from '../lib/fs/data-root.server'
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -101,6 +103,7 @@ function copyDirSync(from: string, to: string): void {
 
 function seedFixtures(): void {
   fs.mkdirSync(SMOKE_ROOT, { recursive: true, mode: 0o700 })
+  writeDataRootMarker(SMOKE_ROOT)
 
   // Stream fixture (playbook + spec + sample) → ${SMOKE_ROOT}/${STREAM_SLUG}/
   copyDirSync(STREAM_FIXTURE_DIR, path.join(SMOKE_ROOT, STREAM_SLUG))

--- a/happyhq/scripts/smoke-e2e.ts
+++ b/happyhq/scripts/smoke-e2e.ts
@@ -25,6 +25,8 @@ import path from 'node:path'
 
 import { chromium } from 'playwright'
 
+import { writeDataRootMarker } from '../lib/fs/data-root.server'
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -70,6 +72,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
 function seedFixtures(): void {
   fs.mkdirSync(SMOKE_ROOT, { recursive: true, mode: 0o700 })
+  writeDataRootMarker(SMOKE_ROOT)
 
   const streamDir = path.join(SMOKE_ROOT, STREAM_SLUG)
   fs.mkdirSync(path.join(streamDir, 'specs'), { recursive: true })


### PR DESCRIPTION
Closes #294

## Why

On macOS (case-insensitive APFS by default), `~/happyhq` and `~/HappyHQ` resolve to the same path. A developer who cloned this repo into their home directory got every top-level entry (`node_modules`, `scripts`, `package.json`, the inner `happyhq/` workspace) silently registered as a stream by `readStreams()`, and the app broke down trying to walk into things like `node_modules/@types` (invalid path segments). More broadly: any unrelated content in `HAPPYHQ_ROOT` was treated as user data because the root had no positive signal that it _was_ a happyhq folder.

## What this changes

Adds a `.happyhq` marker (`{"schemaVersion":1}`) that distinguishes a happyhq data folder from any arbitrary directory. On startup, `ensureDataRoot()` runs before `initializeGitRepo` and gates `readStreams()`:

- **Missing or visibly-empty** → create the dir, write the marker, proceed (true first run).
- **Marker present** → proceed.
- **Pre-marker happyhq root** → detect via our own `.gitignore` (deterministic content from `initializeGitRepo`) and migrate in place by writing the marker. Existing users don't get locked out.
- **Non-empty without marker** → refuse to mount. Print the actionable error from the issue (path, what was found, macOS clone-into-home note, the `HAPPYHQ_ROOT=` fix). `readStreams()` throws the same error, so the API returns 500 instead of registering arbitrary directories as streams.

"Visibly-empty" mirrors `readStreams`' existing filter: dot-prefixed entries like `.cache/` (which `scripts/dev-server.ts` creates before Next boots) never register as streams, so their presence alone shouldn't block first-run init. The source-checkout indicators (`node_modules`, `package.json`, `pnpm-workspace.yaml`, `.git`) are visible, so the polluted-root case still triggers refuse.

Schema version starts at `1` and only bumps when the on-disk layout deliberately changes (cf. SQLite `user_version`, npm `lockfileVersion`).

## Regression test

[`happyhq/lib/fs/data-root.server.test.ts`](happyhq/lib/fs/data-root.server.test.ts) covers all six branches: first-run mkdir, empty-dir init, marker-present passthrough, polluted-root refuse, pre-marker migration, and failure caching.

## Visual evidence

Drove `/api/fs/streams` against two synthetic roots (matches the issue's "Verification" section):

**Polluted root** (`mkdir -p ~/HappyHQ/node_modules/@types/foo`, `~/HappyHQ/scripts`, `echo {} > ~/HappyHQ/package.json`):

```
$ curl -s http://localhost:3030/api/fs/streams
{"error":"Internal server error"}

# Server log:
✗ happyhq data folder is not initialized

  Path: /tmp/happyhq-294/HappyHQ
  Found: node_modules/, package.json
         (looks like a source checkout, not happyhq data)

  Note: on macOS, ~/happyhq and ~/HappyHQ are the same path
  (case-insensitive filesystem) — likely you cloned this repo into ~/.

  Fix: point happyhq at a different folder. Add this to happyhq/.env.local:

      HAPPYHQ_ROOT="$HOME/Documents/HappyHQ"

  Then restart: pnpm dev

  More: README → "Local data folder"
```

Polluted root's contents unchanged after boot — no `.git`, no `.gitignore`, no marker written. The instrumentation aborts before `initializeGitRepo` runs.

**Fresh root** (empty `/tmp/happyhq-294-fresh/HappyHQ`):

```
$ ls -la /tmp/happyhq-294-fresh/HappyHQ/.happyhq
-rw-r--r-- ... .happyhq
$ cat /tmp/happyhq-294-fresh/HappyHQ/.happyhq
{
  "schemaVersion": 1
}
$ curl -s http://localhost:3030/api/fs/streams
[]
```

Marker written, app boots clean, no streams registered. Git init runs after the marker check, so the data root ends up with the expected `.git/`, `.gitignore`, `.q/`, `.happyhq`.

---

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.