### PR TITLE
fix: surface output constraints in learning + general prompts

### DIFF
--- a/happyhq/prompts/general.md
+++ b/happyhq/prompts/general.md
@@ -9,3 +9,5 @@ The user's work lives at `{{WORKSPACE_ROOT}}`. Each stream is a directory with a
 If the user wants to change how you handle work in one of their streams, call EnterLearningMode immediately — before reading files or exploring. Don't ask.
 
 Call CreateTask only when the user has explicitly asked for a task — a specific piece of the stream's actual work they want done. Capability questions, output-format discussion, feedback, agreement, and stream improvements aren't tasks.
+
+You produce written outputs — documents, notes, plans. You can't produce PDFs, Word docs, slides, or images. If the user asks for something you can't make, say so and offer the closest thing you can (e.g. a document they can save as PDF) — don't agree to it or invent a workaround.

--- a/happyhq/prompts/learning.md
+++ b/happyhq/prompts/learning.md
@@ -21,6 +21,10 @@ Never write to `tasks/*/plan.md`, `tasks/*/working/`, or `tasks/*/outputs/`. The
 
 After writing or updating artifacts: `git add -A && git commit` with a `[stream]` prefix.
 
+### Capabilities
+
+You produce written outputs — documents, notes, plans. You can't produce PDFs, Word docs, slides, or images. If the user asks for something you can't make, say so and offer the closest thing you can (e.g. a document they can save as PDF) — don't agree to it or invent a workaround.
+
 ### Interview
 
 Use AskUserQuestion to ask structured questions with clickable options. Ask 2–3 targeted questions at a time. Read samples before asking — use what you find to propose patterns for the user to confirm or correct.


### PR DESCRIPTION
Closes #304

## Root cause

`working.md` and `planning.md` carry a `CONSTRAINTS:` block listing what the sandbox allows (text outputs only — no `pip/npm/apt`, no `curl/wget`, no compiling). `learning.md` and `general.md` had no equivalent, so chat-mode Q had no awareness of what the run would actually allow. When a user asked for a PDF (or any rendered/compiled output), Q would agree, discuss approaches like HTML→PDF or Python rendering, and create a task — which then churned because every approach got denied at the tool level during working mode.

This puts the same capability/constraints info in `learning.md` and `general.md` (the two surfaces where Q chats with the user and decides whether to call CreateTask), framed for conversation: state the constraint, offer what Q *can* produce, don't propose workarounds that won't run.

## Deviations from the report's framing

Issue suggested `learning.md` (or a shared block). Added the block to `general.md` too — the same over-commit happens in general chat, which also calls CreateTask. Two near-identical paragraphs is lighter than introducing a shared-block mechanism for two files.

No regression test: per the rubric's \"tests defend behavior, not lines,\" asserting that a prompt string contains the substring \"PDF\" is a vanity test. The user-visible contract is what Q says in chat when asked for an unsupported output — that's an LLM-eval shape, not a unit test.

## Visual evidence

Prompt-content change. Verified by lint / check-types / vitest (1562 passing). The behavior contract — \"Q surfaces the constraint and proposes an alternative\" — is what the issue's Verification section calls out; it'll show up in real chats once this lands.

---

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.