### PR TITLE
fix(loops): scope dev-server/vitest kills to the loop's worktree

### DIFF
--- a/happyhq/.dev/PROMPT_dependency_upgrade.md
+++ b/happyhq/.dev/PROMPT_dependency_upgrade.md
@@ -27,7 +27,7 @@ If yes, this session uses **elevated scrutiny**: investigation needs to be thoro
      1. Start the server in the background: `(cd ../happyhq && PORT=${SMOKE_PORT} pnpm dev > /tmp/dev-${SMOKE_PORT}.log 2>&1 &)` — or use the Bash tool's `run_in_background: true` with the same command (preferred — gives you a task ID to stop cleanly).
      2. Wait for ready: poll `until curl -sf http://localhost:${SMOKE_PORT}/api/auth/status > /dev/null 2>&1; do sleep 2; done` with the Monitor tool, OR manually re-curl every few seconds. Don't blind-`sleep 30`.
      3. Run the test: `PORT=${SMOKE_PORT} npx tsx scripts/smoke-test.ts`.
-     4. Kill the server: TaskStop on the background task ID, or `pkill -f "next dev"` as a fallback.
+     4. Kill the server: TaskStop on the background task ID, or as a fallback `lsof -ti :${SMOKE_PORT} | xargs kill 2>/dev/null` (port-scoped — do NOT use `pkill -f "next dev"`, that kills the maintainer's own dev server too).
 
 4. **Branch on the result:**
 

--- a/happyhq/.dev/dependency.sh
+++ b/happyhq/.dev/dependency.sh
@@ -122,11 +122,25 @@ git fetch origin --quiet || { echo -e "  ${RED}git fetch failed${RESET}" >&2; ex
 git reset --hard origin/main >/dev/null || { echo -e "  ${RED}git reset failed${RESET}" >&2; exit 1; }
 (cd "$REPO_ROOT" && (pnpm install --frozen-lockfile || pnpm install)) || { echo -e "  ${RED}pnpm install failed${RESET}" >&2; exit 1; }
 
+# Kill processes matching $1 whose cwd is under $REPO_ROOT — i.e. only
+# processes this loop spawned, not the user's own dev/test runs in a
+# sibling worktree.
+kill_scoped() {
+    local pattern="$1"
+    local pid cwd
+    for pid in $(pgrep -f "$pattern" 2>/dev/null); do
+        cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}')
+        if [[ -n "$cwd" && "$cwd" == "$REPO_ROOT"* ]]; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+}
+
 cleanup() {
     echo -e "\n${DIM}Cleaning up child processes...${RESET}"
     pkill -P $$ 2>/dev/null
-    pkill -f "node.*vitest" 2>/dev/null
-    pkill -f "next dev" 2>/dev/null
+    kill_scoped "node.*vitest"
+    kill_scoped "next dev"
     exit 0
 }
 trap cleanup SIGINT SIGTERM
@@ -230,9 +244,10 @@ while [ $DEPS_DONE -lt $MAX_DEPS ]; do
         exit 1
     fi
 
-    # Clean up any orphaned vitest/dev-server processes from the session
-    pkill -f "node.*vitest" 2>/dev/null || true
-    pkill -f "next dev" 2>/dev/null || true
+    # Clean up any orphaned vitest/dev-server processes from the session.
+    # Scoped by cwd so we don't kill the user's own dev/test runs.
+    kill_scoped "node.*vitest"
+    kill_scoped "next dev"
     sleep 1
 done
 

--- a/happyhq/.dev/loop.sh
+++ b/happyhq/.dev/loop.sh
@@ -17,10 +17,28 @@ RESET='\033[0m'
 
 STATS_FILE=$(mktemp /tmp/loop-stats.XXXXXX)
 
+# Loop.sh is invoked from a worktree's repo root (where pnpm test runs).
+# Capture it so kill_scoped can match processes by cwd.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Kill processes matching $1 whose cwd is under $REPO_ROOT — i.e. only
+# processes this loop spawned, not the user's own dev/test runs in a
+# sibling worktree.
+kill_scoped() {
+    local pattern="$1"
+    local pid cwd
+    for pid in $(pgrep -f "$pattern" 2>/dev/null); do
+        cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}')
+        if [[ -n "$cwd" && "$cwd" == "$REPO_ROOT"* ]]; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+}
+
 cleanup() {
     echo -e "\nCleaning up child processes..."
     pkill -P $$ 2>/dev/null
-    pkill -f "node.*vitest" 2>/dev/null
+    kill_scoped "node.*vitest"
     rm -f "$STATS_FILE"
     print_grand_total
     exit 0
@@ -190,7 +208,7 @@ while true; do
     read_stats
 
     # Clean up any orphaned vitest/node workers from this iteration
-    pkill -f "node.*vitest" 2>/dev/null || true
+    kill_scoped "node.*vitest"
     sleep 1
 
     # Show what was committed this iteration

--- a/happyhq/.dev/qa.sh
+++ b/happyhq/.dev/qa.sh
@@ -115,12 +115,27 @@ git fetch origin --quiet || { echo -e "  ${RED}git fetch failed${RESET}" >&2; ex
 git reset --hard origin/main >/dev/null || { echo -e "  ${RED}git reset failed${RESET}" >&2; exit 1; }
 (cd "$REPO_ROOT" && (pnpm install --frozen-lockfile || pnpm install)) || { echo -e "  ${RED}pnpm install failed${RESET}" >&2; exit 1; }
 
+# Kill processes matching $1 whose cwd is under $REPO_ROOT — i.e. only
+# processes this loop spawned, not the user's own dev/test runs in a
+# sibling worktree.
+kill_scoped() {
+    local pattern="$1"
+    local pid cwd
+    for pid in $(pgrep -f "$pattern" 2>/dev/null); do
+        cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}')
+        if [[ -n "$cwd" && "$cwd" == "$REPO_ROOT"* ]]; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+}
+
 cleanup() {
     echo -e "\n${DIM}Cleaning up child processes...${RESET}"
     pkill -P $$ 2>/dev/null
-    pkill -f "next dev" 2>/dev/null
-    pkill -f "node.*vitest" 2>/dev/null
+    kill_scoped "node.*vitest"
     # Stop any lingering dev server from a smoke run mid-execute.
+    # dev-server.ts is PID-file-scoped per cwd hash, so this only kills
+    # the server this loop started — not the user's own `pnpm dev`.
     (cd "$REPO_ROOT/happyhq" && npx tsx scripts/dev-server.ts stop 2>/dev/null) || true
     exit 0
 }
@@ -252,7 +267,6 @@ done
 git -C "$REPO_ROOT" checkout "$BASE_BRANCH" >/dev/null 2>&1 || true
 git -C "$REPO_ROOT" reset --hard origin/main >/dev/null 2>&1 || true
 (cd "$REPO_ROOT/happyhq" && npx tsx scripts/dev-server.ts stop 2>/dev/null) || true
-pkill -f "next dev" 2>/dev/null || true
 
 echo -e "\n  ${GREEN}✓${RESET} QA pass complete. PRs processed: ${QUEUE_COUNT}$([ $ERROR_COUNT -gt 0 ] && echo " (${ERROR_COUNT} errors)")"
 echo -e "  ${DIM}Per-PR outcomes posted as labels and comments on each PR.${RESET}"

--- a/happyhq/.dev/tech-debt.sh
+++ b/happyhq/.dev/tech-debt.sh
@@ -115,10 +115,24 @@ git fetch origin --quiet || { echo -e "  ${RED}git fetch failed${RESET}" >&2; ex
 git reset --hard origin/main >/dev/null || { echo -e "  ${RED}git reset failed${RESET}" >&2; exit 1; }
 (cd "$REPO_ROOT" && (pnpm install --frozen-lockfile || pnpm install)) || { echo -e "  ${RED}pnpm install failed${RESET}" >&2; exit 1; }
 
+# Kill processes matching $1 whose cwd is under $REPO_ROOT — i.e. only
+# processes this loop spawned, not the user's own dev/test runs in a
+# sibling worktree.
+kill_scoped() {
+    local pattern="$1"
+    local pid cwd
+    for pid in $(pgrep -f "$pattern" 2>/dev/null); do
+        cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}')
+        if [[ -n "$cwd" && "$cwd" == "$REPO_ROOT"* ]]; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+}
+
 cleanup() {
     echo -e "\n${DIM}Cleaning up child processes...${RESET}"
     pkill -P $$ 2>/dev/null
-    pkill -f "node.*vitest" 2>/dev/null
+    kill_scoped "node.*vitest"
     exit 0
 }
 trap cleanup SIGINT SIGTERM
@@ -216,7 +230,7 @@ while [ $ISSUES_DONE -lt $MAX_ISSUES ]; do
         exit 1
     fi
 
-    pkill -f "node.*vitest" 2>/dev/null || true
+    kill_scoped "node.*vitest"
     sleep 1
 done
 


### PR DESCRIPTION
## Summary

- Each loop script's cleanup ran `pkill -f \"next dev\"` and `pkill -f \"node.*vitest\"` unconditionally, killing every matching process system-wide. Running any loop while the maintainer had `pnpm dev` up in the primary checkout silently killed their interactive server.
- Adds a `kill_scoped` helper that filters `pgrep` matches by each process's cwd (via `lsof -d cwd`) against `\$REPO_ROOT`, so each loop only kills processes it spawned from its own worktree.
- qa.sh's dev-server cleanup now relies solely on `dev-server.ts stop` (already PID-file-scoped per cwd hash); replaced the broad pkills in dependency.sh, loop.sh, tech-debt.sh.
- Updates the deps-loop prompt fallback from `pkill -f \"next dev\"` to port-scoped `lsof -ti :\${SMOKE_PORT} | xargs kill`.
- bugs.sh already safe (only `pkill -P \$\$`); kill-orphans.sh left as the explicit user-invoked nuke.

## Test plan

- [ ] Start \`pnpm dev\` in the primary checkout (port 3000)
- [ ] In a sibling worktree, run \`./happyhq/.dev/qa.sh\` and Ctrl-C it during cleanup — verify the primary dev server keeps running
- [ ] Repeat for dependency.sh / tech-debt.sh / loop.sh — primary dev server survives
- [ ] Verify each loop still cleans up its own dev server / vitest workers (no orphans after exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)