### PR TITLE
fix: render multi-select questions as checkboxes

### DIFF
--- a/happyhq/app/(playground)/playground/_data/questions.ts
+++ b/happyhq/app/(playground)/playground/_data/questions.ts
@@ -81,3 +81,20 @@ export const QUESTIONS_WITH_DESCRIPTIONS: AskUserQuestionInput['questions'] = [
     multiSelect: false,
   },
 ]
+
+/**
+ * Multi-select — user can pick any number of options. UI renders checkboxes.
+ */
+export const QUESTIONS_MULTI_SELECT: AskUserQuestionInput['questions'] = [
+  {
+    question: 'Which spices should we include in the filling?',
+    header: 'Spices',
+    options: [
+      { label: 'Cinnamon', description: 'Warm and classic' },
+      { label: 'Nutmeg', description: 'Nutty, slightly sweet' },
+      { label: 'Cardamom', description: 'Floral and aromatic' },
+      { label: 'Allspice', description: 'Peppery, complex' },
+    ],
+    multiSelect: true,
+  },
+]

--- a/happyhq/app/(playground)/playground/_registry/interaction.tsx
+++ b/happyhq/app/(playground)/playground/_registry/interaction.tsx
@@ -17,6 +17,7 @@ import {
 } from '../_data/confirmations'
 import {
   QUESTIONS_MULTI,
+  QUESTIONS_MULTI_SELECT,
   QUESTIONS_SINGLE,
   QUESTIONS_WITH_DESCRIPTIONS,
 } from '../_data/questions'
