### PR TITLE
fix: tighten CreateTask trigger to explicit user request

### DIFF
--- a/happyhq/lib/agents/tools.server.ts
+++ b/happyhq/lib/agents/tools.server.ts
@@ -50,7 +50,7 @@ export function createQsMcpServer(
     tools: [
       tool(
         'CreateTask',
-        'Propose a task for the user. Call only when the user has asked for something to be done — never to react to feedback, agreement, or completion. textContext is the only bridge to planning; it reads cold from disk.',
+        "Propose a task for the user. Call only when the user has explicitly asked for a task — a specific piece of the stream's actual work they want done. Capability questions, output-format discussion, feedback, agreement, and stream improvements aren't tasks. textContext is the only bridge to planning; it reads cold from disk.",
         {
           name: z
             .string()

--- a/happyhq/prompts/general.md
+++ b/happyhq/prompts/general.md
@@ -8,4 +8,4 @@ The user's work lives at `{{WORKSPACE_ROOT}}`. Each stream is a directory with a
 
 If the user wants to change how you handle work in one of their streams, call EnterLearningMode immediately — before reading files or exploring. Don't ask.
 
-When the user wants something done, call CreateTask. Wait for them to ask — feedback, chatter, and stream improvements aren't tasks.
+Call CreateTask only when the user has explicitly asked for a task — a specific piece of the stream's actual work they want done. Capability questions, output-format discussion, feedback, agreement, and stream improvements aren't tasks.

--- a/happyhq/prompts/learning.md
+++ b/happyhq/prompts/learning.md
@@ -59,7 +59,7 @@ One spec per distinct output. A document with sections is still one output — o
 
 ### Suggesting a Task
 
-Learning mode is for learning, not working. When the user asks for a task, check the playbook and spec to understand what's needed and ask questions to make sure you have everything. Then call CreateTask — only after a playbook exists.
+Learning mode is for learning, not working. Call CreateTask only when the user has explicitly asked for a task — a specific piece of the stream's actual work they want done. Capability questions, output-format discussion, feedback, agreement, and stream improvements aren't tasks. When they do ask, check the playbook and spec to understand what's needed and ask questions to make sure you have everything. Then call CreateTask — only after a playbook exists.
 
 textContext is the only thing planning sees from this conversation; make it count. Always pass the `files` array with upload directory slugs. Name the task after the subject or inputs (kebab-case), not the output type. After suggesting, don't keep chatting about it — the handoff is in the user's hands.
 


### PR DESCRIPTION
Closes #303

## Why

Q was firing CreateTask in conversations that weren't task requests — e.g. a learning chat that landed on "the output should be a PDF" produced a task about *figuring out how to produce a PDF*. That's work about the stream, not a use of the stream.

The previous wording across the tool description and two prompts was negative-flavored ("never to react to feedback…") and split across phrasings. The model rounded ambiguous moments — capability discussion, output-format chatter, agreement — toward firing.

## Fix

One positive rule, identical across the three trigger surfaces:

> Call CreateTask only when the user has explicitly asked for a task — a specific piece of the stream's actual work they want done. Capability questions, output-format discussion, feedback, agreement, and stream improvements aren't tasks.

Applied to:

- `happyhq/lib/agents/tools.server.ts` (tool description)
- `happyhq/prompts/general.md`
- `happyhq/prompts/learning.md`

## Validation

Text-only change to LLM instructions; no behavioral contract a unit test can pin. Verified the prompts render and load (lint / types / 1562 unit tests pass). Runtime behavior is non-deterministic and best confirmed by the maintainer in a learning conversation that lands on output-format discussion — per issue #303's verification criteria.

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.