### PR TITLE
feat(billing): record task runs even when no usage period covers them

### DIFF
--- a/happyhq/ee/lib/billing/usage.server.test.ts
+++ b/happyhq/ee/lib/billing/usage.server.test.ts
@@ -175,7 +175,8 @@ describe('usage.server', () => {
       expect(taskRunId).toBe('generated-id')
       expect(mockTransact).toHaveBeenCalledWith([
         expect.anything(), // update call
-        expect.anything(), // link call
+        expect.anything(), // user link
+        expect.anything(), // usagePeriod link
       ])
       expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -185,10 +186,11 @@ describe('usage.server', () => {
           status: 'running',
         }),
       )
+      expect(mockLink).toHaveBeenCalledWith({ user: 'user-1' })
       expect(mockLink).toHaveBeenCalledWith({ usagePeriod: 'usage-1' })
     })
 
-    it('returns null when no current usage period exists for paid user', async () => {
+    it('records an orphan task run when no covering usage period exists for a paid user', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       try {
         mockQuery.mockResolvedValueOnce({
@@ -196,12 +198,24 @@ describe('usage.server', () => {
           // Active subscription — paid user whose invoice.paid hasn't fired yet
           subscriptions: [{ status: 'active', tier: 'pro' }],
         })
+        mockTransact.mockResolvedValue(undefined)
 
         const { startTaskRun } = await import('./usage.server')
         const result = await startTaskRun('user-1', 'my-stream', 'my-task')
 
-        expect(result).toBeNull()
-        expect(mockTransact).not.toHaveBeenCalled()
+        // Orphan run is still recorded, linked to the user but not a usage period
+        expect(result).toBe('generated-id')
+        expect(mockTransact).toHaveBeenCalledWith([
+          expect.anything(), // update call
+          expect.anything(), // user link
+        ])
+        expect(mockLink).toHaveBeenCalledWith({ user: 'user-1' })
+        expect(mockLink).not.toHaveBeenCalledWith(
+          expect.objectContaining({ usagePeriod: expect.anything() }),
+        )
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('usage_anomaly'),
+        )
       } finally {
         warnSpy.mockRestore()
       }

--- a/happyhq/ee/lib/billing/usage.server.ts
+++ b/happyhq/ee/lib/billing/usage.server.ts
@@ -77,9 +77,11 @@ export async function getCurrentUsage(userId: string): Promise<Usage | null> {
 }
 
 /**
- * Creates a task run record linked to the user's current usage period.
- * Returns the task run ID for subsequent updateUsage/finalizeTaskRun calls.
- * Returns null if no current usage period exists (free user or no billing cycle).
+ * Creates a task run record for the user. Always links to the user; links to
+ * the current usage period when one exists. When no usage period covers now
+ * (e.g. a paid user whose renewal webhook dropped), the task run is still
+ * recorded as an orphan — discoverable via the user link, summable later by
+ * reconciliation. Returns the task run ID, or null only on hard failures.
  */
 export async function startTaskRun(
   userId: string,
@@ -87,17 +89,10 @@ export async function startTaskRun(
   task: string,
 ): Promise<string | null> {
   const usage = await getCurrentUsage(userId)
-  if (!usage) {
-    console.warn(
-      `startTaskRun: No current usage period for user ${userId} — task run not recorded`,
-    )
-    return null
-  }
-
   const adminDb = getAdminDb()
   const taskRunId = id()
 
-  await adminDb.transact([
+  const txs = [
     adminDb.tx.taskRuns[taskRunId].update({
       stream,
       task,
@@ -105,9 +100,17 @@ export async function startTaskRun(
       minutes: 0,
       status: 'running',
     }),
-    adminDb.tx.taskRuns[taskRunId].link({ usagePeriod: usage.id }),
-  ])
+    adminDb.tx.taskRuns[taskRunId].link({ user: userId }),
+  ]
+  if (usage) {
+    txs.push(adminDb.tx.taskRuns[taskRunId].link({ usagePeriod: usage.id }))
+  } else {
+    console.warn(
+      `usage_anomaly: startTaskRun for user ${userId} with no covering usage period — task run ${taskRunId} recorded as orphan`,
+    )
+  }
 
+  await adminDb.transact(txs)
   return taskRunId
 }
 

--- a/happyhq/instant.perms.ts
+++ b/happyhq/instant.perms.ts
@@ -32,7 +32,7 @@ const rules: InstantRules = {
   },
   taskRuns: {
     allow: {
-      view: "auth.id in data.ref('usagePeriod.user.id')",
+      view: "auth.id in data.ref('user.id') || auth.id in data.ref('usagePeriod.user.id')",
       create: 'false',
       update: 'false',
       delete: 'false',

--- a/happyhq/lib/database/schema.ts
+++ b/happyhq/lib/database/schema.ts
@@ -60,6 +60,10 @@ const schema = i.schema({
       forward: { on: 'taskRuns', has: 'one', label: 'usagePeriod' },
       reverse: { on: 'usage', has: 'many', label: 'taskRuns' },
     },
+    userTaskRuns: {
+      forward: { on: 'taskRuns', has: 'one', label: 'user' },
+      reverse: { on: '$users', has: 'many', label: 'taskRuns' },
+    },
     userAvatar: {
       forward: { on: '$users', has: 'one', label: 'avatar' },
       reverse: { on: '$files', has: 'one', label: 'user' },


### PR DESCRIPTION
## Summary

When a paid user's renewal webhook drops (or any other edge case leaves `getCurrentUsage` returning null), the run loop currently lets the task execute but no `taskRuns` row is written. The minutes worked are lost to accounting and unattributable. This change captures the data even in that state by always creating the `taskRuns` row, linking it to the user, and adding the `usagePeriod` link only when a current usage row exists.

When no covering period exists, an `orphan` task run is created and a `usage_anomaly` warning is logged so operations can see this is happening. Orphans are discoverable via the new direct user link and can be reconciled to a usage period later (manually, or by a future self-heal step). They naturally don't count against `usedMinutes` because the existing `getAuthoritativeUsedMinutes` only sums runs linked to a given `usagePeriod` — meaning behavior is unchanged for users in the healthy path.

Limits enforcement is intentionally unchanged in this PR: `canStartTask` still permits paid users with no covering period, the same as today. This step is about capturing the data, not gating who can run.

### Schema

Additive only:
- New `userTaskRuns` link: `taskRuns.user → $users` (`has: 'one'` / `has: 'many'`).
- `taskRuns` view perm widened to `auth.id in data.ref('user.id') || auth.id in data.ref('usagePeriod.user.id')`.

Both InstantDB apps (dev and prod) need `pnpm db:push-schema` and `pnpm db:push-perms` before this code starts running.

### Follow-ups (out of scope here)

- Self-heal `getCurrentUsage` to create a usage period from the active subscription's Stripe-side dates when a paid user has no covering period.
- Decide whether `canStartTask` should hard-cap mid-run, not just at run start.
- Close the upgrade-flow gap (no replay path for `checkout.session.completed` failures past 30 days).

## Test plan

- [x] Updated unit tests: orphan recording path + happy path both verified
- [x] `pnpm check-types`, `pnpm lint`, `pnpm test ee/lib/billing` and `pnpm test lib/run/loop.server` all pass
- [ ] After schema/perms push to dev: start a task as a user with no covering usage row and confirm a `taskRuns` row exists with the user link, no `usagePeriod` link, and a `usage_anomaly` log line
- [ ] After merge to prod: same end-to-end check on the prod environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)