@@ -58,6 +59,7 @@ const questionOptionsRegistration: PlaygroundComponent = {
   variants: {
     'single-question': { name: 'Single Question', data: QUESTIONS_SINGLE },
     'multi-question': { name: 'Multi Question', data: QUESTIONS_MULTI },
+    'multi-select': { name: 'Multi-select', data: QUESTIONS_MULTI_SELECT },
     'with-descriptions': {
       name: 'With Descriptions',
       data: QUESTIONS_WITH_DESCRIPTIONS,

--- a/happyhq/components/features/chat/interaction/question-options.test.tsx
+++ b/happyhq/components/features/chat/interaction/question-options.test.tsx
@@ -129,6 +129,77 @@ describe('QuestionOptions', () => {
     expect(screen.getByText('A file for a future task')).not.toBeNull()
   })
 
+  describe('multi-select questions', () => {
+    const multiSelectQuestion = {
+      question: 'What kinds of docs do you write?',
+      header: 'Doc types',
+      options: [
+        { label: 'Specs', description: 'Design specs' },
+        { label: 'Runbooks', description: 'Ops runbooks' },
+        { label: 'Postmortems', description: 'Incident reviews' },
+      ],
+      multiSelect: true,
+    }
+
+    it('lets the user select more than one option and submits them comma-joined', () => {
+      const onAnswer = vi.fn()
+      render(
+        <QuestionOptions
+          questions={[multiSelectQuestion]}
+          onAnswer={onAnswer}
+        />,
+      )
+
+      fireEvent.click(screen.getByText('Specs'))
+      fireEvent.click(screen.getByText('Postmortems'))
+      fireEvent.click(screen.getByText('Submit answers'))
+
+      expect(onAnswer).toHaveBeenCalledWith({
+        'What kinds of docs do you write?': 'Specs, Postmortems',
+      })
+    })
+
+    it('toggles a selected option off when clicked again', () => {
+      const onAnswer = vi.fn()
+      render(
+        <QuestionOptions
+          questions={[multiSelectQuestion]}
+          onAnswer={onAnswer}
+        />,
+      )
+
+      fireEvent.click(screen.getByText('Specs'))
+      fireEvent.click(screen.getByText('Runbooks'))
+      fireEvent.click(screen.getByText('Specs'))
+      fireEvent.click(screen.getByText('Submit answers'))
+
+      expect(onAnswer).toHaveBeenCalledWith({
+        'What kinds of docs do you write?': 'Runbooks',
+      })
+    })
+
+    it('appends "Other" freeform text to the selection set', () => {
+      const onAnswer = vi.fn()
+      render(
+        <QuestionOptions
+          questions={[multiSelectQuestion]}
+          onAnswer={onAnswer}
+        />,
+      )
+
+      fireEvent.click(screen.getByText('Specs'))
+      fireEvent.click(screen.getByText('Other'))
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'API references' },
+      })
+      fireEvent.click(screen.getByText('Submit answers'))
+
+      expect(onAnswer).toHaveBeenCalledWith({
+        'What kinds of docs do you write?': 'Specs, API references',
+      })
+    })
+  })
+
   describe('multi-question auto-advance', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/happyhq/components/features/chat/interaction/question-options.tsx
+++ b/happyhq/components/features/chat/interaction/question-options.tsx
@@ -26,7 +26,36 @@ export function QuestionOptions({
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [otherActive, setOtherActive] = useState<Record<string, boolean>>({})
   const [otherTexts, setOtherTexts] = useState<Record<string, string>>({})
+  const [multiSelections, setMultiSelections] = useState<
+    Record<string, string[]>
+  >({})
   const [activeTab, setActiveTab] = useState(questions[0].question)
+
+  const writeMultiAnswer = (
+    questionText: string,
+    selections: string[],
+    otherText: string,
+  ) => {
+    const items = [...selections]
+    const trimmedOther = otherText.trim()
+    if (trimmedOther) items.push(trimmedOther)
+    const joined = items.join(', ')
+    setAnswers((prev) => {
+      const next = { ...prev }
+      if (joined) next[questionText] = joined
+      else delete next[questionText]
+      return next
+    })
+  }
+
+  const handleToggleMulti = (questionText: string, label: string) => {
+    const current = multiSelections[questionText] ?? []
+    const next = current.includes(label)
+      ? current.filter((l) => l !== label)
+      : [...current, label]
+    setMultiSelections((prev) => ({ ...prev, [questionText]: next }))
+    writeMultiAnswer(questionText, next, otherTexts[questionText] ?? '')
+  }
 
   const autoResize = (el: HTMLTextAreaElement) => {
     el.style.height = 'auto'
@@ -57,8 +86,16 @@ export function QuestionOptions({
     setOtherActive((prev) => ({ ...prev, [questionText]: true }))
   }
 
-  const handleOtherText = (questionText: string, text: string) => {
+  const handleOtherText = (
+    question: AskUserQuestionInput['questions'][number],
+    text: string,
+  ) => {
+    const questionText = question.question
     setOtherTexts((prev) => ({ ...prev, [questionText]: text }))
+    if (question.multiSelect) {
+      writeMultiAnswer(questionText, multiSelections[questionText] ?? [], text)
+      return
+    }
     if (text.trim()) {
       setAnswers((prev) => ({ ...prev, [questionText]: text.trim() }))
     } else {
@@ -99,39 +136,83 @@ export function QuestionOptions({
       </p>
 
       <div className="space-y-0.5">
-        <RadioGroup
-          value={
-            otherActive[question.question]
-              ? ''
-              : (answers[question.question] ?? '')
-          }
-          onChange={(val: string) => handleSelect(question.question, val)}
-        >
-          {question.options.map((option) => (
-            <Radio
-              key={option.label}
-              value={option.label}
-              className={cn(
-                'group flex w-full cursor-pointer items-center justify-between rounded-lg px-3 py-1 text-left transition-colors',
-                'hover:bg-black/5',
-                'data-checked:bg-black/5',
-                'outline-none',
-              )}
-            >
-              <div className="min-w-0">
-                <span className="text-sm font-medium text-zinc-900">
-                  {option.label}
-                </span>
-                {option.description && (
-                  <span className="block text-xs text-zinc-500">
-                    {option.description}
-                  </span>
+        {question.multiSelect ? (
+          <div role="group" aria-label={question.question}>
+            {question.options.map((option) => {
+              const checked = (
+                multiSelections[question.question] ?? []
+              ).includes(option.label)
+              return (
+                <button
+                  key={option.label}
+                  type="button"
+                  role="checkbox"
+                  aria-checked={checked}
+                  onClick={() =>
+                    handleToggleMulti(question.question, option.label)
+                  }
+                  className={cn(
+                    'group flex w-full cursor-pointer items-center justify-between rounded-lg px-3 py-1 text-left transition-colors',
+                    'hover:bg-black/5',
+                    checked && 'bg-black/5',
+                    'outline-none',
+                  )}
+                >
+                  <div className="min-w-0">
+                    <span className="text-sm font-medium text-zinc-900">
+                      {option.label}
+                    </span>
+                    {option.description && (
+                      <span className="block text-xs text-zinc-500">
+                        {option.description}
+                      </span>
+                    )}
+                  </div>
+                  <Check
+                    className={cn(
+                      'h-4 w-4 shrink-0 text-zinc-900 transition',
+                      checked ? 'opacity-100' : 'opacity-0',
+                    )}
+                  />
+                </button>
+              )
+            })}
+          </div>
+        ) : (
+          <RadioGroup
+            value={
+              otherActive[question.question]
+                ? ''
+                : (answers[question.question] ?? '')
+            }
+            onChange={(val: string) => handleSelect(question.question, val)}
+          >
+            {question.options.map((option) => (
+              <Radio
+                key={option.label}
+                value={option.label}
+                className={cn(
+                  'group flex w-full cursor-pointer items-center justify-between rounded-lg px-3 py-1 text-left transition-colors',
+                  'hover:bg-black/5',
+                  'data-checked:bg-black/5',
+                  'outline-none',
                 )}
-              </div>
-              <Check className="h-4 w-4 shrink-0 text-zinc-900 opacity-0 transition group-data-checked:opacity-100" />
-            </Radio>
-          ))}
-        </RadioGroup>
+              >
+                <div className="min-w-0">
+                  <span className="text-sm font-medium text-zinc-900">
+                    {option.label}
+                  </span>
+                  {option.description && (
+                    <span className="block text-xs text-zinc-500">
+                      {option.description}
+                    </span>
+                  )}
+                </div>
+                <Check className="h-4 w-4 shrink-0 text-zinc-900 opacity-0 transition group-data-checked:opacity-100" />
+              </Radio>
+            ))}
+          </RadioGroup>
+        )}
 
         {/* Auto-generated "Other" option — outside RadioGroup since it clears radio selection */}
         <button
@@ -148,7 +229,7 @@ export function QuestionOptions({
               value={otherTexts[question.question] || ''}
               onClick={(e) => e.stopPropagation()}
               onChange={(e) => {
-                handleOtherText(question.question, e.target.value)
+                handleOtherText(question, e.target.value)
                 autoResize(e.target)
               }}
               onKeyDown={(e) => {


### PR DESCRIPTION
Closes #319

## Why

The Agent SDK's `AskUserQuestion` tool carries a per-question `multiSelect: boolean`, but `QuestionOptions` rendered a Headless UI `RadioGroup` unconditionally. When the agent asked an any-of-N question (e.g. *"What kinds of docs do you write? Pick all that apply"*) the user could only pick one — and the agent then reasoned over a single value, silently dropping the rest of their intent.

## What changed

`components/features/chat/interaction/question-options.tsx`:

- Branches on `question.multiSelect`. Multi-select questions render an aria-checkbox group; selections are tracked in `multiSelections: Record<string, string[]>` and joined with `, ` on submit, matching the SDK's documented `AskUserQuestionOutput` wire format (*"multi-select answers are comma-separated"*). The `onAnswer` payload stays `Record<string, string>` — no API change.
- Auto-advance stays disabled for multi-select so the user can toggle freely before moving on.
- "Other" appends a freeform value to the selection set for multi-select (single-select still replaces, as before).

Also adds a `multi-select` variant to the `Ask User Question` playground entry for future visual verification.

## Regression test

`components/features/chat/interaction/question-options.test.tsx:132` — three new cases covering multi-toggle output, toggle-off, and the appended-Other path. The existing 12 cases still pass (15 total).

## Visual evidence

Drove the new playground variant in a headless browser. Selected two checkboxes (Cinnamon + Cardamom):

![two checkboxes selected](https://ralphie.happyhq.com/pr/324/60937d03-92fd-45f6-a1b7-e1ed72db451b/319-01-two-selected.png)

Submitted; the playground event log shows the comma-joined payload `onAnswer {"Which spices should we include in the filling?":"Cinnamon, Cardamom"}`:

![onAnswer event payload](https://ralphie.happyhq.com/pr/324/60937d03-92fd-45f6-a1b7-e1ed72db451b/319-03-event.png)

Single-select variant still renders as a radio group (unchanged):

![single-select radio group unchanged](https://ralphie.happyhq.com/pr/324/60937d03-92fd-45f6-a1b7-e1ed72db451b/319-04-single-still-radio.png)

## AI assistance

Authored by Ralphie, the autonomous bug-fix loop. Reviewed by maintainer before merge.