### PR TITLE
fix: hide spinner on task rows awaiting clarification

### DIFF
--- a/happyhq/components/features/tasks/list/item.test.tsx
+++ b/happyhq/components/features/tasks/list/item.test.tsx
@@ -1,0 +1,64 @@
+import type { RunInfo, TaskItem } from '@/lib/fs/types'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('swr', () => ({
+  useSWRConfig: () => ({ mutate: vi.fn() }),
+}))
+
+vi.mock('@/lib/actions', () => ({
+  toggleTaskDone: vi.fn(),
+}))
+
+import { TaskListItem } from './item'
+
+function makeTask(opts: {
+  pending?: 'clarification'
+  runStatus?: RunInfo['status']
+  completedAt?: string
+}): TaskItem {
+  return {
+    slug: 'task-abc',
+    frontmatter: {
+      title: 'Write report',
+      createdAt: '2026-04-01T00:00:00.000Z',
+      updatedAt: '2026-04-01T00:00:00.000Z',
+      pending: opts.pending,
+      completedAt: opts.completedAt,
+    } as TaskItem['frontmatter'],
+    run: opts.runStatus
+      ? ({
+          status: opts.runStatus,
+          stopReason: null,
+          startedAt: '2026-04-01T00:00:00.000Z',
+          lastIterationAt: '2026-04-01T00:00:00.000Z',
+          phases: {},
+        } as unknown as RunInfo)
+      : null,
+    description: null,
+  }
+}
+
+describe('TaskListItem checkbox slot', () => {
+  it('does not show the spinner while a task is awaiting clarification, even if run.status is still discovering (regression: #313)', () => {
+    const { container } = render(
+      <TaskListItem
+        task={makeTask({ pending: 'clarification', runStatus: 'discovering' })}
+        selected={false}
+        onSelect={() => {}}
+      />,
+    )
+    expect(container.querySelector('.animate-spin')).toBeNull()
+  })
+
+  it('shows the spinner for an actively running task with no pending clarification', () => {
+    const { container } = render(
+      <TaskListItem
+        task={makeTask({ runStatus: 'working' })}
+        selected={false}
+        onSelect={() => {}}
+      />,
+    )
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+  })
+})

--- a/happyhq/components/features/tasks/list/item.tsx
+++ b/happyhq/components/features/tasks/list/item.tsx
@@ -32,18 +32,22 @@ export function TaskListItem({
     setLastServerDone(isDone)
     setOptimisticDone(isDone)
   }
+  // Clarification-pending means the agent has handed control back to the user;
+  // the checkbox slot should match the amber badge, not keep spinning as if work
+  // is in flight.
+  const isAwaitingClarification = frontmatter.pending === 'clarification'
   const isRunning =
-    task.run?.status === 'discovering' ||
-    task.run?.status === 'planning' ||
-    task.run?.status === 'working'
+    !isAwaitingClarification &&
+    (task.run?.status === 'discovering' ||
+      task.run?.status === 'planning' ||
+      task.run?.status === 'working')
 
   const streamLabel = frontmatter.stream ? formatSlug(frontmatter.stream) : null
   // "Needs clarification" wins over the run-status label so the human-action
   // ask is visible at a glance — discovery has paused itself awaiting answers.
-  const statusLabel =
-    frontmatter.pending === 'clarification'
-      ? ({ text: 'Needs clarification', badgeColor: 'amber' } as const)
-      : getRunStatusLabel(task.run?.status, task.run?.stopReason)
+  const statusLabel = isAwaitingClarification
+    ? ({ text: 'Needs clarification', badgeColor: 'amber' } as const)
+    : getRunStatusLabel(task.run?.status, task.run?.stopReason)
 
   async function handleToggle() {
     const prev = optimisticDone


### PR DESCRIPTION
Closes #313

## Root cause

`TaskListItem` derived `isRunning` purely from `task.run?.status` (`discovering` / `planning` / `working`) and rendered a spinning `LoaderCircle` in the checkbox slot whenever that was true. When the agent pauses itself to ask the user a clarifying question, the run status stays on `discovering` while `frontmatter.pending` flips to `clarification` — so the right-side badge correctly switched to amber "Needs clarification" but the leftmost affordance kept spinning. At a glance the row read as busy/working and the user didn't realise their own input was the blocker.

The status-label branch above already special-cased `pending === 'clarification'`. The fix mirrors that on the checkbox: clarification-pending wins over `run.status` for the "is this row actively working?" decision.

## Test

`components/features/tasks/list/item.test.tsx:38` — renders `TaskListItem` with `pending: 'clarification'` + `run.status: 'discovering'` and asserts the spinning loader is absent; a companion case asserts the spinner still appears for an actively running task with no pending clarification.

## Verification

The fix is a one-branch render change inside a render-only component. The regression test renders the actual `TaskListItem` and asserts the user-visible DOM contract directly (`.animate-spin` present vs absent), which is the same surface a Playwright check would assert. Reproducing the natural failure mode end-to-end requires running a real planning task that organically asks a clarifying question; the cheaper synthetic that exercises the same code path is the component-level render assertion already in the regression test.

`pnpm format` / `pnpm lint` / `pnpm check-types` / `pnpm test` all green (1570 passed).

---

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.