### PR TITLE
chore: keep QA screenshots out of the repo, always upload evidence

### DIFF
--- a/happyhq/.dev/PROMPT_qa_execute.md
+++ b/happyhq/.dev/PROMPT_qa_execute.md
@@ -29,18 +29,19 @@
      - **Log inspection** → `npx tsx scripts/read-logs.ts --event=...` per CLAUDE.md "Debugging Q".
      - **Targeted unit test** → `pnpm test <path>` from `happyhq/`.
 
-   Capture evidence as you go: screenshots into `/tmp/qa-bespoke-${PR_NUMBER}/`, log excerpts in working memory, command output in working memory. You'll cite all of it in the comment.
+   Capture evidence as you go: screenshots **only** into `/tmp/qa-bespoke-${PR_NUMBER}/` (never anywhere inside the repo tree — the wrapper's pre-flight guard will reject the next run if it finds stray PNGs), log excerpts in working memory, command output in working memory. You'll cite all of it in the comment.
 
 6. **Run smoke as backstop** — unless the plan's `Backstop:` is `skip`. From `happyhq/`: `pnpm smoke:e2e`. Capture full output (stdout + stderr) — you'll quote the last 30 lines on failure.
 
 7. **Apply the litmus test one final time.** _Are you satisfied with what's been tested?_ If yes → pass. If no (verification failed, smoke failed, or the verification's kind didn't match the risk's kind after all) → fail.
 
-8. **Workspace cleanup** if you used the `qa-bespoke-${PR_NUMBER}` stream slug:
-   - `rm -rf ~/HappyHQ/qa-bespoke-${PR_NUMBER}`. Best-effort — note any failure under an "Artifacts" line in the comment, but don't let cleanup failure change the verdict.
+8. **Upload evidence + workspace cleanup.**
+   - **Upload first, clean up after.** If you captured any screenshots in `/tmp/qa-bespoke-${PR_NUMBER}/`, run `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} /tmp/qa-bespoke-${PR_NUMBER}` and keep the printed R2 URLs for step 9 — pass or fail, embed them in the comment. The comment must stand alone for future readers; "screenshot captured locally" is not citation.
+   - **Then clean up.** If you used the `qa-bespoke-${PR_NUMBER}` stream slug: `rm -rf ~/HappyHQ/qa-bespoke-${PR_NUMBER}`. Also `rm -rf /tmp/qa-bespoke-${PR_NUMBER}` if you wrote screenshots there. Best-effort — note any failure under an "Artifacts" line in the comment, but don't let cleanup failure change the verdict.
 
 9. **Apply the terminal label and post the comment** per the rubric's "Comment shape":
-   - On pass: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-pass"` + `gh pr comment ${PR_NUMBER} --body "..."` using the qa-pass shape. Cite the verification evidence and the smoke result (or `skipped — non-code`).
-   - On fail: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-fail"` + qa-fail comment. Quote the failing step (last 30 log lines on smoke fail). Link the preserved smoke root (`/tmp/happyhq-smoke-*`). Embed any failure screenshot via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <dir>`.
+   - On pass: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-pass"` + `gh pr comment ${PR_NUMBER} --body "..."` using the qa-pass shape. Cite the verification evidence (including the R2 screenshot URLs from step 8) and the smoke result (or `skipped — non-code`).
+   - On fail: `gh pr edit ${PR_NUMBER} --add-label "ralphie:qa-fail"` + qa-fail comment. Quote the failing step (last 30 log lines on smoke fail). Link the preserved smoke root (`/tmp/happyhq-smoke-*`). Embed the R2 screenshot URLs from step 8.
 
    The triage comment stays untouched. If you deviated from the plan, name the deviation in your own qa-pass / qa-fail comment.
 
