### PR TITLE
fix: route chat Start Task bubble through Discovery

### DIFF
--- a/happyhq/components/features/desktop/hooks/use-chat-actions.ts
+++ b/happyhq/components/features/desktop/hooks/use-chat-actions.ts
@@ -319,7 +319,7 @@ export function useChatActions(): ChatActions {
           frontmatter: null,
           description: null,
           run: {
-            status: 'planning' as const,
+            status: 'discovering' as const,
             startedAt: now,
             lastIterationAt: now,
             phases: [],
@@ -348,7 +348,7 @@ export function useChatActions(): ChatActions {
         body: JSON.stringify({
           stream: streamSlug ?? undefined,
           task: slug,
-          mode: 'planning',
+          mode: 'discovery',
         }),
       }).catch(() => {})
 


### PR DESCRIPTION
Closes #309

## Root cause

Discovery shipped as the first phase of a task run. The task-panel Start button correctly posts `mode: 'discovery'` and seeds the optimistic cache with `status: 'discovering'` ([use-run-actions.ts:241-263](happyhq/components/features/desktop/hooks/use-run-actions.ts#L241-L263)). The chat "Start Task" bubble's `startTask` was still hardcoded to `mode: 'planning'` / `status: 'planning'` ([use-chat-actions.ts:292-358](happyhq/components/features/desktop/hooks/use-chat-actions.ts#L292-L358)) — a leftover from before Discovery existed — so bubble-started tasks silently skipped Discovery. Two lines: flip the mode in the POST body and the optimistic seed status to match the panel path.

Input plumbing (`textContext`, `files`) is already handled upstream: `createTaskFromChat` calls `createTask` with the description and `setupTaskFromChat` to move the chat uploads into the task's inputs before `startTask` fires, so Discovery receives both without re-asking.

## Verification

- `pnpm format`, `pnpm lint`, `pnpm check-types`, `pnpm --filter=happyhq test` (1568 tests) all pass.
- No regression test added — the change is a 2-line string-constant flip that mirrors the panel path. Per `bugs-rubric.md`'s "Tests defend behavior, not lines": the only assertion would be `mode === 'discovery'`, which is what someone reverting the exact line would already break — a vanity test. The receiving API/run-loop discovery path is already covered by `pnpm smoke:discovery`.
- Driving the bubble end-to-end requires a real chat session where Q surfaces a `CreateTask` tool call, which is stochastic + costly. The fix is verifiable by inspection against the tested panel path it now mirrors.

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.