### PR TITLE
fix: friendlier toast copy for fetch network failures

### DIFF
--- a/happyhq/components/features/command-menu/command-menu.tsx
+++ b/happyhq/components/features/command-menu/command-menu.tsx
@@ -8,6 +8,7 @@
 
 import type { UnfurlResult } from '@/lib/actions/unfurl'
 import { addWebInput } from '@/lib/actions/web-input'
+import { friendlyErrorMessage } from '@/lib/errors/friendly-message'
 import { invalidateStream } from '@/lib/swr-helpers'
 import {
   useCommandMenuPage,
@@ -92,7 +93,7 @@ function PaletteContent() {
         {
           loading: 'Saving link...',
           success: 'Link added to task inputs',
-          error: (err) => err.message || 'Failed to add link',
+          error: (err) => friendlyErrorMessage(err, 'Failed to add link'),
         },
       )
     },

--- a/happyhq/components/features/desktop/hooks/use-run-actions.ts
+++ b/happyhq/components/features/desktop/hooks/use-run-actions.ts
@@ -2,6 +2,7 @@
 
 import { toastError } from '@/components/common/ui/sonner'
 import { useBillingData } from '@/components/features/billing/use-billing-data'
+import { friendlyErrorMessage } from '@/lib/errors/friendly-message'
 import type { DesktopData, RunInfo, TaskContent } from '@/lib/fs/types'
 import { invalidateStream } from '@/lib/swr-helpers'
 import { desktopDataKey, taskContentKey } from '@/lib/swr-keys'
