### PR TITLE
fix(chat): keepalive on chat stream to prevent canUseTool deadlock

### DIFF
--- a/happyhq/app/api/chat/route.ts
+++ b/happyhq/app/api/chat/route.ts
@@ -74,6 +74,15 @@ export async function POST(request: Request) {
 
   const abortController = registerSession(sessionId)
 
+  // If the client SSE goes away (tab closed, network drop, browser killed),
+  // cancel the SDK so we don't leak a hung agent process holding canUseTool
+  // open forever. Without this, the SDK keeps spinning until something else
+  // aborts the registered session.
+  request.signal.addEventListener('abort', () => {
+    log('chat.client_disconnect', { sessionId })
+    abortController.abort()
+  })
+
   let streamController: ReadableStreamDefaultController<Uint8Array>
 
   const notifyClient = (event: ChatStreamEvent) => {

--- a/happyhq/app/api/chat/route.ts
+++ b/happyhq/app/api/chat/route.ts
@@ -18,6 +18,12 @@ import { streamExists } from '@/lib/fs/read.server'
 import { log } from '@/lib/log.server'
 import { encodeEvent, filterMessage } from '@/lib/run/filter.server'
 
+// Pre-encoded keepalive bytes — a bare newline parses as a whitespace-only
+// line (skipped by readNDJSON) so the client can ignore it without a
+// dedicated event type. The byte itself is enough to force Node's HTTP
+// write buffer to flush any pending chunks.
+const KEEPALIVE_BYTES = new TextEncoder().encode('\n')
+
 export async function POST(request: Request) {
   let body: ChatRequest
   try {
@@ -80,6 +86,20 @@ export async function POST(request: Request) {
     async start(controller) {
       streamController = controller
       const stderrBuf = new StderrBuffer()
+
+      // Periodic keepalive to keep the HTTP write buffer flushing while the
+      // SDK is otherwise idle (e.g. waiting in canUseTool for an answer to
+      // AskUserQuestion). Without this, bytes the SDK enqueued just before
+      // blocking can sit in Node's HTTP buffer indefinitely — the client
+      // sees the question never arrive and the chat looks hung. The client's
+      // NDJSON parser yields no event for whitespace-only lines.
+      const keepalive = setInterval(() => {
+        try {
+          controller.enqueue(KEEPALIVE_BYTES)
+        } catch {
+          // Controller closed — interval will be cleared in finally.
+        }
+      }, 1_500)
 
       try {
         if (abortController.signal.aborted) return
@@ -146,6 +166,7 @@ export async function POST(request: Request) {
           }
         }
       } finally {
+        clearInterval(keepalive)
         clearSession(sessionId)
         clearSessionMode(sessionId)
         controller.close()

--- a/happyhq/lib/agents/config.server.ts
+++ b/happyhq/lib/agents/config.server.ts
@@ -128,6 +128,11 @@ export async function chatAgentOptions(params: {
     disallowedTools: ['EnterPlanMode', 'ExitPlanMode'],
     canUseTool: async (toolName, input, { signal, toolUseID }) => {
       if (toolName === 'AskUserQuestion') {
+        log('chat.canusetool_fired', {
+          sessionId,
+          toolName,
+          toolUseId: toolUseID,
+        })
         try {
           const answers = await Promise.race([
             waitForAnswer(sessionId),
@@ -139,11 +144,21 @@ export async function chatAgentOptions(params: {
               )
             }),
           ])
+          log('chat.canusetool_resolved', {
+            sessionId,
+            toolUseId: toolUseID,
+            outcome: 'answered',
+          })
           return {
             behavior: 'allow' as const,
             updatedInput: { ...input, answers },
           }
         } catch {
+          log('chat.canusetool_resolved', {
+            sessionId,
+            toolUseId: toolUseID,
+            outcome: 'dismissed',
+          })
           return {
             behavior: 'deny' as const,
             message: 'User dismissed the question',


### PR DESCRIPTION
## Summary
- Chat AskUserQuestion was hanging intermittently — the question UI never appeared even though the SDK had emitted it server-side.
- Root cause: SDK blocks in canUseTool waiting for the user's answer. If the client reader is slow (tab hidden, devtools open, heavy render), Node's HTTP write buffer fills. Bytes the SDK enqueued just before blocking — including the assistant event with the AskUserQuestion tool_use — sit unflushed. With no further enqueues (because canUseTool is blocking), nothing pushes them to the wire. Starvation deadlock.
- Fix: enqueue a bare `\n` every 1.5s while the chat route is open. Each enqueue forces Node to flush the pending HTTP buffer. The newline is a whitespace-only line that `readNDJSON` already skips, so no client-side changes needed.
- Also adds `chat.canusetool_fired` / `chat.canusetool_resolved` log lines for ongoing observability into question cadence and answer/dismiss rates.

## Diagnosis trail
Cross-referencing server breadcrumbs with a captured client byte ledger and parser-buffer probe showed the SDK enqueued a 2286-byte assistant event that never arrived at the client; tab visibility transitioned to `hidden` 3.9s before. Diagnosis details and the throw-away instrumentation that found it live on the `chore/chat-hang-instrumentation` branch as a forensic record.

## Test plan
- [ ] Type-check + lint: `pnpm check-types && pnpm lint`
- [ ] Existing chatStore tests still pass: `pnpm test stores/chatStore.test.ts` (54 tests)
- [ ] Manual: send a chat message that triggers AskUserQuestion, click between tabs / windows during streaming, verify the question UI renders reliably (was the easy repro pre-fix)
- [ ] Manual: send several multi-turn chats with AskUserQuestion, verify no hangs across N questions
- [ ] Inspect logs after a chat: `npx tsx scripts/read-logs.ts --event=chat.canusetool` shows fired/resolved pairs