### PR TITLE
feat: sidebar "New task" focuses inline composer on task-list routes

### DIFF
--- a/happyhq/components/features/sidebar/atoms/action-buttons.tsx
+++ b/happyhq/components/features/sidebar/atoms/action-buttons.tsx
@@ -13,12 +13,21 @@ import {
 
 export function ActionButtons({ onNewClick }: { onNewClick: () => void }) {
   const pathname = usePathname()
+  const inlineComposerVisible = pathname.startsWith('/tasks')
+
+  function handleNewClick() {
+    if (inlineComposerVisible) {
+      window.dispatchEvent(new CustomEvent('happyhq:focus-quick-add'))
+      return
+    }
+    onNewClick()
+  }
 
   return (
     <SidebarGroup>
       <SidebarMenu>
         <SidebarMenuItem>
-          <SidebarMenuButton tooltip="New task" onClick={onNewClick}>
+          <SidebarMenuButton tooltip="New task" onClick={handleNewClick}>
             <span className="flex size-4 items-center justify-center rounded-full bg-current/10 ring-3 ring-current/10">
               <Plus className="size-4!" />
             </span>

--- a/happyhq/components/features/tasks/create/quick-add.tsx
+++ b/happyhq/components/features/tasks/create/quick-add.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { toastError, toastWarning } from '@/components/common/ui/sonner'
 import { FileRow } from '@/components/features/desktop/windows/shared/file-row'
@@ -45,6 +45,14 @@ export function TaskQuickAdd({
   const { isDragOver, dragHandlers } = useFileDrop(addFiles, {
     enabled: expanded,
   })
+
+  useEffect(() => {
+    function focus() {
+      titleRef.current?.focus()
+    }
+    window.addEventListener('happyhq:focus-quick-add', focus)
+    return () => window.removeEventListener('happyhq:focus-quick-add', focus)
+  }, [])
 
   const canSubmit = title.trim().length > 0
 


### PR DESCRIPTION
## Summary

- On `/tasks`, `/tasks/inbox/[task]`, `/tasks/[stream]`, and `/tasks/[stream]/[task]`, the sidebar "New task" button now focuses the inline `TaskQuickAdd` composer instead of opening `TaskCreateDialog`. The composer auto-expands via its existing `onFocus` handler.
- Everywhere else (chat, settings, `/stream/new`, etc.), behaviour is unchanged — the dialog still opens.
- Wiring: `ActionButtons` checks `pathname.startsWith('/tasks')` and dispatches a `happyhq:focus-quick-add` window event; `TaskQuickAdd` listens and focuses `titleRef`. No new store.

## Test plan

- [ ] `/tasks` → sidebar "New task" → inline composer expands, title input focused, no modal.
- [ ] `/tasks/inbox/<slug>` → same.
- [ ] `/tasks/<stream>` → same; stream stays fixed via `fixedStream`.
- [ ] `/tasks/<stream>/<task>` → same.
- [ ] `/chat`, `/chat/<id>`, `/stream/new`, settings → dialog opens (unchanged).
- [ ] Rapid double-click on `/tasks` → composer focused once, no flicker, no dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)