@@ -174,7 +175,7 @@ export function useRunActions(
       // in desktop-data-provider handles live updates, and calling it here
       // would fight the optimistic update we just set above.
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to approve'
+      const msg = friendlyErrorMessage(err, 'Failed to approve')
       setError(msg)
       toastError(msg)
       // Revalidate to undo optimistic update on failure
@@ -226,7 +227,7 @@ export function useRunActions(
           setRemainingMinutes(data.remainingMinutes ?? null)
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Failed to continue'
+        const msg = friendlyErrorMessage(err, 'Failed to continue')
         setError(msg)
         toastError(msg)
         invalidateStream(streamSlug)
@@ -277,7 +278,7 @@ export function useRunActions(
       }
       // No invalidateStream() on success — same reasoning as approve().
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to start'
+      const msg = friendlyErrorMessage(err, 'Failed to start')
       setError(msg)
       toastError(msg)
       // Revalidate to undo optimistic update on failure
@@ -309,7 +310,7 @@ export function useRunActions(
       }
       invalidateStream(streamSlug)
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to stop'
+      const msg = friendlyErrorMessage(err, 'Failed to stop')
       setError(msg)
       toastError(msg)
       setIsStopping(false)
@@ -337,8 +338,7 @@ export function useRunActions(
         }
         invalidateStream(streamSlug)
       } catch (err) {
-        const msg =
-          err instanceof Error ? err.message : 'Failed to submit answer'
+        const msg = friendlyErrorMessage(err, 'Failed to submit answer')
         toastError(msg)
         throw err
       }

--- a/happyhq/components/features/tasks/create/dialog.tsx
+++ b/happyhq/components/features/tasks/create/dialog.tsx
@@ -8,6 +8,7 @@ import { useFileDrop } from '@/components/features/desktop/windows/shared/use-fi
 import { StreamPicker } from '@/components/features/tasks/atoms/stream-picker'
 import { useCurrentUser } from '@/lib/accounts/hooks'
 import { createTask, ingestTaskInput } from '@/lib/actions'
+import { friendlyErrorMessage } from '@/lib/errors/friendly-message'
 import { ALLOWED_INPUT_ACCEPT } from '@/lib/file-types'
 import { generateTaskSlug } from '@/lib/format'
 import { taskItemsKey } from '@/lib/swr-keys'
@@ -94,7 +95,7 @@ function TaskCreateDialogShell({
       mutate(taskItemsKey())
       onClose()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to create task')
+      toast.error(friendlyErrorMessage(err, 'Failed to create task'))
     } finally {
       setIsCreating(false)
     }

--- a/happyhq/components/features/tasks/hooks/use-optimistic-uploads.ts
+++ b/happyhq/components/features/tasks/hooks/use-optimistic-uploads.ts
@@ -1,6 +1,7 @@
 import { toastError, toastWarning } from '@/components/common/ui/sonner'
 import { useCurrentUser } from '@/lib/accounts/hooks'
 import { ingestTaskInput } from '@/lib/actions'
+import { friendlyErrorMessage } from '@/lib/errors/friendly-message'
 import { useCallback, useRef, useState } from 'react'
 
 function truncate(s: string, max: number) {
@@ -128,7 +129,7 @@ export function useOptimisticUploads(opts: {
                 ),
               )
               toastError(
-                `Failed to upload ${pf.file.name}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+                `Failed to upload ${pf.file.name}: ${friendlyErrorMessage(err, 'Unknown error')}`,
               )
               throw err
             }

--- a/happyhq/lib/errors/friendly-message.test.ts
+++ b/happyhq/lib/errors/friendly-message.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { friendlyErrorMessage, isNetworkError } from './friendly-message'
+
+describe('isNetworkError', () => {
+  it('detects Chrome "Failed to fetch"', () => {
+    expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true)
+  })
+
+  it('detects Safari "Load failed"', () => {
+    expect(isNetworkError(new TypeError('Load failed'))).toBe(true)
+  })
+
+  it('detects Firefox "NetworkError when attempting to fetch resource"', () => {
+    expect(
+      isNetworkError(
+        new TypeError('NetworkError when attempting to fetch resource.'),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects non-TypeError errors with similar text', () => {
+    expect(isNetworkError(new Error('Failed to fetch'))).toBe(false)
+  })
+
+  it('rejects unrelated TypeErrors', () => {
+    expect(isNetworkError(new TypeError('x is not a function'))).toBe(false)
+  })
+})
+
+describe('friendlyErrorMessage', () => {
+  it('maps fetch network failures to a friendly message', () => {
+    const msg = friendlyErrorMessage(
+      new TypeError('Failed to fetch'),
+      'Failed to start',
+    )
+    expect(msg).toBe(
+      "Couldn't reach the server — check your connection and try again",
+    )
+  })
+
+  it('passes through real Error messages from the server', () => {
+    expect(
+      friendlyErrorMessage(
+        new Error('Usage limit exceeded'),
+        'Failed to start',
+      ),
+    ).toBe('Usage limit exceeded')
+  })
+
+  it('falls back when the value is not an Error', () => {
+    expect(friendlyErrorMessage('boom', 'Failed to start')).toBe(
+      'Failed to start',
+    )
+  })
+
+  it('falls back when an Error has no message', () => {
+    expect(friendlyErrorMessage(new Error(), 'Failed to start')).toBe(
+      'Failed to start',
+    )
+  })
+})

--- a/happyhq/lib/errors/friendly-message.ts
+++ b/happyhq/lib/errors/friendly-message.ts
@@ -1,0 +1,25 @@
+// Browser `fetch` throws a TypeError when the server is unreachable
+// (Chrome: "Failed to fetch", Safari: "Load failed", Firefox: "NetworkError
+// when attempting to fetch resource"). Forwarding that string into a toast
+// leaves the user with no actionable cue.
+const NETWORK_ERROR_PATTERNS = [
+  'failed to fetch',
+  'load failed',
+  'networkerror',
+  'network request failed',
+]
+
+const NETWORK_ERROR_MESSAGE =
+  "Couldn't reach the server — check your connection and try again"
+
+export function isNetworkError(err: unknown): boolean {
+  if (!(err instanceof TypeError)) return false
+  const msg = err.message.toLowerCase()
+  return NETWORK_ERROR_PATTERNS.some((pattern) => msg.includes(pattern))
+}
+
+export function friendlyErrorMessage(err: unknown, fallback: string): string {
+  if (isNetworkError(err)) return NETWORK_ERROR_MESSAGE
+  if (err instanceof Error && err.message) return err.message
+  return fallback
+}


### PR DESCRIPTION
Closes #315

## Why

When the dev server (or backend) is unreachable, browser `fetch` throws a `TypeError` whose `.message` reads `Failed to fetch` (Chrome), `Load failed` (Safari), or `NetworkError when attempting to fetch resource` (Firefox). Several toast paths forwarded that raw message verbatim, leaving the user staring at browser-internal jargon with no hint that the action was "the server isn't reachable, try again."

## Deviations from the report's framing

The report pointed at `create-stream-dialog.tsx:182` — that path uses a server action and doesn't surface raw `fetch` errors. Per the reopen comment ("this happens in many places"), the real shape is broader: every client-side `fetch` toast path forwarded `err.message` straight through. Fix is a small shared helper applied across the live fetch-based toast call sites:

- `components/features/desktop/hooks/use-run-actions.ts` — approve / continue / start / stop / answerQuestion (all hit `/api/run/*`)
- `components/features/tasks/create/dialog.tsx` — task creation catch
- `components/features/tasks/hooks/use-optimistic-uploads.ts` — file upload error
- `components/features/command-menu/command-menu.tsx` — `addWebInput` toast.promise error

`friendlyErrorMessage(err, fallback)` returns the friendly copy only when `err` is a `TypeError` matching the known network-failure patterns; real `Error.message` strings from the server still pass through unchanged.

## Regression test

`happyhq/lib/errors/friendly-message.test.ts` pins the contract:
- Chrome / Safari / Firefox `TypeError` shapes map to the friendly message.
- Non-`TypeError` `Error` instances pass through.
- Non-`Error` values fall back to the caller-provided string.

## Evidence

Unit tests:

```
$ pnpm --filter=happyhq test lib/errors/friendly-message.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Full suite: 130 files / 1577 tests pass. `pnpm lint` and `pnpm check-types` clean.

In-browser synthetic trigger against the live dev server confirmed the helper output:

```js
> // page-side evaluate with the same TypeError fetch throws
> friendlyErrorMessage(new TypeError('Failed to fetch'), 'Failed to start')
"Couldn't reach the server — check your connection and try again"
```

End-to-end UI toast capture wasn't reachable here: the natural trigger surfaces (`use-run-actions`) require an existing task, and Next's server-action transport in dev mode doesn't route through `window.fetch`, so a `fetch` override didn't propagate into the create-task dialog. The behavior contract is pinned by the unit test; the call-site swaps are mechanical and behavior-preserving for non-network errors.

---

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.