### PR TITLE
fix: clickable stopped Planning/Working labels (#300)

### DIFF
--- a/happyhq/components/features/tasks/card/outputs-section.tsx
+++ b/happyhq/components/features/tasks/card/outputs-section.tsx
@@ -92,6 +92,17 @@ export function OutputsSection({
         ) : stoppedDuringWorking ? (
           <SectionHeader
             label={`Working ${isBudgetStop ? 'paused' : 'stopped'} after ${formatDuration(workDurationMs)}`}
+            onLabelClick={
+              workingSessionIds.length > 0 && streamSlug && taskSlug
+                ? () =>
+                    openChatSessionWindow(
+                      streamSlug,
+                      workingSessionIds,
+                      'Working Session',
+                      `chat-${taskSlug}-working`,
+                    )
+                : undefined
+            }
             rightSlot={
               isBudgetStop ? (
                 <button

--- a/happyhq/components/features/tasks/card/plan-section.tsx
+++ b/happyhq/components/features/tasks/card/plan-section.tsx
@@ -90,6 +90,17 @@ export function PlanSection({
         ) : stoppedDuringPlanning ? (
           <SectionHeader
             label={`Planning ${isBudgetStop ? 'paused' : 'stopped'} after ${formatDuration(planDurationMs)}`}
+            onLabelClick={
+              planningPhase?.sessionId && streamSlug && taskSlug
+                ? () =>
+                    openChatSessionWindow(
+                      streamSlug,
+                      [planningPhase.sessionId],
+                      'Planning Session',
+                      `chat-${taskSlug}-planning`,
+                    )
+                : undefined
+            }
             rightSlot={
               isBudgetStop ? (
                 <button

--- a/happyhq/components/features/tasks/panel/index.tsx
+++ b/happyhq/components/features/tasks/panel/index.tsx
@@ -537,6 +537,17 @@ export function TaskPanel({
                   ) : stoppedDuringPlanning ? (
                     <SectionHeader
                       label={`Planning ${isBudgetStop ? 'paused' : 'stopped'} after ${formatDuration(planDurationMs)}`}
+                      onLabelClick={
+                        planningPhase?.sessionId && streamSlug && taskSlug
+                          ? () =>
+                              openChatSessionWindow(
+                                streamSlug,
+                                [planningPhase.sessionId],
+                                'Planning Session',
+                                `chat-${taskSlug}-planning`,
+                              )
+                          : undefined
+                      }
                       rightSlot={
                         isBudgetStop ? (
                           <button
@@ -663,6 +674,17 @@ export function TaskPanel({
                   ) : stoppedDuringWorking ? (
                     <SectionHeader
                       label={`Working ${isBudgetStop ? 'paused' : 'stopped'} after ${formatDuration(workDurationMs)}`}
+                      onLabelClick={
+                        workingSessionIds.length > 0 && streamSlug && taskSlug
+                          ? () =>
+                              openChatSessionWindow(
+                                streamSlug,
+                                workingSessionIds,
+                                'Working Session',
+                                `chat-${taskSlug}-working`,
+                              )
+                          : undefined
+                      }
                       rightSlot={
                         isBudgetStop ? (
                           <button


### PR DESCRIPTION
Closes #300

## Why

When a run is stopped mid-planning or mid-working, the section header reads "Planning stopped after Xm" / "Working stopped after Xm" — but those labels were inert. The clean-finish equivalents ("Planned" / "Worked") *are* clickable and open the corresponding chat session, so stopping a run silently demoted the affordance at the exact moment the user is most likely to want to look back at what Q was doing.

The session ids (`workingSessionIds`, `planningPhase.sessionId`) were already computed in the same component scope as the clean-finish branch right below — the wiring was simply missing. This change passes the same `onLabelClick` to the `SectionHeader` in the stopped branches, mirroring the clean-finish branch verbatim. Covers both user-stops ("…stopped after…") and budget-stops ("…paused after…") since they share the rendering path.

## Deviations from the report's framing

The issue identified `card/outputs-section.tsx` and `card/plan-section.tsx`. The bug also exists in `panel/index.tsx`, which is the surface actually rendered by the `/<stream>/<task>` route. Without the panel fix, the change isn't visible on the route used to reproduce the bug. Fixed all three; they share the same component pattern.

## Validation

Drove the stopped-planning and stopped-working surfaces via Playwright on synthetic tasks seeded with `.run.json` files for each `stoppedDuring` variant. Clicking the label opens the expected chat session window in both cases.

**Planning stopped → "Planning Session" window opens:**

![300-planning-stopped-opens-chat](https://ralphie.happyhq.com/pr/300/df06ca8d-0108-4ca8-9a8c-6f9fda3f1195/300-planning-stopped-opens-chat.png)

**Working stopped → "Working Session" window opens:**

![300-working-stopped-opens-chat](https://ralphie.happyhq.com/pr/300/df06ca8d-0108-4ca8-9a8c-6f9fda3f1195/300-working-stopped-opens-chat.png)

No regression test added — `SectionHeader`'s `onLabelClick` → button-element switch is already covered by the clean-finish path; this change just mirrors that wiring into two sibling branches. A test would assert "onLabelClick prop is passed" which fails the "what bug would this catch?" litmus.

`pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm test` all pass.

---

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.