### PR TITLE
fix: allow $users self-create so new signups work

### DIFF
--- a/happyhq/instant.perms.ts
+++ b/happyhq/instant.perms.ts
@@ -10,7 +10,7 @@ const rules: InstantRules = {
     allow: {
       view: 'auth.id == data.id',
       update: 'auth.id == data.id',
-      create: 'false',
+      create: 'auth.id == data.id',
       delete: 'false',
     },
   },


### PR DESCRIPTION
## Summary

- Brand-new accounts were failing magic-code sign-in with InstantDB "permission-denied: not perms-pass?" because `$users.create` was `false`. The auth flow's internal `$users` row creation got rejected on first login.
- Changed the rule to `auth.id == data.id`. Since the row id IS the auth id, a user can only create their own `$users` row — same blast radius as `false` for everyone else, but lets the legitimate auth-system write through.
- Already pushed perms to both environments out-of-band; this PR records the source change so the repo matches prod.

## What we don't know

Existing users sign in fine and at least one new signup worked as recently as yesterday, so something changed between then and now to expose this. We haven't confirmed what — possibilities include the repo perms drifting from what was live on the server, an InstantDB-side behavior change, or something else. Not worth speculating further in the commit history.

## Test plan

- [x] Reproduced locally with a fresh account → "permission-denied" on `$users` `create`
- [x] Applied fix, re-pushed perms locally → new account magic-code sign-in succeeds
- [ ] Existing accounts still sign in cleanly (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)