### PR TITLE
fix(chat): create .chats directory before sending intent message

### DIFF
--- a/happyhq/components/features/desktop/windows/chat/chat-window-provider.tsx
+++ b/happyhq/components/features/desktop/windows/chat/chat-window-provider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ChatSessionContext } from '@/components/features/desktop/providers/chat-session-provider'
+import { createChatSession } from '@/lib/actions/chat'
 import { createChatStore } from '@/stores/chatStore'
 import { useStreamSlug } from '@/stores/desktopStore'
 import { useWindowStore } from '@/stores/windowStore'
@@ -68,6 +69,7 @@ export function ChatWindowProvider({
     const sid = sessionId ?? crypto.randomUUID()
     consumedIntent.current = true
     sessionIdRef.current = sid
+    createChatSession(sid, streamSlug || undefined)
     store.getState().sendMessage({
       message: seed,
       sessionId: sid,


### PR DESCRIPTION
## Summary

- Fixes missing chat persistence when a chat is initiated from stream creation in the desktop
- `ChatWindowProvider` was calling `sendMessage()` without first calling `createChatSession()`, so the `.chats/{sessionId}/` directory never got created
- Added `createChatSession(sid, streamSlug)` before the `sendMessage()` call in the intent-consumption effect

## Test plan

- [ ] Create a new stream in the desktop app
- [ ] Verify `.chats/{sessionId}/` directory is created with `chat.json` inside
- [ ] Verify chat messages persist and reload on refresh
- [ ] Verify existing flows (home composer, use-chat-actions) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)