@@ -56,7 +57,7 @@
 
 **[1]** ONE PR per session. Read its triage plan, run the verification, smoke as backstop, apply the litmus test, label, comment, summarize, exit.
 **[2]** Hard constraints from @qa-rubric.md are non-negotiable: never auto-merge, never push to a PR's branch, never apply both `qa-pass` and `qa-fail` to the same PR, never QA fork PRs (apply `qa-fail` with v1-limitation comment), only operate in the qa worktree.
-**[3]** Cite evidence in every comment — quote smoke output, link the smoke root on failure, embed screenshot URLs (upload via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} <dir>`). Comments are the artifact future-readers consume; they need to stand alone.
+**[3]** Cite evidence in every comment — quote smoke output, link the smoke root on failure, embed screenshot URLs (always upload via `npx tsx scripts/upload-evidence.ts ${PR_NUMBER} /tmp/qa-bespoke-${PR_NUMBER}` when you captured screenshots, pass or fail). Comments are the artifact future-readers consume; they need to stand alone.
 **[4]** Don't return to `${BASE_BRANCH}` or stop the dev server before exiting — the wrapper does both before the next PR.
 **[5]** Bespoke workspace cleanup (`rm -rf ~/HappyHQ/qa-bespoke-${PR_NUMBER}`) IS your job — the wrapper doesn't know what stream slug you used. Run it after any UI-driving verification, even on failure. Best-effort: cleanup failure doesn't change the verdict.
 **[6]** Preserve the smoke root on failure — never delete `/tmp/happyhq-smoke-*` directories yourself.

--- a/happyhq/.dev/qa.sh
+++ b/happyhq/.dev/qa.sh
@@ -97,6 +97,12 @@ if [ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]; then
     exit 1
 fi
 
+# Sweep stray QA screenshot artifacts before the clean-tree check. Prior
+# execute sessions occasionally mis-routed screenshots into the repo instead
+# of /tmp/qa-bespoke-${PR_NUMBER}/, leaving them as untracked files that
+# block the next run. Narrow glob — only qa-*.png directly under .dev/.
+find "$REPO_ROOT/happyhq/.dev" -maxdepth 1 -type f -name 'qa-*.png' -delete 2>/dev/null || true
+
 # Guard against losing uncommitted work — the next step is `git reset --hard`.
 if [ -n "$(git status --porcelain)" ]; then
     echo -e "  ${RED}Error: uncommitted changes in ${REPO_ROOT}. Commit, stash, or discard before running the loop — the next step hard-resets to origin/main.${RESET}" >&2


### PR DESCRIPTION
## Summary

A QA execute session for PR #302 mis-routed screenshots to `happyhq/.dev/qa-302-panel-{planning,working}.png` instead of `/tmp/qa-bespoke-302/`. The next `./qa.sh` run hit the clean-tree pre-flight guard and refused to start. Separately, the pass comment on #302 just said `Artifacts: ~/HappyHQ/qa-bespoke-302* cleaned up` — no R2 URLs, because the prompt only required `upload-evidence.ts` on fail.

- **`PROMPT_qa_execute.md`** — screenshots restricted to `/tmp/qa-bespoke-${PR_NUMBER}/` with an explicit note that stray PNGs in the repo will block the next run. Upload step lifted out of the fail-only branch into an unconditional step 8: if there are screenshots, upload and embed the R2 URLs in the comment regardless of verdict (so future readers don't open a comment that says "screenshot captured locally").
- **`qa.sh`** — pre-flight sweeps `happyhq/.dev/qa-*.png` (narrow glob, `-maxdepth 1`) before the clean-tree check so this artifact class self-heals.

## Test plan

- [ ] Next `./qa.sh` run from `happyhq-qa` starts cleanly (no leftover PNGs blocking it).
- [ ] A passing QA session that captured screenshots posts a comment containing `ralphie.happyhq.com/pr/...` URLs, not "screenshot captured locally".
- [ ] If an execute session ever drops a `qa-*.png` into `happyhq/.dev/`, the next run silently sweeps it instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)